### PR TITLE
fix(leaderboard): fix top_teams config and one-shot scroll mode

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-02-11",
+  "last_updated": "2026-02-12",
   "plugins": [
     {
       "id": "hello-world",
@@ -355,10 +355,10 @@
       "plugin_path": "plugins/ledmatrix-leaderboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2025-11-06",
+      "last_updated": "2026-02-12",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.5"
+      "latest_version": "1.0.6"
     },
     {
       "id": "news",

--- a/plugins/ledmatrix-leaderboard/data_fetcher.py
+++ b/plugins/ledmatrix-leaderboard/data_fetcher.py
@@ -39,41 +39,35 @@ class DataFetcher:
     def fetch_standings(self, league_config: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Fetch standings for a specific league from ESPN API with caching.
-        
+
         Args:
             league_config: League configuration dictionary
-            
+
         Returns:
             List of team standings dictionaries
         """
         league_key = league_config['league']
         cache_key = f"leaderboard_{league_key}"
-        
+
         # Try to get cached data first
         cached_data = self.cache_manager.get_cached_data_with_strategy(cache_key, 'leaderboard')
         if cached_data:
             self.logger.info(f"Using cached leaderboard data for {league_key}")
-            return cached_data.get('standings', [])
-        
-        # Special handling for college football - use rankings endpoint
-        if league_key == 'college-football':
-            return self._fetch_ncaa_fb_rankings(league_config)
+            standings = cached_data.get('standings', [])
+        elif league_key == 'college-football':
+            standings = self._fetch_ncaa_fb_rankings(league_config)
+        elif league_key == 'mens-college-hockey':
+            standings = self._fetch_ncaam_hockey_rankings(league_config)
+        elif league_key in ['mens-college-basketball', 'womens-college-basketball']:
+            standings = self._fetch_ncaa_basketball_rankings(league_config)
+        elif league_key in ['nfl', 'mlb', 'nhl', 'college-baseball']:
+            standings = self._fetch_standings_data(league_config)
+        else:
+            standings = self._fetch_teams_data(league_config)
 
-        # Special handling for mens-college-hockey - use rankings endpoint
-        if league_key == 'mens-college-hockey':
-            return self._fetch_ncaam_hockey_rankings(league_config)
-
-        # Special handling for college basketball - use rankings endpoint
-        # ESPN college basketball API requires numeric team IDs, not abbreviations
-        if league_key in ['mens-college-basketball', 'womens-college-basketball']:
-            return self._fetch_ncaa_basketball_rankings(league_config)
-
-        # Use standings endpoint for NFL, MLB, NHL, and NCAA Baseball
-        if league_key in ['nfl', 'mlb', 'nhl', 'college-baseball']:
-            return self._fetch_standings_data(league_config)
-
-        # For NBA and other leagues, use teams endpoint
-        return self._fetch_teams_data(league_config)
+        # Apply top_teams limit centrally so config changes take effect immediately
+        top_teams = league_config.get('top_teams', 10)
+        return standings[:top_teams]
     
     def _fetch_ncaa_fb_rankings(self, league_config: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Fetch NCAA Football rankings from ESPN API using the rankings endpoint."""
@@ -151,24 +145,22 @@ class DataFetcher:
                     'ranking_name': ranking_name
                 })
             
-            top_teams = standings[:league_config.get('top_teams', 25)]
-            
-            # Cache the results
+            # Cache the full results (top_teams slicing is applied in fetch_standings)
             cache_data = {
-                'standings': top_teams,
+                'standings': standings,
                 'timestamp': time.time(),
                 'league': league_key,
                 'ranking_name': ranking_name
             }
             self.cache_manager.save_cache(cache_key, cache_data)
-            
-            self.logger.info(f"Fetched and cached {len(top_teams)} teams for {league_key}")
-            return top_teams
-            
+
+            self.logger.info(f"Fetched and cached {len(standings)} teams for {league_key}")
+            return standings
+
         except Exception as e:
             self.logger.error(f"Error fetching rankings for {league_key}: {e}")
             return []
-    
+
     def _fetch_ncaam_hockey_rankings(self, league_config: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Fetch NCAA Men's Hockey rankings from ESPN API."""
         league_key = league_config['league']
@@ -225,19 +217,18 @@ class DataFetcher:
                     'ranking_name': ranking_name
                 })
             
