### PR TITLE
fix(basketball): fix records display and reduce no-live-games log noise

### DIFF
--- a/plugins/basketball-scoreboard/basketball.py
+++ b/plugins/basketball-scoreboard/basketball.py
@@ -240,11 +240,12 @@ class BasketballLive(Basketball, SportsLive):
                 # Display away team info
                 if away_abbr:
                     if self.show_ranking and self.show_records:
+                        # Rankings take priority, fall back to record for unranked teams
                         away_rank = self._team_rankings_cache.get(away_abbr, 0)
                         if away_rank > 0:
                             away_text = f"#{away_rank}"
                         else:
-                            away_text = ''
+                            away_text = game.get('away_record', '')
                     elif self.show_ranking:
                         away_rank = self._team_rankings_cache.get(away_abbr, 0)
                         if away_rank > 0:
@@ -255,7 +256,7 @@ class BasketballLive(Basketball, SportsLive):
                         away_text = game.get('away_record', '')
                     else:
                         away_text = ''
-                    
+
                     if away_text:
                         away_record_x = 3
                         self.logger.debug(f"Drawing away ranking '{away_text}' at ({away_record_x}, {record_y})")
@@ -264,11 +265,12 @@ class BasketballLive(Basketball, SportsLive):
                 # Display home team info
                 if home_abbr:
                     if self.show_ranking and self.show_records:
+                        # Rankings take priority, fall back to record for unranked teams
                         home_rank = self._team_rankings_cache.get(home_abbr, 0)
                         if home_rank > 0:
                             home_text = f"#{home_rank}"
                         else:
-                            home_text = ''
+                            home_text = game.get('home_record', '')
                     elif self.show_ranking:
                         home_rank = self._team_rankings_cache.get(home_abbr, 0)
                         if home_rank > 0:

--- a/plugins/basketball-scoreboard/scroll_display.py
+++ b/plugins/basketball-scoreboard/scroll_display.py
@@ -268,17 +268,17 @@ class ScrollDisplay:
         Determine the game type from the game's status.
 
         Args:
