### PR TITLE
Fix clock-simple plugin position config handling and add manifest icons

### DIFF
--- a/plugins/clock-simple/manager.py
+++ b/plugins/clock-simple/manager.py
@@ -53,10 +53,16 @@ class SimpleClock(BasePlugin):
         self.date_color = tuple(config.get('date_color', [255, 128, 64]))
         self.ampm_color = tuple(config.get('ampm_color', [255, 255, 128]))
 
-        # Position
+        # Position - handle both dict and legacy string/invalid formats
         position = config.get('position', {'x': 0, 'y': 0})
-        self.pos_x = position.get('x', 0)
-        self.pos_y = position.get('y', 0)
+        if isinstance(position, dict):
+            self.pos_x = position.get('x', 0)
+            self.pos_y = position.get('y', 0)
+        else:
+            # Fallback for invalid/legacy position format
+            self.logger.warning(f"Invalid position format: {type(position)}. Using defaults (0, 0)")
+            self.pos_x = 0
+            self.pos_y = 0
 
         # Get timezone
         self.timezone = self._get_timezone()

--- a/plugins/clock-simple/manifest.json
+++ b/plugins/clock-simple/manifest.json
@@ -9,6 +9,7 @@
   "class_name": "SimpleClock",
   "category": "time",
   "tags": ["clock", "time", "date"],
+  "icon": "fas fa-clock",
   "compatible_versions": [">=2.0.0"],
   "ledmatrix_version": "2.0.0",
   "requires": {

--- a/plugins/hello-world/manifest.json
+++ b/plugins/hello-world/manifest.json
@@ -9,6 +9,7 @@
   "class_name": "HelloWorldPlugin",
   "category": "demo",
   "tags": ["demo", "test", "simple"],
+  "icon": "👋",
   "compatible_versions": [">=2.0.0"],
   "ledmatrix_version": "2.0.0",
   "requires": {


### PR DESCRIPTION
- Fix AttributeError in clock-simple when position config is invalid format
- Add defensive type checking for position config (handle string/invalid types)
- Log warning and use defaults (0,0) when position format is incorrect
- Add icon field to clock-simple manifest (fas fa-clock)
- Add icon field to hello-world manifest (👋)