### PR TITLE
fix(weather): diagnostics for One Call API 3.0 auth failures

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-02-12",
+  "last_updated": "2026-02-13",
   "plugins": [
     {
       "id": "hello-world",
@@ -59,10 +59,10 @@
       "repo": "https://github.com/ChuckBuilds/ledmatrix-plugins",
       "branch": "main",
       "plugin_path": "plugins/ledmatrix-weather",
-      "latest_version": "2.0.9",
+      "latest_version": "2.1.0",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2025-11-05",
+      "last_updated": "2026-02-13",
       "verified": true,
       "screenshot": ""
     },

--- a/plugins/ledmatrix-weather/CHANGELOG.md
+++ b/plugins/ledmatrix-weather/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2.1.0] - 2026-02-13
+
+### Fixed
+- **CRITICAL: "No Data Available" with valid API key**: Added specific HTTP error handling
+  for One Call API 3.0 401 Unauthorized errors with actionable log messages guiding users
+  to subscribe to One Call 3.0
+- **Wind direction always showing "N"**: Fixed missing `wind_deg` field in weather data
+  storage; wind direction is now correctly read from the API response
+- **Geocoding failure causes infinite retry loop**: Empty geocoding results now set
+  `last_update` to prevent burning API calls on unresolvable locations
+
+### Improved
+- Diagnostic "no data" display now shows *why* there's no data (no API key, API
+  subscription error, unknown location) instead of generic "No Weather Data"
+- Updated config schema and README to clearly state the One Call API 3.0 subscription
+  requirement
+
 ## [2.0.9] - 2025-11-05
 
 ### Fixed

--- a/plugins/ledmatrix-weather/README.md
+++ b/plugins/ledmatrix-weather/README.md
@@ -49,11 +49,16 @@ Daily Forecast:
 
 ### API Key
 
-Get a free 1000 Daily API Calls on their pay as you go plan (requires CC but won't charge) via their One Call API Key from [OpenWeatherMap](https://openweathermap.org/api):
-1. Sign up for an account
-2. Navigate to API Keys section
-3. Generate a new API key
-4. Add it to your plugin configuration
+This plugin requires a **One Call API 3.0** subscription from [OpenWeatherMap](https://openweathermap.org/api) (free tier: 1,000 calls/day):
+
+1. Sign up for an account at https://openweathermap.org
+2. Navigate to API Keys section and generate a new API key
+3. **Subscribe to One Call API 3.0** — this is a separate step from getting an API key:
+   - Go to https://openweathermap.org/api
+   - Find "One Call API 3.0" and click Subscribe
+   - The free tier requires adding payment info but will not charge you
+   - A standard API key alone will **not** work; you must subscribe to One Call 3.0
+4. Add the API key to your plugin configuration
 
 
 ### Configuration Options
@@ -83,11 +88,13 @@ The plugin automatically rotates through enabled display modes based on the `dis
 
 ## Troubleshooting
 
-**No weather data displayed:**
-- Check that your API key is valid
+**No weather data displayed / "No Data" on screen:**
+- **Most common cause**: Your API key is not subscribed to One Call API 3.0
+  - Check logs for "401 Unauthorized" errors
+  - Subscribe at https://openweathermap.org/api -> One Call API 3.0 -> Subscribe
+- Verify your API key is correct
 - Verify internet connection
-- Check logs for API errors
-- Ensure location is spelled correctly
+- Ensure location is spelled correctly (city name must match OpenWeatherMap's geocoding)
 
 **Slow updates:**
 - API has rate limits, respect the minimum update interval

--- a/plugins/ledmatrix-weather/config_schema.json
+++ b/plugins/ledmatrix-weather/config_schema.json
@@ -25,7 +25,7 @@
     "api_key": {
       "type": "string",
       "default": "YOUR_OPENWEATHERMAP_API_KEY",
-      "description": "OpenWeatherMap API key (required - get one at https://openweathermap.org/api). Store in config_secrets.json for security.",
+      "description": "OpenWeatherMap API key (required). Must be subscribed to One Call API 3.0 at https://openweathermap.org/api (free tier available, requires payment info). Store in config_secrets.json for security.",
       "title": "API Key",
       "x-secret": true
     },

--- a/plugins/ledmatrix-weather/manifest.json
+++ b/plugins/ledmatrix-weather/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-weather",
   "name": "Weather Display",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "author": "ChuckBuilds",
   "class_name": "WeatherPlugin",
   "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, UV index, wind direction, and weather icons. Features state caching, API counter tracking, and error handling. Powered by OpenWeatherMap API with beautiful weather icons.",
@@ -24,6 +24,11 @@
   ],
   "versions": [
     {
+      "version": "2.1.0",
+      "ledmatrix_min": "2.0.0",
+      "released": "2026-02-13"
+    },
+    {
       "version": "2.0.9",
       "ledmatrix_min": "2.0.0",
       "released": "2025-11-05"
@@ -44,7 +49,7 @@
       "ledmatrix_min": "2.0.0"
     }
   ],
-  "last_updated": "2025-11-05",
+  "last_updated": "2026-02-13",
   "stars": 0,
   "downloads": 0,
   "verified": true,


### PR DESCRIPTION
## Summary
- **Root cause of "No Data Available" reports**: The weather plugin uses One Call API 3.0 (`/data/3.0/onecall`) which requires a separate subscription. Users with a standard OWM API key get `401 Unauthorized` but the error was caught generically with no guidance
- Added targeted HTTP error handling with actionable log messages for 401 (subscription needed), 429 (rate limit), and other HTTP errors
- LED display now shows *why* there's no data: "No API Key", "Subscribe to One Call 3.0", "Unknown: city, state", etc.
- Fixed wind direction always showing "N" — `wind_deg` was never stored from the API response
- Fixed geocoding empty result causing infinite retry loop (now respects `update_interval`)
- Updated README and config schema to clearly document the One Call 3.0 subscription requirement

## Test plan
- [ ] Test with no API key configured — display should show "Weather: / No API Key"
- [ ] Test with a standard OWM key (not subscribed to 3.0) — display should show "Subscribe to One Call 3.0", logs should have actionable URL
- [ ] Test with valid 3.0-subscribed key — weather should display normally with correct wind direction
- [ ] Test with misspelled city — display should show location error hint, should not retry every cycle
- [ ] Verify `plugins.json` registry was updated (pre-commit hook handled this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wind direction display to read from API correctly
  * Added specific error handling for API subscription issues with actionable guidance
  * Improved handling of unresolvable locations to prevent unnecessary API calls
  * Enhanced diagnostic messages to show specific error causes (missing key, subscription error, unknown location)

* **Documentation**
  * Updated setup instructions to clarify One Call API 3.0 subscription requirements
  * Expanded troubleshooting guide with verification steps and free tier limitations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->