### PR TITLE
refactor: simplify hockey-scoreboard configuration to match original …

### DIFF
--- a/plugins/hockey-scoreboard/config_schema.json
+++ b/plugins/hockey-scoreboard/config_schema.json
@@ -7,312 +7,129 @@
       "default": true,
       "description": "Enable or disable the hockey scoreboard plugin"
     },
-    "nhl": {
+    "leagues": {
       "type": "object",
-      "description": "NHL (National Hockey League) configuration",
+      "description": "Enable/disable specific hockey leagues",
       "properties": {
-        "enabled": {
+        "nhl": {
           "type": "boolean",
           "default": true,
-          "description": "Enable NHL games"
+          "description": "Show NHL games"
         },
-        "display_modes": {
-          "type": "object",
-          "description": "Display modes for NHL",
-          "properties": {
-            "live": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NHL live games"
-            },
-            "recent": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NHL recent games"
-            },
-            "upcoming": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NHL upcoming games"
-            }
-          }
-        },
-        "favorite_teams": {
-          "type": "array",
-          "items": {"type": "string"},
-          "default": [],
-          "description": "NHL favorite team abbreviations (e.g., ['TB', 'TOR', 'BOS'])"
-        },
-        "live_priority": {
-          "type": "boolean",
-          "default": true,
-          "description": "Prioritize NHL live games over other leagues"
-        },
-        "show_odds": {
+        "ncaa_mens": {
           "type": "boolean",
           "default": false,
-          "description": "Show betting odds for NHL games"
+          "description": "Show NCAA Men's Hockey games"
         },
-        "show_favorite_teams_only": {
+        "ncaa_womens": {
           "type": "boolean",
           "default": false,
-          "description": "Only show NHL games with favorite teams"
-        },
-        "recent_games_to_show": {
-          "type": "number",
-          "default": 5,
-          "minimum": 1,
-          "maximum": 20,
-          "description": "Number of recent NHL games to show"
-        },
-        "upcoming_games_to_show": {
-          "type": "number",
-          "default": 10,
-          "minimum": 1,
-          "maximum": 50,
-          "description": "Number of upcoming NHL games to show"
-        },
-        "logo_dir": {
-          "type": "string",
-          "default": "assets/sports/nhl_logos",
-          "description": "Directory for NHL team logos"
-        },
-        "update_interval_seconds": {
-          "type": "number",
-          "default": 60,
-          "minimum": 15,
-          "maximum": 300,
-          "description": "NHL data update interval in seconds"
+          "description": "Show NCAA Women's Hockey games"
         }
       }
     },
-    "ncaa_mens": {
+    "display_modes": {
       "type": "object",
-      "description": "NCAA Men's Hockey configuration",
+      "description": "Enable/disable display modes for all leagues",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable NCAA Men's Hockey games"
-        },
-        "display_modes": {
-          "type": "object",
-          "description": "Display modes for NCAA Men's Hockey",
-          "properties": {
-            "live": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NCAA Men's Hockey live games"
-            },
-            "recent": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NCAA Men's Hockey recent games"
-            },
-            "upcoming": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NCAA Men's Hockey upcoming games"
-            }
-          }
-        },
-        "favorite_teams": {
-          "type": "array",
-          "items": {"type": "string"},
-          "default": [],
-          "description": "NCAA Men's Hockey favorite team abbreviations (e.g., ['BU', 'BC', 'MICH'])"
-        },
-        "live_priority": {
-          "type": "boolean",
-          "default": false,
-          "description": "Prioritize NCAA Men's Hockey live games"
-        },
-        "show_odds": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show betting odds for NCAA Men's Hockey games"
-        },
-        "show_favorite_teams_only": {
-          "type": "boolean",
-          "default": false,
-          "description": "Only show NCAA Men's Hockey games with favorite teams"
-        },
-        "recent_games_to_show": {
-          "type": "number",
-          "default": 5,
-          "minimum": 1,
-          "maximum": 20,
-          "description": "Number of recent NCAA Men's Hockey games to show"
-        },
-        "upcoming_games_to_show": {
-          "type": "number",
-          "default": 10,
-          "minimum": 1,
-          "maximum": 50,
-          "description": "Number of upcoming NCAA Men's Hockey games to show"
-        },
-        "logo_dir": {
-          "type": "string",
-          "default": "assets/sports/ncaa_logos",
-          "description": "Directory for NCAA Men's Hockey team logos"
-        },
-        "update_interval_seconds": {
-          "type": "number",
-          "default": 120,
-          "minimum": 30,
-          "maximum": 600,
-          "description": "NCAA Men's Hockey data update interval in seconds"
-        }
-      }
-    },
-    "ncaa_womens": {
-      "type": "object",
-      "description": "NCAA Women's Hockey configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable NCAA Women's Hockey games"
-        },
-        "display_modes": {
-          "type": "object",
-          "description": "Display modes for NCAA Women's Hockey",
-          "properties": {
-            "live": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NCAA Women's Hockey live games"
-            },
-            "recent": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NCAA Women's Hockey recent games"
-            },
-            "upcoming": {
-              "type": "boolean",
-              "default": true,
-              "description": "Show NCAA Women's Hockey upcoming games"
-            }
-          }
-        },
-        "favorite_teams": {
-          "type": "array",
-          "items": {"type": "string"},
-          "default": [],
-          "description": "NCAA Women's Hockey favorite team abbreviations (e.g., ['WISC', 'MINN', 'OSU'])"
-        },
-        "live_priority": {
-          "type": "boolean",
-          "default": false,
-          "description": "Prioritize NCAA Women's Hockey live games"
-        },
-        "show_odds": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show betting odds for NCAA Women's Hockey games"
-        },
-        "show_favorite_teams_only": {
-          "type": "boolean",
-          "default": false,
-          "description": "Only show NCAA Women's Hockey games with favorite teams"
-        },
-        "recent_games_to_show": {
-          "type": "number",
-          "default": 5,
-          "minimum": 1,
-          "maximum": 20,
-          "description": "Number of recent NCAA Women's Hockey games to show"
-        },
-        "upcoming_games_to_show": {
-          "type": "number",
-          "default": 10,
-          "minimum": 1,
-          "maximum": 50,
-          "description": "Number of upcoming NCAA Women's Hockey games to show"
-        },
-        "logo_dir": {
-          "type": "string",
-          "default": "assets/sports/ncaa_logos",
-          "description": "Directory for NCAA Women's Hockey team logos"
-        },
-        "update_interval_seconds": {
-          "type": "number",
-          "default": 180,
-          "minimum": 60,
-          "maximum": 900,
-          "description": "NCAA Women's Hockey data update interval in seconds"
-        }
-      }
-    },
-    "global": {
-      "type": "object",
-      "description": "Global hockey scoreboard settings",
-      "properties": {
-        "show_all_live": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show all live games regardless of league priority"
-        },
-        "show_records": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show team records (wins-losses)"
-        },
-        "show_ranking": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show team rankings/standings"
-        },
-        "show_shots_on_goal": {
-          "type": "boolean",
-          "default": false,
-          "description": "Display shots on goal statistics during games"
-        },
-        "show_powerplay": {
+        "hockey_live": {
           "type": "boolean",
           "default": true,
-          "description": "Highlight powerplay situations"
+          "description": "Show live games in progress"
         },
-        "display_duration": {
-          "type": "number",
-          "default": 15,
-          "minimum": 5,
-          "maximum": 60,
-          "description": "How long to display each game (in seconds)"
+        "hockey_recent": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show recently completed games"
         },
-        "background_service": {
-          "type": "object",
-          "description": "Background data fetching configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": true,
-              "description": "Use background service for data fetching"
-            },
-            "request_timeout": {
-              "type": "number",
-              "default": 30,
-              "minimum": 5,
-              "maximum": 120,
-              "description": "API request timeout in seconds"
-            },
-            "max_retries": {
-              "type": "number",
-              "default": 3,
-              "minimum": 0,
-              "maximum": 10,
-              "description": "Maximum number of retry attempts"
-            },
-            "priority": {
-              "type": "number",
-              "default": 2,
-              "minimum": 1,
-              "maximum": 5,
-              "description": "Request priority (1=highest, 5=lowest)"
-            }
-          }
+        "hockey_upcoming": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show upcoming scheduled games"
         }
       }