-            top_teams = standings[:league_config.get('top_teams', 25)]
-            
+            # Cache the full results (top_teams slicing is applied in fetch_standings)
             cache_data = {
-                'standings': top_teams,
+                'standings': standings,
                 'timestamp': time.time(),
                 'league': league_key,
                 'ranking_name': ranking_name
             }
             self.cache_manager.save_cache(cache_key, cache_data)
-            
-            self.logger.info(f"Fetched and cached {len(top_teams)} teams for {league_key}")
-            return top_teams
-            
+
+            self.logger.info(f"Fetched and cached {len(standings)} teams for {league_key}")
+            return standings
+
         except Exception as e:
             self.logger.error(f"Error fetching rankings for {league_key}: {e}")
             return []
@@ -316,18 +307,17 @@ class DataFetcher:
                     'ranking_name': ranking_name
                 })
 
-            top_teams = standings[:league_config.get('top_teams', 25)]
-
+            # Cache the full results (top_teams slicing is applied in fetch_standings)
             cache_data = {
-                'standings': top_teams,
+                'standings': standings,
                 'timestamp': time.time(),
                 'league': league_key,
                 'ranking_name': ranking_name
             }
             self.cache_manager.save_cache(cache_key, cache_data)
 
-            self.logger.info(f"Fetched and cached {len(top_teams)} teams for {league_key}")
-            return top_teams
+            self.logger.info(f"Fetched and cached {len(standings)} teams for {league_key}")
+            return standings
 
         except Exception as e:
             self.logger.error(f"Error fetching rankings for {league_key}: {e}")
@@ -413,10 +403,9 @@ class DataFetcher:
             else:
                 self.logger.debug(f"Trusting API sort order for {len(standings)} teams")
             
-            top_teams = standings[:league_config.get('top_teams', 10)]
-            
+            # Cache the full results (top_teams slicing is applied in fetch_standings)
             cache_data = {
-                'standings': top_teams,
+                'standings': standings,
                 'timestamp': time.time(),
                 'league': league_key,
                 'level': params['level']
@@ -425,9 +414,9 @@ class DataFetcher:
             if 'season' in params:
                 cache_data['season'] = params['season']
             self.cache_manager.save_cache(cache_key, cache_data)
-            
-            self.logger.info(f"Fetched and cached {len(top_teams)} teams for {league_key} (from {len(standings)} total standings)")
-            return top_teams
+
+            self.logger.info(f"Fetched and cached {len(standings)} teams for {league_key}")
+            return standings
             
         except Exception as e:
             self.logger.error(f"Error fetching standings for {league_key}: {e}")
@@ -484,17 +473,17 @@ class DataFetcher:
                     })
             
             standings.sort(key=lambda x: x['win_percentage'], reverse=True)
-            top_teams = standings[:league_config.get('top_teams', 10)]
-            
+
+            # Cache the full results (top_teams slicing is applied in fetch_standings)
             cache_data = {
-                'standings': top_teams,
+                'standings': standings,
                 'timestamp': time.time(),
                 'league': league_key
             }
             self.cache_manager.save_cache(cache_key, cache_data)
-            
-            self.logger.info(f"Fetched and cached {len(top_teams)} teams for {league_config['league']}")
-            return top_teams
+
+            self.logger.info(f"Fetched and cached {len(standings)} teams for {league_config['league']}")
+            return standings
             
         except Exception as e:
             self.logger.error(f"Error fetching standings for {league_config['league']}: {e}")

--- a/plugins/ledmatrix-leaderboard/manager.py
+++ b/plugins/ledmatrix-leaderboard/manager.py
@@ -81,7 +81,9 @@ class LeaderboardPlugin(BasePlugin):
         self.max_duration = self.dynamic_duration_settings['max_duration_seconds']
         self.duration_buffer = self.dynamic_duration_settings['buffer_ratio']
         self.dynamic_duration_cap = self.dynamic_duration_settings['controller_cap_seconds']
-        self.loop = bool(self.global_config.get('loop', True))
+        # Determine loop behavior: scroll_mode takes precedence, then loop boolean
+        scroll_mode = self.global_config.get('scroll_mode', 'one_shot')
+        self.loop = scroll_mode == 'continuous' or bool(self.global_config.get('loop', False))
         
         # Request timeout
         self.request_timeout = self.global_config.get('request_timeout', 30)
