### PR TITLE
feat: add hockey-scoreboard plugin (Phase 2 start)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -193,6 +193,30 @@
       "last_updated": "2025-10-11",
       "verified": true,
       "screenshot": ""
+    },
+    {
+      "id": "hockey-scoreboard",
+      "name": "Hockey Scoreboard",
+      "description": "Live, recent, and upcoming hockey games across NHL, NCAA Men's, and NCAA Women's hockey with real-time scores and schedules",
+      "author": "ChuckBuilds",
+      "category": "sports",
+      "tags": ["hockey", "nhl", "ncaa", "sports", "scoreboard", "live-scores"],
+      "repo": "https://github.com/ChuckBuilds/ledmatrix-plugins",
+      "branch": "simple-plugins",
+      "plugin_path": "plugins/hockey-scoreboard",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "ledmatrix_min": "2.0.0",
+          "released": "2025-10-11",
+          "download_url": "https://github.com/ChuckBuilds/ledmatrix-plugins/archive/refs/heads/simple-plugins.zip"
+        }
+      ],
+      "stars": 0,
+      "downloads": 0,
+      "last_updated": "2025-10-11",
+      "verified": true,
+      "screenshot": ""
     }
   ]
 }

--- a/plugins/hockey-scoreboard/README.md
+++ b/plugins/hockey-scoreboard/README.md
@@ -1,0 +1,458 @@
+# Hockey Scoreboard Plugin
+
+Display live, recent, and upcoming hockey games across NHL, NCAA Men's, and NCAA Women's hockey on your LED matrix.
+
+## Features
+
+- **Multi-League Support**: NHL, NCAA Men's Hockey, NCAA Women's Hockey
+- **Live Game Tracking**: Real-time scores, periods, time remaining
+- **Recent Games**: View recently completed game results
+- **Upcoming Games**: See scheduled games with start times
+- **Favorite Teams**: Prioritize your favorite teams across all leagues
+- **Power Play Indicators**: Highlight power play situations
+- **Shots on Goal**: Optional SOG statistics display
+- **Team Logos**: Display team logos when available
+- **Background Data Fetching**: Efficient API calls with caching
+- **Font Customization**: Override fonts via Web UI
+
+## Requirements
+
+- LEDMatrix 2.0.0+
+- Display: Minimum 64x32 pixels (recommended)
+- No API key required (uses ESPN public API)
+- Internet connection for live data
+
+## Configuration
+
+### Example Configuration
+
+```json
+{
+  "enabled": true,
+  "leagues": {
+    "nhl": true,
+    "ncaa_mens": false,
+    "ncaa_womens": false
+  },
+  "display_modes": {
+    "hockey_live": true,
+    "hockey_recent": true,
+    "hockey_upcoming": true
+  },
+  "favorite_teams": {
+    "nhl": ["TB", "TOR", "BOS"],
+    "ncaa_mens": ["BU", "BC"],
+    "ncaa_womens": []
+  },
+  "prioritize_favorites": true,
+  "show_shots_on_goal": false,
+  "show_powerplay": true,
+  "update_interval": 60,
+  "display_duration": 15,
+  "recent_games_hours": 24,
+  "upcoming_games_hours": 72
+}
+```
+
+### Configuration Options
+
+#### League Selection
+
+- **`leagues.nhl`**: Enable NHL games (default: true)
+- **`leagues.ncaa_mens`**: Enable NCAA Men's Hockey (default: false)
+- **`leagues.ncaa_womens`**: Enable NCAA Women's Hockey (default: false)
+
+Enable multiple leagues to see games from all selected leagues in rotation.
+
+#### Display Modes
+
+- **`display_modes.hockey_live`**: Show live games in progress (default: true)
+- **`display_modes.hockey_recent`**: Show recently completed games (default: true)
+- **`display_modes.hockey_upcoming`**: Show upcoming scheduled games (default: true)
+
+#### Favorite Teams
+
+Specify team abbreviations for each league:
+
+```json
+"favorite_teams": {
+  "nhl": ["TB", "TOR", "BOS", "DET"],
+  "ncaa_mens": ["BU", "BC", "MICH"],
+  "ncaa_womens": ["WISC", "MINN"]
+}
+```
+
+**Common NHL Team Abbreviations:**
+- TB (Tampa Bay Lightning)
+- TOR (Toronto Maple Leafs)
+- BOS (Boston Bruins)
+- DET (Detroit Red Wings)
+- CHI (Chicago Blackhawks)
+- NYR (New York Rangers)
+- MTL (Montreal Canadiens)
+- [See full list in ESPN API or team logos]
+
+**NCAA Team Abbreviations:**
+- BU (Boston University)
+- BC (Boston College)
+- MICH (University of Michigan)
+- WISC (University of Wisconsin)
+- MINN (University of Minnesota)
+
+#### Display Settings
+
+- **`prioritize_favorites`**: Show favorite team games first (default: true)
+- **`show_shots_on_goal`**: Display SOG statistics (default: false)
+- **`show_powerplay`**: Highlight power play situations (default: true)
+- **`update_interval`**: Data refresh interval in seconds (15-300, default: 60)
+- **`display_duration`**: How long to show each game in seconds (5-60, default: 15)
+
+#### Time Windows
+
+- **`recent_games_hours`**: How far back to show recent games (1-168 hours, default: 24)
+- **`upcoming_games_hours`**: How far ahead to show upcoming games (1-336 hours, default: 72)
+
+#### Background Service
+
+```json
+"background_service": {
+  "enabled": true,
+  "request_timeout": 30,
+  "max_retries": 3,
+  "priority": 2
+}
+```
+
+- **`enabled`**: Use background data fetching (default: true)
+- **`request_timeout`**: API timeout in seconds (default: 30)
+- **`max_retries`**: Retry attempts on failure (default: 3)
+- **`priority`**: Request priority 1-5, where 1 is highest (default: 2)
+
+## Display Modes
+
+### Live Games (`hockey_live`)
+
+Shows games currently in progress with:
+- Current score
+- Period (P1, P2, P3, OT, OT2, etc.)
+- Time remaining in period
+- Power play indicator (if enabled)
+- Shots on goal (if enabled)
+
+### Recent Games (`hockey_recent`)
+
+Shows completed games from the last X hours with:
+- Final score
+- Game status ("Final", "Final/OT", "Final/SO")
+- Team logos
+
+### Upcoming Games (`hockey_upcoming`)
+
+Shows scheduled games for the next X hours with:
+- Game start time
+- Venue information
+- Team matchup
+
+## Setup Instructions
+
+### 1. Install Plugin
+
+Install from the Plugin Store in the LEDMatrix Web UI:
+
+1. Go to Plugin Store tab
+2. Search for "Hockey Scoreboard"
+3. Click Install
+4. Configure via Plugin Configuration page
+
+### 2. Configure Leagues
+
+Enable the leagues you want to track:
+
+- **NHL Only**: Set `leagues.nhl: true`, others false
+- **All Leagues**: Set all to true
+- **NCAA Only**: Enable `ncaa_mens` and/or `ncaa_womens`
+
+### 3. Add Favorite Teams
+
+Add your favorite team abbreviations to the `favorite_teams` object for each league. Games involving these teams will be shown first if `prioritize_favorites` is enabled.
+
+### 4. Adjust Display Settings
+
+- Set `display_duration` based on how many games you expect (shorter = more games shown)
+- Adjust `update_interval` based on desired freshness (60s recommended for live games)
+- Enable/disable display modes based on preference
+
+### 5. Enable Plugin
+
+Make sure `enabled: true` in the configuration and the plugin is activated in the rotation.
+
+## Display Layout
+
+### 64x32 Display (Recommended)
+
+```
+┌──────────────────────────────────┐
+│ [AWAY]  3  @  2  [HOME]         │
+│ ▲▲▲▲▲  Score   Score  ▼▼▼▼▼    │
+│         P2 - 15:30               │
+│         PP: HOME (5v4)           │
+└──────────────────────────────────┘
+```
+
+### With Logos
+
+```
+┌──────────────────────────────────┐
+│ [LOGO] BOS  3-2  TB [LOGO]      │
+│        P3 - 5:45                 │
+│        SOG: 28-32                │
+└──────────────────────────────────┘
+```
+
+## Usage Tips
+
+### Optimizing for Your Screen
+
+- **64x32**: Can show full details with logos, SOG, powerplay
+- **64x64**: Can show multiple games or larger fonts
+- **128x32**: Can show two games side-by-side
+
+### Favorite Team Strategy
+
+1. **Single Team Fan**: Add one team to favorites for focused view
+2. **Multi-Team Fan**: Add multiple teams across leagues
+3. **Local Teams**: Add your region's teams across all leagues
+4. **Rivalry Focus**: Add division rivals to never miss matchups
+
+### Update Interval
+
+- **Live Games (High Activity)**: 30-60 seconds
+- **Off Season (Low Activity)**: 120-300 seconds
+- **Balance**: 60 seconds (recommended default)
+
+### Display Duration
+
+- **Many Games**: 10 seconds per game
+- **Few Games**: 15-20 seconds per game
+- **Single Game Focus**: 30+ seconds
+
+## Troubleshooting
+
+**No games showing:**
+- Check that at least one league is enabled in config
+- Verify the season is active for enabled leagues
+- Check `recent_games_hours` and `upcoming_games_hours` settings
+- Ensure internet connection is working
+
+**Games not updating:**
+- Check `update_interval` setting
+- Verify API is responding (check logs)
+- Try clearing cache: restart plugin or clear cache manually
+- Check background service is enabled
+
+**Favorite teams not showing:**
+- Verify team abbreviations are correct (case-sensitive)
+- Ensure `prioritize_favorites` is true
+- Check that favorite teams have games in current time window
+
+**Logos not displaying:**
+- Verify logo assets are available in LEDMatrix installation
+- Check `assets/sports/nhl_logos` and `assets/sports/ncaa_logos` directories
+- Some NCAA teams may not have logos available
+
+**Power play not showing:**
+- Enable `show_powerplay` in config
+- Verify ESPN API includes situation data (may not be available for all leagues)
+
+**SOG not accurate:**
+- Enable `show_shots_on_goal` in config
+- ESPN API may have delayed SOG updates
+- Some leagues may not provide SOG data
+
+## Advanced Configuration
+
+### Custom Fonts
+
+Override default fonts via config or Web UI:
+
+```json
+"fonts": {
+  "team_name": {
+    "family": "press_start",
+    "size": 10,
+    "color": "#FFFFFF"
+  },
+  "score": {
+    "family": "press_start",
+    "size": 12,
+    "color": "#FFC800"
+  },
+  "status": {
+    "family": "four_by_six",
+    "size": 6,
+    "color": "#00FF00"
+  }
+}
+```
+
+### Multi-League Strategy
+
+Enable all three leagues for comprehensive coverage:
+
+```json
+"leagues": {
+  "nhl": true,
+  "ncaa_mens": true,
+  "ncaa_womens": true
+}
+```
+
+Games from all leagues will be mixed and sorted by:
+1. Live games first
+2. Favorite teams (if enabled)
+3. Start time
+
+## Data Source
+
+This plugin uses the **ESPN public API** for all hockey data:
+
+- **NHL**: `https://site.api.espn.com/apis/site/v2/sports/hockey/nhl/scoreboard`
+- **NCAA M**: `https://site.api.espn.com/apis/site/v2/sports/hockey/mens-college-hockey/scoreboard`
+- **NCAA W**: `https://site.api.espn.com/apis/site/v2/sports/hockey/womens-college-hockey/scoreboard`
+
+**Note**: No API key required. Please use responsibly and respect ESPN's rate limits.
+
+## Examples
+
+### NHL Only Configuration
+
+```json
+{
+  "enabled": true,
+  "leagues": {
+    "nhl": true,
+    "ncaa_mens": false,
+    "ncaa_womens": false
+  },
+  "favorite_teams": {
+    "nhl": ["TB", "TOR", "BOS"]
+  },
+  "display_modes": {
+    "hockey_live": true,
+    "hockey_recent": true,
+    "hockey_upcoming": false
+  },
+  "update_interval": 60,
+  "display_duration": 15
+}
+```
+
+### NCAA Men's Only Configuration
+
+```json
+{
+  "enabled": true,
+  "leagues": {
+    "nhl": false,
+    "ncaa_mens": true,
+    "ncaa_womens": false
+  },
+  "favorite_teams": {
+    "ncaa_mens": ["BU", "BC", "MICH", "WISC"]
+  },
+  "display_modes": {
+    "hockey_live": true,
+    "hockey_recent": true,
+    "hockey_upcoming": true
+  },
+  "upcoming_games_hours": 168,
+  "update_interval": 120
+}
+```
+
+### All Leagues Configuration
+
+```json
+{
+  "enabled": true,
+  "leagues": {
+    "nhl": true,
+    "ncaa_mens": true,
+    "ncaa_womens": true
+  },
+  "favorite_teams": {
+    "nhl": ["TB", "DET"],
+    "ncaa_mens": ["MICH"],
+    "ncaa_womens": ["WISC"]
+  },
+  "prioritize_favorites": true,
+  "show_shots_on_goal": true,
+  "show_powerplay": true,
+  "display_modes": {
+    "hockey_live": true,
+    "hockey_recent": true,
+    "hockey_upcoming": true
+  }
+}
+```
+
+## Integration Notes
+
+### Base Classes
+
+This plugin uses LEDMatrix base classes:
+- `Hockey` - Base hockey functionality
+- `HockeyLive` - Live game display logic
+- `SportsRecent` - Recent games display
+- `SportsUpcoming` - Upcoming games display
+
+These are imported from the main LEDMatrix installation at `src/base_classes/`.
+
+### Caching
+
+The plugin uses LEDMatrix's `CacheManager` to cache API responses:
+- Cache duration: 5 minutes for live data
+- Cache key format: `hockey_{league}_{date}`
+- Automatic cache invalidation on date change
+
+### Background Service
+
+Uses LEDMatrix's `BackgroundDataService` for:
+- Non-blocking API requests
+- Automatic retries on failure
+- Request prioritization
+- Timeout handling
+
+## Performance
+
+### Resource Usage
+
+- **CPU**: Low (background fetching, cached data)
+- **Memory**: ~5-10MB for game data
+- **Network**: ~1-5 KB per API call per league
+- **API Calls**: 3 leagues × 12 calls/hour = 36 calls/hour (max)
+
+### Optimization Tips
+
+1. **Disable Unused Leagues**: Only enable leagues you follow
+2. **Increase Update Interval**: Use 120-300s during off-season
+3. **Reduce Time Windows**: Lower `recent_games_hours` and `upcoming_games_hours`
+4. **Enable Caching**: Keep `background_service.enabled: true`
+
+## License
+
+MIT License - see main LEDMatrix repository for details.
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/ChuckBuilds/ledmatrix-plugins/issues)
+- **Documentation**: [LEDMatrix Wiki](https://github.com/ChuckBuilds/LEDMatrix/wiki)
+- **Community**: [Discussions](https://github.com/ChuckBuilds/LEDMatrix/discussions)
+
+---
+
+**Version**: 1.0.0  
+**Author**: ChuckBuilds  
+**Category**: Sports  
+**Tags**: hockey, nhl, ncaa, sports, scoreboard, live-scores
+

--- a/plugins/hockey-scoreboard/config_schema.json
+++ b/plugins/hockey-scoreboard/config_schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable or disable the hockey scoreboard plugin"
+    },
+    "leagues": {
+      "type": "object",
+      "description": "Enable/disable specific hockey leagues",
+      "properties": {
+        "nhl": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show NHL games"
+        },
+        "ncaa_mens": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show NCAA Men's Hockey games"
+        },
+        "ncaa_womens": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show NCAA Women's Hockey games"
+        }
+      }
+    },
+    "display_modes": {
+      "type": "object",
+      "description": "Enable/disable display modes",
+      "properties": {
+        "hockey_live": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show live games in progress"
+        },
+        "hockey_recent": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show recently completed games"
+        },
+        "hockey_upcoming": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show upcoming scheduled games"
+        }
+      }
+    },
+    "favorite_teams": {
+      "type": "object",
+      "description": "Favorite teams by league (use team abbreviations)",
+      "properties": {
+        "nhl": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "NHL team abbreviations (e.g., ['TB', 'TOR', 'BOS'])"
+        },
+        "ncaa_mens": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "NCAA Men's team abbreviations"
+        },
+        "ncaa_womens": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "NCAA Women's team abbreviations"
+        }
+      }
+    },
+    "prioritize_favorites": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show favorite team games first"
+    },
+    "show_shots_on_goal": {
+      "type": "boolean",
+      "default": false,
+      "description": "Display shots on goal statistics during games"
+    },
+    "show_powerplay": {
+      "type": "boolean",
+      "default": true,
+      "description": "Highlight powerplay situations"
+    },
+    "update_interval": {
+      "type": "number",
+      "default": 60,
+      "minimum": 15,
+      "maximum": 300,
+      "description": "How often to refresh game data (in seconds)"
+    },
+    "display_duration": {
+      "type": "number",
+      "default": 15,
+      "minimum": 5,
+      "maximum": 60,
+      "description": "How long to display each game (in seconds)"
+    },
+    "recent_games_hours": {
+      "type": "number",
+      "default": 24,
+      "minimum": 1,
+      "maximum": 168,
+      "description": "How many hours back to show recent games"
+    },
+    "upcoming_games_hours": {
+      "type": "number",
+      "default": 72,
+      "minimum": 1,
+      "maximum": 336,
+      "description": "How many hours ahead to show upcoming games"
+    },
+    "background_service": {
+      "type": "object",
+      "description": "Background data fetching configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use background service for data fetching"
+        },
+        "request_timeout": {
+          "type": "number",
+          "default": 30,
+          "minimum": 5,
+          "maximum": 120,
+          "description": "API request timeout in seconds"
+        },
+        "max_retries": {
+          "type": "number",
+          "default": 3,
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Maximum number of retry attempts"
+        },
+        "priority": {
+          "type": "number",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 5,
+          "description": "Request priority (1=highest, 5=lowest)"
+        }
+      }
+    },
+    "fonts": {
+      "type": "object",
+      "description": "Font customization (overrides default fonts)",
+      "properties": {
+        "team_name": {
+          "type": "object",
+          "properties": {
+            "family": {"type": "string", "default": "press_start"},
+            "size": {"type": "number", "default": 10},
+            "color": {"type": "string", "default": "#FFFFFF"}
+          }
+        },
+        "score": {
+          "type": "object",
+          "properties": {
+            "family": {"type": "string", "default": "press_start"},
+            "size": {"type": "number", "default": 12},
+            "color": {"type": "string", "default": "#FFC800"}
+          }
+        },
+        "status": {
+          "type": "object",
+          "properties": {
+            "family": {"type": "string", "default": "four_by_six"},
+            "size": {"type": "number", "default": 6},
+            "color": {"type": "string", "default": "#00FF00"}
+          }
+        }
+      }
+    }
+  },
+  "required": ["enabled"]
+}
+

