### PR TITLE
refactor(baseball): use background_data_service via data_manager

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -272,10 +272,10 @@
       "plugin_path": "plugins/baseball-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2025-10-20",
+      "last_updated": "2026-02-12",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.4"
+      "latest_version": "1.0.5"
     },
     {
       "id": "soccer-scoreboard",

--- a/plugins/baseball-scoreboard/manifest.json
+++ b/plugins/baseball-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "baseball-scoreboard",
   "name": "Baseball Scoreboard",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming baseball games across MLB, MiLB, and NCAA Baseball with real-time scores and schedules",
   "category": "sports",
@@ -20,7 +20,15 @@
     "baseball_recent",
     "baseball_upcoming"
   ],
+  "repo": "https://github.com/ChuckBuilds/ledmatrix-plugins",
+  "branch": "main",
+  "plugin_path": "plugins/baseball-scoreboard",
   "versions": [
+    {
+      "released": "2026-02-12",
+      "version": "1.0.5",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2025-10-20",
       "version": "1.0.4",
@@ -37,7 +45,7 @@
       "ledmatrix_min": "2.0.0"
     }
   ],
-  "last_updated": "2025-10-19",
+  "last_updated": "2026-02-12",
   "stars": 0,
   "downloads": 0,
   "verified": true,


### PR DESCRIPTION
## Summary
- Wire `manager.py` to delegate data fetching to the existing `data_manager.py`, which already has full `background_data_service` integration (`submit_fetch_request` with callbacks, request tracking, and sync fallback)
- This brings the baseball-scoreboard in line with basketball, football, hockey, and soccer scoreboard plugins which all use `background_data_service` for async background fetching
- Old synchronous fetch logic preserved as `_fetch_league_data_sync()` fallback if `data_manager` import fails

## Changes
- **`manager.py`**: Import `BaseballDataManager`, initialize in `__init__()`, delegate `_fetch_league_data()` to data manager, add MiLB format converter, update `cleanup()`
- **`manifest.json`**: Bump to v1.0.5, add monorepo fields (`repo`, `branch`, `plugin_path`)
- **`plugins.json`**: Sync `last_updated` to `2026-02-12` to match manifest

## Test plan
- [ ] Verify `data_manager.py` imports resolve when running as a plugin
- [ ] Check logs for "Baseball data manager initialized with background service support"
- [ ] Verify ESPN data fetching works via background service (MLB, NCAA Baseball)
- [ ] Verify MiLB data fetching works via data_manager
- [ ] Test fallback: if `data_manager` import fails, sync fetch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background data fetching for the baseball-scoreboard plugin for improved performance and reliability.

* **Chores**
  * Updated baseball-scoreboard plugin to version 1.0.5.
  * Updated plugin registry metadata and configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->