+    },
+    "favorite_teams": {
+      "type": "object",
+      "description": "Favorite teams by league (use team abbreviations)",
+      "properties": {
+        "nhl": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "NHL team abbreviations (e.g., ['TB', 'TOR', 'BOS'])"
+        },
+        "ncaa_mens": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "NCAA Men's team abbreviations (e.g., ['BU', 'BC', 'MICH'])"
+        },
+        "ncaa_womens": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "NCAA Women's team abbreviations (e.g., ['WISC', 'MINN', 'OSU'])"
+        }
+      }
+    },
+    "live_priority": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show live games first (prioritize over recent/upcoming)"
+    },
+    "recent_games_to_show": {
+      "type": "number",
+      "default": 5,
+      "minimum": 1,
+      "maximum": 20,
+      "description": "Number of recent games to show"
+    },
+    "upcoming_games_to_show": {
+      "type": "number",
+      "default": 10,
+      "minimum": 1,
+      "maximum": 50,
+      "description": "Number of upcoming games to show"
+    },
+    "show_records": {
+      "type": "boolean",
+      "default": false,
+      "description": "Show team records (wins-losses)"
+    },
+    "show_ranking": {
+      "type": "boolean",
+      "default": false,
+      "description": "Show team rankings/standings"
+    },
+    "show_shots_on_goal": {
+      "type": "boolean",
+      "default": false,
+      "description": "Display shots on goal statistics during games"
+    },
+    "show_powerplay": {
+      "type": "boolean",
+      "default": true,
+      "description": "Highlight powerplay situations"
+    },
+    "logo_dir": {
+      "type": "string",
+      "default": "assets/sports",
+      "description": "Base directory for team logos (nhl_logos, ncaa_logos)"
+    },
+    "update_interval": {
+      "type": "number",
+      "default": 60,
+      "minimum": 15,
+      "maximum": 300,
+      "description": "How often to refresh game data (in seconds)"
+    },
+    "display_duration": {
+      "type": "number",
+      "default": 15,
+      "minimum": 5,
+      "maximum": 60,
+      "description": "How long to display each game (in seconds)"
     },
     "fonts": {
       "type": "object",


### PR DESCRIPTION
…manager

Simplified configuration structure to match original NHL manager:

## Configuration Structure

### Top Level Settings
- **enabled**: Enable/disable plugin
- **leagues**: Checkbox toggles for NHL, NCAA Men's, NCAA Women's
- **display_modes**: Checkbox toggles for hockey_live, hockey_recent, hockey_upcoming
- **favorite_teams**: Team abbreviations per league (nhl, ncaa_mens, ncaa_womens)
- **live_priority**: Prioritize live games (boolean)
- **recent_games_to_show**: Number of recent games to display
- **upcoming_games_to_show**: Number of upcoming games to display
- **show_records**: Display team records
- **show_ranking**: Display team rankings
- **show_shots_on_goal**: Display shots on goal statistics
- **show_powerplay**: Highlight powerplay situations
- **logo_dir**: Base directory for team logos
- **update_interval**: Data refresh interval
- **display_duration**: How long each game displays
- **fonts**: Font customization for team_name, score, status, info

## Behavior
- Simple checkbox interface for leagues and display modes
- Global settings apply to all enabled leagues
- Matches original NHL manager configuration pattern
- Cleaner, more intuitive Web UI configuration