### PR TITLE
fix(leaderboard): fix top_teams config and one-shot scroll mode

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-02-11",
+  "last_updated": "2026-02-12",
   "plugins": [
     {
       "id": "hello-world",
@@ -355,10 +355,10 @@
       "plugin_path": "plugins/ledmatrix-leaderboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2025-11-06",
+      "last_updated": "2026-02-12",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.5"
+      "latest_version": "1.0.6"
     },
     {
       "id": "news",

--- a/plugins/ledmatrix-leaderboard/manifest.json
+++ b/plugins/ledmatrix-leaderboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-leaderboard",
   "name": "Sports Leaderboard",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Displays scrolling leaderboards and standings for multiple sports leagues including NFL, NBA, MLB, NCAA Football, NCAA Basketball, and more",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -32,6 +32,11 @@
   "min_ledmatrix_version": "2.0.0",
   "versions": [
     {
+      "version": "1.0.6",
+      "ledmatrix_min": "2.0.0",
+      "released": "2026-02-12"
+    },
+    {
       "version": "1.0.5",
       "ledmatrix_min": "2.0.0",
       "released": "2025-11-06"
@@ -42,5 +47,5 @@
       "released": "2025-11-06"
     }
   ],
-  "last_updated": "2025-11-06"
+  "last_updated": "2026-02-12"
 }


### PR DESCRIPTION
## Summary
- **Top teams not adjusting:** The `top_teams` slice was applied inside each fetch method *before* caching, so cached data was already truncated and config changes had no effect until cache expired. Moved the slice to `fetch_standings()` so it's applied after cache retrieval — config changes now take effect immediately. Also removed a redundant top-level cache lookup that only matched the `_fetch_teams_data` cache key.
- **One-shot mode not working:** `scroll_mode` and `loop` config values were defined in the schema but never read/used in code. The `loop` default was also `True` (contradicting schema default of `false`). Now both settings are read, wired into `display()` (sets scrolling state to `False` and returns early after one pass), and `is_cycle_complete()` (returns `False` in continuous mode so the display controller keeps the plugin active).

## Test plan
- [ ] Set a league's `top_teams` to 5, restart plugin, verify only 5 teams scroll
- [ ] Change `top_teams` to 10, restart, verify 10 teams now scroll
- [ ] Set `global.scroll_mode` to `"one_shot"` — verify leaderboard scrolls once then stops
- [ ] Set `global.scroll_mode` to `"continuous"` — verify leaderboard loops continuously
- [ ] Check init logs for `Scroll mode: one_shot` / `Scroll mode: continuous`

🤖 Generated with [Claude Code](https://claude.com/claude-code)