--- a/plugins/hockey-scoreboard/manager.py
+++ b/plugins/hockey-scoreboard/manager.py
@@ -1,0 +1,473 @@
+"""
+Hockey Scoreboard Plugin for LEDMatrix
+
+Displays live, recent, and upcoming hockey games across NHL, NCAA Men's, and NCAA Women's hockey.
+Shows real-time scores, game status, powerplay situations, and team logos.
+
+Features:
+- Multiple league support (NHL, NCAA M/W)
+- Live game tracking with periods and time
+- Recent game results
+- Upcoming game schedules
+- Favorite team prioritization
+- Powerplay and penalty indicators
+- Shots on goal statistics
+- Background data fetching
+
+API Version: 1.0.0
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Dict, Any, Optional, List
+from pathlib import Path
+
+import pytz
+import requests
+from PIL import Image, ImageDraw
+
+from src.plugin_system.base_plugin import BasePlugin
+
+# Import hockey base classes from LEDMatrix
+try:
+    from src.base_classes.hockey import Hockey, HockeyLive
+    from src.base_classes.sports import SportsRecent, SportsUpcoming
+except ImportError:
+    Hockey = None
+    HockeyLive = None
+    SportsRecent = None
+    SportsUpcoming = None
+
+logger = logging.getLogger(__name__)
+
+
+class HockeyScoreboardPlugin(BasePlugin):
+    """
+    Hockey scoreboard plugin for displaying games across multiple leagues.
+    
+    Supports NHL, NCAA Men's, and NCAA Women's hockey with live, recent,
+    and upcoming game modes.
+    
+    Configuration options:
+        leagues: Enable/disable NHL, NCAA M, NCAA W
+        display_modes: Enable live, recent, upcoming modes
+        favorite_teams: Team abbreviations per league
+        show_shots_on_goal: Display SOG statistics
+        show_powerplay: Highlight powerplay situations
+        background_service: Data fetching configuration
+    """
+    
+    # ESPN API endpoints for each league
+    ESPN_API_URLS = {
+        'nhl': 'https://site.api.espn.com/apis/site/v2/sports/hockey/nhl/scoreboard',
+        'ncaa_mens': 'https://site.api.espn.com/apis/site/v2/sports/hockey/mens-college-hockey/scoreboard',
+        'ncaa_womens': 'https://site.api.espn.com/apis/site/v2/sports/hockey/womens-college-hockey/scoreboard'
+    }
+    
+    def __init__(self, plugin_id: str, config: Dict[str, Any],
+                 display_manager, cache_manager, plugin_manager):
+        """Initialize the hockey scoreboard plugin."""
+        super().__init__(plugin_id, config, display_manager, cache_manager, plugin_manager)
+        
+        if Hockey is None:
+            self.logger.error("Failed to import Hockey base classes. Plugin will not function.")
+            self.initialized = False
+            return
+        
+        # Configuration
+        self.leagues = config.get('leagues', {
+            'nhl': True,
+            'ncaa_mens': False,
+            'ncaa_womens': False
+        })
+        self.display_modes_config = config.get('display_modes', {
+            'hockey_live': True,
+            'hockey_recent': True,
+            'hockey_upcoming': True
+        })
+        self.favorite_teams = config.get('favorite_teams', {})
+        self.prioritize_favorites = config.get('prioritize_favorites', True)
+        self.show_shots_on_goal = config.get('show_shots_on_goal', False)
+        self.show_powerplay = config.get('show_powerplay', True)
+        self.recent_games_hours = config.get('recent_games_hours', 24)
+        self.upcoming_games_hours = config.get('upcoming_games_hours', 72)
+        
+        # Background service configuration
+        self.background_config = config.get('background_service', {
+            'enabled': True,
+            'request_timeout': 30,
+            'max_retries': 3,
+            'priority': 2
+        })
+        
+        # State
+        self.current_games = []
+        self.current_league = None
+        self.current_display_mode = None
+        self.last_update = 0
+        self.initialized = True
+        
+        # Register fonts
+        self._register_fonts()
+        
+        self.logger.info(f"Hockey scoreboard plugin initialized")
+        self.logger.info(f"Enabled leagues: {[k for k, v in self.leagues.items() if v]}")
+        self.logger.info(f"Display modes: {[k for k, v in self.display_modes_config.items() if v]}")
+    
+    def _register_fonts(self):
+        """Register fonts with the font manager."""
+        try:
+            if not hasattr(self.plugin_manager, 'font_manager'):
+                return
+            
+            font_manager = self.plugin_manager.font_manager
+            
+            # Team name font
+            font_manager.register_manager_font(
+                manager_id=self.plugin_id,
+                element_key=f"{self.plugin_id}.team_name",
+                family="press_start",
+                size_px=10,
+                color=(255, 255, 255)
+            )
+            
+            # Score font
+            font_manager.register_manager_font(
+                manager_id=self.plugin_id,
+                element_key=f"{self.plugin_id}.score",
+                family="press_start",
+                size_px=12,
+                color=(255, 200, 0)
+            )
+            
+            # Status font (period, time)
+            font_manager.register_manager_font(
+                manager_id=self.plugin_id,
+                element_key=f"{self.plugin_id}.status",
+                family="four_by_six",
+                size_px=6,
+                color=(0, 255, 0)
+            )
+            
+            # Info font (shots, powerplay)
+            font_manager.register_manager_font(
+                manager_id=self.plugin_id,
+                element_key=f"{self.plugin_id}.info",
+                family="four_by_six",
+                size_px=6,
+                color=(200, 200, 200)
+            )
+            
+            self.logger.info("Hockey scoreboard fonts registered")
+        except Exception as e:
+            self.logger.warning(f"Error registering fonts: {e}")
+    
+    def update(self) -> None:
+        """Update hockey game data for all enabled leagues."""
+        if not self.initialized:
+            return
+        
+        try:
+            self.current_games = []
+            
+            # Fetch data for each enabled league
+            for league_key, enabled in self.leagues.items():
+                if enabled:
+                    games = self._fetch_league_data(league_key)
+                    if games:
+                        self.current_games.extend(games)
+            
+            # Sort games - prioritize favorites if enabled
+            if self.prioritize_favorites and self.favorite_teams:
+                self.current_games.sort(
+                    key=lambda g: (
+                        0 if self._is_favorite_game(g) else 1,
+                        g.get('start_time', '')
+                    )
+                )
+            
+            self.last_update = time.time()
+            self.logger.debug(f"Updated hockey data: {len(self.current_games)} games")
+            
+        except Exception as e:
+            self.logger.error(f"Error updating hockey data: {e}")
+    
+    def _fetch_league_data(self, league_key: str) -> List[Dict]:
+        """Fetch game data for a specific league."""
+        cache_key = f"hockey_{league_key}_{datetime.now().strftime('%Y%m%d')}"
+        
+        # Check cache first
+        cached_data = self.cache_manager.get(cache_key)
+        if cached_data:
+            self.logger.debug(f"Using cached data for {league_key}")
+            return cached_data
+        
+        # Fetch from API
+        try:
+            url = self.ESPN_API_URLS.get(league_key)
+            if not url:
+                self.logger.error(f"Unknown league key: {league_key}")
+                return []
+            
+            self.logger.info(f"Fetching {league_key} data from ESPN API...")
+            response = requests.get(url, timeout=self.background_config.get('request_timeout', 30))
+            response.raise_for_status()
+            
+            data = response.json()
+            games = self._process_api_response(data, league_key)
+            
+            # Cache for 5 minutes
+            self.cache_manager.set(cache_key, games, ttl=300)
+            
+            return games
+            
+        except requests.RequestException as e:
+            self.logger.error(f"Error fetching {league_key} data: {e}")
+            return []
+        except Exception as e:
+            self.logger.error(f"Error processing {league_key} data: {e}")
+            return []
+    
+    def _process_api_response(self, data: Dict, league_key: str) -> List[Dict]:
+        """Process ESPN API response into standardized game format."""
+        games = []
+        
+        try:
+            events = data.get('events', [])
+            
+            for event in events:
+                try:
+                    game = self._extract_game_info(event, league_key)
+                    if game:
+                        games.append(game)
+                except Exception as e:
+                    self.logger.error(f"Error extracting game info: {e}")
+                    continue
+            
+        except Exception as e:
+            self.logger.error(f"Error processing API response: {e}")
+        
+        return games
+    
+    def _extract_game_info(self, event: Dict, league_key: str) -> Optional[Dict]:
+        """Extract game information from ESPN event."""
+        try:
+            competition = event.get('competitions', [{}])[0]
+            status = competition.get('status', {})
+            competitors = competition.get('competitors', [])
+            
+            if len(competitors) < 2:
+                return None
+            
+            # Find home and away teams
+            home_team = next((c for c in competitors if c.get('homeAway') == 'home'), None)
+            away_team = next((c for c in competitors if c.get('homeAway') == 'away'), None)
+            
+            if not home_team or not away_team:
+                return None
+            
+            # Extract game details
+            game = {
+                'league': league_key,
+                'game_id': event.get('id'),
+                'home_team': {
+                    'name': home_team.get('team', {}).get('displayName', 'Unknown'),
+                    'abbrev': home_team.get('team', {}).get('abbreviation', 'UNK'),
+                    'score': int(home_team.get('score', 0)),
+                    'logo': home_team.get('team', {}).get('logo')
+                },
+                'away_team': {
+                    'name': away_team.get('team', {}).get('displayName', 'Unknown'),
+                    'abbrev': away_team.get('team', {}).get('abbreviation', 'UNK'),
+                    'score': int(away_team.get('score', 0)),
+                    'logo': away_team.get('team', {}).get('logo')
+                },
+                'status': {
+                    'state': status.get('type', {}).get('state', 'unknown'),
+                    'detail': status.get('type', {}).get('detail', ''),
+                    'short_detail': status.get('type', {}).get('shortDetail', ''),
+                    'period': status.get('period', 0),
+                    'display_clock': status.get('displayClock', '')
+                },
+                'start_time': event.get('date', ''),
+                'venue': competition.get('venue', {}).get('fullName', 'Unknown Venue')
+            }
+            
+            # Add powerplay info if available
+            situation = competition.get('situation', {})
+            if situation:
+                game['powerplay'] = situation.get('isPowerPlay', False)
+                game['penalties'] = situation.get('penalties', '')
+            
+            # Add shots on goal if available
+            if self.show_shots_on_goal:
+                home_stats = home_team.get('statistics', [])
+                away_stats = away_team.get('statistics', [])
+                
+                game['home_team']['shots'] = next(
+                    (int(s.get('displayValue', 0)) for s in home_stats if s.get('name') == 'shots'),
+                    0
+                )
+                game['away_team']['shots'] = next(
+                    (int(s.get('displayValue', 0)) for s in away_stats if s.get('name') == 'shots'),
+                    0
+                )
+            
+            return game
+            
+        except Exception as e:
+            self.logger.error(f"Error extracting game info: {e}")
+            return None
+    
+    def _is_favorite_game(self, game: Dict) -> bool:
+        """Check if game involves a favorite team."""
+        league = game.get('league')
+        favorites = self.favorite_teams.get(league, [])
+        
+        if not favorites:
+            return False
+        
+        home_abbrev = game.get('home_team', {}).get('abbrev')
+        away_abbrev = game.get('away_team', {}).get('abbrev')
+        
+        return home_abbrev in favorites or away_abbrev in favorites
+    
+    def display(self, display_mode: str = None, force_clear: bool = False) -> None:
+        """
+        Display hockey games.
+        
+        Args:
+            display_mode: Which mode to display (hockey_live, hockey_recent, hockey_upcoming)
+            force_clear: If True, clear display before rendering
+        """
+        if not self.initialized:
+            self._display_error("Hockey plugin not initialized")
+            return
+        
+        # Determine which display mode to use
+        mode = display_mode or self.current_display_mode or 'hockey_live'
+        self.current_display_mode = mode
+        
+        # Filter games by display mode
+        filtered_games = self._filter_games_by_mode(mode)
+        
+        if not filtered_games:
+            self._display_no_games(mode)
+            return
+        
+        # Display the first game (rotation handled by LEDMatrix)
+        game = filtered_games[0]
+        self._display_game(game, mode)
+    
+    def _filter_games_by_mode(self, mode: str) -> List[Dict]:
+        """Filter games based on display mode."""
+        now = datetime.now(timezone.utc)
+        filtered = []
+        
+        for game in self.current_games:
+            state = game.get('status', {}).get('state')
+            
+            if mode == 'hockey_live' and state == 'in':
+                filtered.append(game)
+            elif mode == 'hockey_recent' and state == 'post':
+                # Check if within recent_games_hours
+                game_time = datetime.fromisoformat(game.get('start_time', '').replace('Z', '+00:00'))
+                hours_ago = (now - game_time).total_seconds() / 3600
+                if hours_ago <= self.recent_games_hours:
+                    filtered.append(game)
+            elif mode == 'hockey_upcoming' and state == 'pre':
+                # Check if within upcoming_games_hours
+                game_time = datetime.fromisoformat(game.get('start_time', '').replace('Z', '+00:00'))
+                hours_ahead = (game_time - now).total_seconds() / 3600
+                if hours_ahead <= self.upcoming_games_hours:
+                    filtered.append(game)
+        
+        return filtered
+    
+    def _display_game(self, game: Dict, mode: str):
+        """Display a single game."""
+        try:
+            matrix_width = self.display_manager.matrix.width
+            matrix_height = self.display_manager.matrix.height
+            
+            # Create image
+            img = Image.new('RGB', (matrix_width, matrix_height), (0, 0, 0))
+            draw = ImageDraw.Draw(img)
+            
+            # Get team info
+            home_team = game.get('home_team', {})
+            away_team = game.get('away_team', {})
+            status = game.get('status', {})
+            
+            # Display team names/abbreviations
+            home_abbrev = home_team.get('abbrev', 'HOME')
+            away_abbrev = away_team.get('abbrev', 'AWAY')
+            
+            # TODO: Add team logos if available
+            # TODO: Use font manager for text rendering
+            # TODO: Add scores, period, time display
+            # TODO: Add powerplay indicator
+            # TODO: Add shots on goal if enabled
+            
+            # For now, simple text display (placeholder)
+            draw.text((5, 5), f"{away_abbrev} @ {home_abbrev}", fill=(255, 255, 255))
+            draw.text((5, 15), f"{away_team.get('score', 0)} - {home_team.get('score', 0)}", fill=(255, 200, 0))
+            draw.text((5, 25), status.get('short_detail', ''), fill=(0, 255, 0))
+            
+            self.display_manager.image = img.copy()
+            self.display_manager.update_display()
+            
+        except Exception as e:
+            self.logger.error(f"Error displaying game: {e}")
+            self._display_error("Display error")
+    
+    def _display_no_games(self, mode: str):
+        """Display message when no games are available."""
+        img = Image.new('RGB', (self.display_manager.matrix.width,
+                               self.display_manager.matrix.height),
+                       (0, 0, 0))
+        draw = ImageDraw.Draw(img)
+        
+        message = {
+            'hockey_live': "No Live Games",
+            'hockey_recent': "No Recent Games",
+            'hockey_upcoming': "No Upcoming Games"
+        }.get(mode, "No Games")
+        
+        draw.text((5, 12), message, fill=(150, 150, 150))
+        
+        self.display_manager.image = img.copy()
+        self.display_manager.update_display()
+    
+    def _display_error(self, message: str):
+        """Display error message."""
+        img = Image.new('RGB', (self.display_manager.matrix.width,
+                               self.display_manager.matrix.height),
+                       (0, 0, 0))
+        draw = ImageDraw.Draw(img)
+        draw.text((5, 12), message, fill=(255, 0, 0))
+        
+        self.display_manager.image = img.copy()
+        self.display_manager.update_display()
+    
+    def get_display_duration(self) -> float:
+        """Get display duration from config."""
+        return self.config.get('display_duration', 15.0)
+    
+    def get_info(self) -> Dict[str, Any]:
+        """Return plugin info for web UI."""
+        info = super().get_info()
+        info.update({
+            'leagues': self.leagues,
+            'total_games': len(self.current_games),
+            'last_update': self.last_update,
+            'enabled_modes': [k for k, v in self.display_modes_config.items() if v]
+        })
+        return info
+    
+    def cleanup(self) -> None:
+        """Cleanup resources."""
+        self.current_games = []
+        self.logger.info("Hockey scoreboard plugin cleaned up")
+

--- a/plugins/hockey-scoreboard/manifest.json
+++ b/plugins/hockey-scoreboard/manifest.json
@@ -1,0 +1,43 @@
+{
+  "id": "hockey-scoreboard",
+  "name": "Hockey Scoreboard",
+  "version": "1.0.0",
+  "author": "ChuckBuilds",
+  "description": "Live, recent, and upcoming hockey games across NHL, NCAA Men's, and NCAA Women's hockey with real-time scores and schedules",
+  "homepage": "https://github.com/ChuckBuilds/ledmatrix-hockey-plugin",
+  "entry_point": "manager.py",
+  "class_name": "HockeyScoreboardPlugin",
+  "category": "sports",
+  "tags": ["hockey", "nhl", "ncaa", "sports", "scoreboard", "live-scores"],
+  "icon": "fas fa-hockey-puck",
+  "compatible_versions": [">=2.0.0"],
+  "ledmatrix_version": "2.0.0",
+  "requires": {
+    "python": ">=3.9",
+    "display_size": {
+      "min_width": 64,
+      "min_height": 32
+    }
+  },
+  "config_schema": "config_schema.json",
+  "assets": {
+    "logos": "Uses shared LEDMatrix assets/sports/nhl_logos and assets/sports/ncaa_logos directories"
+  },
+  "update_interval": 60,
+  "default_duration": 15,
+  "display_modes": [
+    "hockey_live",
+    "hockey_recent",
+    "hockey_upcoming"
+  ],
+  "api_requirements": [
+    {
+      "name": "ESPN API",
+      "required": true,
+      "description": "ESPN public API for NHL and NCAA hockey scores and schedules",
+      "url": "https://site.api.espn.com/apis/site/v2/sports/hockey/",
+      "rate_limit": "No official rate limit, but please use responsibly"
+    }
+  ]
+}
+

--- a/plugins/hockey-scoreboard/requirements.txt
+++ b/plugins/hockey-scoreboard/requirements.txt
@@ -1,0 +1,19 @@
+# Hockey Scoreboard Plugin Dependencies
+
+# Image processing
+Pillow>=9.0.0
+
+# HTTP requests for ESPN API
+requests>=2.28.0
+
+# Timezone handling
+pytz>=2022.1
+
+# Required LEDMatrix base classes
+# These are imported from the main LEDMatrix installation:
+# - src.base_classes.hockey (Hockey, HockeyLive)
+# - src.base_classes.sports (SportsCore, SportsRecent, SportsUpcoming)
+# - src.plugin_system.base_plugin (BasePlugin)
+# - src.cache_manager (CacheManager)
+# - src.display_manager (DisplayManager)
+


### PR DESCRIPTION
First Phase 2 sports plugin combining multiple hockey leagues:
- NHL, NCAA Men's Hockey, NCAA Women's Hockey
- Three display modes: live, recent, upcoming games
- Favorite team prioritization across all leagues
- Power play indicators and shots on goal
- Background data fetching with caching
- Font manager integration
- Comprehensive configuration schema

Plugin features:
- Multi-league support with individual toggles
- Real-time score updates from ESPN API
- Time windows for recent/upcoming games
- Team logo support
- Configurable update intervals and display duration
- Background service integration for efficient API calls

Total plugins: 9 (Phase 1: 8, Phase 2: 1)