-            game: Game dictionary
+            game: Game dictionary (flat format from sports.py)
 
         Returns:
             Game type: 'live', 'recent', or 'upcoming'
         """
-        state = game.get('status', {}).get('state', '')
-        if state == 'in':
+        # Use flat game dict flags from sports.py
+        if game.get('is_live'):
             return 'live'
-        elif state == 'post':
+        elif game.get('is_final'):
             return 'recent'
-        elif state == 'pre':
+        elif game.get('is_upcoming'):
             return 'upcoming'
         else:
             # Default to upcoming if state is unknown

--- a/plugins/basketball-scoreboard/sports.py
+++ b/plugins/basketball-scoreboard/sports.py
@@ -195,7 +195,7 @@ class SportsCore(ABC):
             if not hasattr(self, "_last_warning_time"):
                 self._last_warning_time = 0
             if current_time - getattr(self, "_last_warning_time", 0) > 300:
-                self.logger.warning(
+                self.logger.debug(
                     f"No game data available to display in {self.__class__.__name__}"
                 )
                 setattr(self, "_last_warning_time", current_time)
@@ -1485,13 +1485,12 @@ class SportsUpcoming(SportsCore):
                 # Display away team info
                 if away_abbr:
                     if self.show_ranking and self.show_records:
-                        # When both rankings and records are enabled, rankings replace records completely
+                        # Rankings take priority, fall back to record for unranked teams
                         away_rank = self._team_rankings_cache.get(away_abbr, 0)
                         if away_rank > 0:
                             away_text = f"#{away_rank}"
                         else:
-                            # Show nothing for unranked teams when rankings are prioritized
-                            away_text = ""
+                            away_text = game.get("away_record", "")
                     elif self.show_ranking:
                         # Show ranking only if available
                         away_rank = self._team_rankings_cache.get(away_abbr, 0)
@@ -1500,7 +1499,6 @@ class SportsUpcoming(SportsCore):
                         else:
                             away_text = ""
                     elif self.show_records:
-                        # Show record only when rankings are disabled
                         away_text = game.get("away_record", "")
                     else:
                         away_text = ""
@@ -1520,13 +1518,12 @@ class SportsUpcoming(SportsCore):
                 # Display home team info
                 if home_abbr:
                     if self.show_ranking and self.show_records:
-                        # When both rankings and records are enabled, rankings replace records completely
+                        # Rankings take priority, fall back to record for unranked teams
                         home_rank = self._team_rankings_cache.get(home_abbr, 0)
                         if home_rank > 0:
                             home_text = f"#{home_rank}"
                         else:
-                            # Show nothing for unranked teams when rankings are prioritized
-                            home_text = ""
+                            home_text = game.get("home_record", "")
                     elif self.show_ranking:
                         # Show ranking only if available
                         home_rank = self._team_rankings_cache.get(home_abbr, 0)
@@ -1535,7 +1532,6 @@ class SportsUpcoming(SportsCore):
                         else:
                             home_text = ""
                     elif self.show_records:
-                        # Show record only when rankings are disabled
                         home_text = game.get("home_record", "")
                     else:
                         home_text = ""
@@ -2008,13 +2004,12 @@ class SportsRecent(SportsCore):
                 # Display away team info
                 if away_abbr:
                     if self.show_ranking and self.show_records:
-                        # When both rankings and records are enabled, rankings replace records completely
+                        # Rankings take priority, fall back to record for unranked teams
                         away_rank = self._team_rankings_cache.get(away_abbr, 0)
                         if away_rank > 0:
                             away_text = f"#{away_rank}"
                         else:
-                            # Show nothing for unranked teams when rankings are prioritized
-                            away_text = ""
+                            away_text = game.get("away_record", "")
                     elif self.show_ranking:
                         # Show ranking only if available
                         away_rank = self._team_rankings_cache.get(away_abbr, 0)
@@ -2023,7 +2018,6 @@ class SportsRecent(SportsCore):
                         else:
                             away_text = ""
                     elif self.show_records:
-                        # Show record only when rankings are disabled
                         away_text = game.get("away_record", "")
                     else:
                         away_text = ""
@@ -2043,13 +2037,12 @@ class SportsRecent(SportsCore):
                 # Display home team info
                 if home_abbr:
                     if self.show_ranking and self.show_records:
-                        # When both rankings and records are enabled, rankings replace records completely
+                        # Rankings take priority, fall back to record for unranked teams
                         home_rank = self._team_rankings_cache.get(home_abbr, 0)
                         if home_rank > 0:
                             home_text = f"#{home_rank}"
                         else:
-                            # Show nothing for unranked teams when rankings are prioritized
-                            home_text = ""
+                            home_text = game.get("home_record", "")
                     elif self.show_ranking:
                         # Show ranking only if available
                         home_rank = self._team_rankings_cache.get(home_abbr, 0)
@@ -2058,7 +2051,6 @@ class SportsRecent(SportsCore):
                         else:
                             home_text = ""
                     elif self.show_records:
-                        # Show record only when rankings are disabled
                         home_text = game.get("home_record", "")
                     else:
                         home_text = ""


### PR DESCRIPTION
- When both show_ranking and show_records are enabled, fall back to showing the team record if no ranking is available (previously showed nothing for unranked teams)
- Lower "no game data available" log from WARNING to DEBUG since the display controller already skips modes with no content
- Fix GameRenderer config reading to find show_records/show_ranking from per-league display_options instead of a nonexistent defaults key
- Fix GameRenderer to use flat game dict format (home_abbr, home_score, home_record) matching what sports.py produces instead of nested home_team/away_team dicts
- Fix scroll_display game type detection to use is_live/is_final/ is_upcoming flags instead of nested status.state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved team ranking and record display fallback behavior on the scoreboard.
  * Enhanced game status rendering for live, recent, and upcoming games.
  * Reduced unnecessary warning messages in system logs.

* **Improvements**
  * More robust handling of league display options and settings.
  * Better accuracy in game time and status information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->