@@ -168,6 +170,7 @@ class LeaderboardPlugin(BasePlugin):
             else:
                 pixels_per_second = self.scroll_speed / self.scroll_delay if self.scroll_delay > 0 else self.scroll_speed * 100
                 self.logger.info(f"Scroll speed: {pixels_per_second:.1f} px/s")
+        self.logger.info(f"Scroll mode: {'continuous' if self.loop else 'one_shot'}")
         self.logger.info(
             "Dynamic duration settings: enabled=%s, min=%ss, max=%ss, buffer=%.2f, controller_cap=%ss",
             self.dynamic_duration_enabled,
@@ -289,10 +292,18 @@ class LeaderboardPlugin(BasePlugin):
         # Signal scrolling state
         self.display_manager.set_scrolling_state(True)
         self.display_manager.process_deferred_updates()
-        
+
+        # In one-shot mode, stop scrolling once the cycle is complete
+        if not self.loop and self._cycle_complete:
+            visible_portion = self.scroll_helper.get_visible_portion()
+            if visible_portion:
+                self.display_manager.image.paste(visible_portion, (0, 0))
+                self.display_manager.update_display()
+            return
+
         # Update scroll position using the scroll helper
         self.scroll_helper.update_scroll_position()
-        if self.dynamic_duration_enabled and self.scroll_helper.is_scroll_complete():
+        if self.scroll_helper.is_scroll_complete():
             if not self._cycle_complete:
                 scroll_info = self.scroll_helper.get_scroll_info()
                 elapsed_time = scroll_info.get('elapsed_time')
@@ -478,6 +489,10 @@ class LeaderboardPlugin(BasePlugin):
         """Report whether the scrolling cycle has completed at least once."""
         if not self.dynamic_duration_enabled:
             return True
+        # In continuous loop mode, never report completion so the display
+        # controller keeps this plugin active until its duration expires
+        if self.loop:
+            return False
         return self._cycle_complete
     
     def get_cycle_duration(self, display_mode: str = None) -> Optional[float]:

--- a/plugins/ledmatrix-leaderboard/manifest.json
+++ b/plugins/ledmatrix-leaderboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-leaderboard",
   "name": "Sports Leaderboard",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Displays scrolling leaderboards and standings for multiple sports leagues including NFL, NBA, MLB, NCAA Football, NCAA Basketball, and more",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -32,6 +32,11 @@
   "min_ledmatrix_version": "2.0.0",
   "versions": [
     {
+      "version": "1.0.6",
+      "ledmatrix_min": "2.0.0",
+      "released": "2026-02-12"
+    },
+    {
       "version": "1.0.5",
       "ledmatrix_min": "2.0.0",
       "released": "2025-11-06"
@@ -42,5 +47,5 @@
       "released": "2025-11-06"
     }
   ],
-  "last_updated": "2025-11-06"
+  "last_updated": "2026-02-12"
 }


### PR DESCRIPTION
## Summary
- **Top teams not adjusting:** The `top_teams` slice was applied inside each fetch method *before* caching, so cached data was already truncated and config changes had no effect until cache expired. Moved the slice to `fetch_standings()` so it's applied after cache retrieval — config changes now take effect immediately.
- **One-shot mode not working:** `scroll_mode` and `loop` config values were defined in the schema but never read/used in code. The `loop` default was also `True` (contradicting schema default of `false`). Now both settings are read, wired into `display()` (stops scrolling after one pass in one-shot mode), and `is_cycle_complete()` (returns `False` in continuous mode so the display controller keeps the plugin active).

## Test plan
- [ ] Set a league's `top_teams` to 5, restart plugin, verify only 5 teams scroll
- [ ] Change `top_teams` to 10, restart, verify 10 teams now scroll
- [ ] Set `global.scroll_mode` to `"one_shot"` — verify leaderboard scrolls once then stops
- [ ] Set `global.scroll_mode` to `"continuous"` — verify leaderboard loops continuously
- [ ] Check init logs for `Scroll mode: one_shot` / `Scroll mode: continuous`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable scroll mode setting allowing users to choose between continuous scrolling or one-shot display modes. Default scroll behavior switched to one-shot for improved control and consistency.

* **Chores**
  * Version updated to 1.0.6 with revised system requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->