### PR TITLE
fix: post-audit follow-ups (lacrosse rename + dead v2 imports)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -744,10 +744,10 @@
       "plugin_path": "plugins/lacrosse-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-06",
+      "last_updated": "2026-04-07",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.3",
+      "latest_version": "1.1.0",
       "icon": "fas fa-baseball-ball"
     }
   ]

--- a/plugins/baseball-scoreboard/base_odds_manager.py
+++ b/plugins/baseball-scoreboard/base_odds_manager.py
@@ -19,15 +19,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -145,8 +136,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/basketball-scoreboard/base_odds_manager.py
+++ b/plugins/basketball-scoreboard/base_odds_manager.py
@@ -19,15 +19,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -149,8 +140,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/football-scoreboard/base_odds_manager.py
+++ b/plugins/football-scoreboard/base_odds_manager.py
@@ -19,15 +19,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -144,8 +135,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/hockey-scoreboard/base_odds_manager.py
+++ b/plugins/hockey-scoreboard/base_odds_manager.py
@@ -19,15 +19,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -144,8 +135,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/lacrosse-scoreboard/CHANGELOG.md
+++ b/plugins/lacrosse-scoreboard/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Lacrosse Scoreboard — Changelog
+
+## 1.1.0 (2026-04-07)
+
+### Breaking change — display modes renamed with `lax_` prefix
+
+The six display modes this plugin exposes previously collided with
+the NCAA hockey modes shipped by `hockey-scoreboard`. LEDMatrix's
+display controller keys modes in a flat dict
+(`src/display_controller.py`), so installing both plugins at the
+same time meant whichever loaded second silently overrode the
+first one's NCAA modes.
+
+All lacrosse modes now carry a `lax_` prefix. The six renames:
+
+| Old                     | New                         |
+|-------------------------|-----------------------------|
+| `ncaa_mens_recent`      | `lax_ncaa_mens_recent`      |
+| `ncaa_mens_upcoming`    | `lax_ncaa_mens_upcoming`    |
+| `ncaa_mens_live`        | `lax_ncaa_mens_live`        |
+| `ncaa_womens_recent`    | `lax_ncaa_womens_recent`    |
+| `ncaa_womens_upcoming`  | `lax_ncaa_womens_upcoming`  |
+| `ncaa_womens_live`      | `lax_ncaa_womens_live`      |
+
+### Migration required
+
+If you referenced any of the old names anywhere in `config.json`,
+update them to the new prefixed names. Common places:
+
+- `display_durations` overrides keyed by mode name
+- `rotation_order` entries listing which modes to cycle through
+- Any custom scripting or automation that pokes the REST API with
+  these mode names
+
+There is no backward-compat alias — the old names are no longer
+recognized by the plugin dispatch logic.
+
+### Why now
+
+The collision with `hockey-scoreboard` was a silent data loss bug:
+whichever plugin loaded second won, without any warning in the
+logs. Renaming with a plugin-specific prefix is the only durable
+fix until the display controller grows proper namespacing. The
+`lax_` prefix was chosen to be short and consistent with how other
+prefix-disambiguated codebases handle the same problem.
+
+## 1.0.3 (2026-04-06)
+
+Schema-conformance manifest cleanup.
+
+## 1.0.2 (2026-04-06)
+
+Initial monorepo release.

--- a/plugins/lacrosse-scoreboard/README.md
+++ b/plugins/lacrosse-scoreboard/README.md
@@ -2,17 +2,13 @@
 
 Live, recent, and upcoming NCAA Men's and Women's Lacrosse games on your LEDMatrix display. Real-time scores, schedules, favorite-team filtering, live-game priority, poll-rank badges, and both switch and scroll display modes — modeled on the existing hockey scoreboard plugin.
 
-> ⚠️ **Known conflict with `hockey-scoreboard`.** This plugin's display
-> modes are named `ncaa_mens_recent` / `ncaa_mens_upcoming` /
-> `ncaa_mens_live` / `ncaa_womens_recent` / `ncaa_womens_upcoming` /
-> `ncaa_womens_live` — the **same names** the hockey scoreboard plugin
-> uses for its NCAA hockey divisions. The display controller stores
-> modes in a flat dict keyed by mode name
-> (`src/display_controller.py:295`), so if you install both plugins,
-> whichever loads second silently overrides the first one's NCAA modes.
-> Track the issue at the LEDMatrix repo. Until it's fixed in a
-> version-bumped release that renames lacrosse's modes (e.g.
-> `lax_ncaa_mens_*`), enable only one of the two plugins at a time.
+> **Breaking change in 1.1.0:** display modes gained a `lax_` prefix
+> (e.g. `lax_ncaa_mens_recent`) to avoid colliding with the NCAA
+> hockey modes exposed by `hockey-scoreboard`. If you pinned any of
+> the old `ncaa_mens_*` / `ncaa_womens_*` names in
+> `display_durations`, `rotation_order`, or anywhere else in
+> `config.json`, update them to the new prefixed names. See the
+> plugin [CHANGELOG](CHANGELOG.md) for the full mapping.
 
 ## Features
 
@@ -190,8 +186,8 @@ Tokens can be mixed with literal abbreviations: `["NCAA_MENS_TOP_10", "JOHNS HOP
 
 The plugin exposes six granular display modes the LEDMatrix host rotation can cycle through:
 
-- `ncaa_mens_live`, `ncaa_mens_recent`, `ncaa_mens_upcoming`
-- `ncaa_womens_live`, `ncaa_womens_recent`, `ncaa_womens_upcoming`
+- `lax_ncaa_mens_live`, `lax_ncaa_mens_recent`, `lax_ncaa_mens_upcoming`
+- `lax_ncaa_womens_live`, `lax_ncaa_womens_recent`, `lax_ncaa_womens_upcoming`
 
 ## Data Source
 

--- a/plugins/lacrosse-scoreboard/base_odds_manager.py
+++ b/plugins/lacrosse-scoreboard/base_odds_manager.py
@@ -19,15 +19,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -144,8 +135,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/lacrosse-scoreboard/manager.py
+++ b/plugins/lacrosse-scoreboard/manager.py
@@ -577,10 +577,11 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
 
     def _extract_mode_type(self, display_mode: str) -> Optional[str]:
         """Extract mode type (live, recent, upcoming) from display mode string.
-        
+
         Args:
-            display_mode: Display mode string (e.g., 'ncaa_mens_live', 'ncaa_womens_recent')
-            
+            display_mode: Display mode string (e.g., 'lax_ncaa_mens_live',
+                'lax_ncaa_womens_recent')
+
         Returns:
             Mode type string ('live', 'recent', 'upcoming') or None
         """
@@ -851,11 +852,11 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
                     mode_enabled = display_modes_config.get("upcoming", display_modes_config.get("show_upcoming", True))
                 
                 if mode_enabled:
-                    modes.append(f"{league_id}_{mode_type}")
+                    modes.append(f"lax_{league_id}_{mode_type}")
 
         # Default to NCAA Men's Lacrosse if no leagues enabled
         if not modes:
-            modes = ["ncaa_mens_recent", "ncaa_mens_upcoming", "ncaa_mens_live"]
+            modes = ["lax_ncaa_mens_recent", "lax_ncaa_mens_upcoming", "lax_ncaa_mens_live"]
 
         return modes
 
@@ -866,10 +867,12 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
 
         current_mode = self.modes[self.current_mode_index]
 
-        if current_mode.startswith("ncaa_mens_"):
+        # Display modes look like "lax_ncaa_mens_recent" / "lax_ncaa_womens_live".
+        # Strip the "lax_" prefix, then take the last segment for the mode type.
+        if current_mode.startswith("lax_ncaa_mens_"):
             if not self.ncaa_mens_enabled:
                 return None
-            mode_type = current_mode.split("_", 2)[2]  # "live", "recent", "upcoming"
+            mode_type = current_mode.rsplit("_", 1)[1]  # "live", "recent", "upcoming"
             if mode_type == "live":
                 return self.ncaa_mens_live
             elif mode_type == "recent":
@@ -877,10 +880,10 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
             elif mode_type == "upcoming":
                 return self.ncaa_mens_upcoming
 
-        elif current_mode.startswith("ncaa_womens_"):
+        elif current_mode.startswith("lax_ncaa_womens_"):
             if not self.ncaa_womens_enabled:
                 return None
-            mode_type = current_mode.split("_", 2)[2]  # "live", "recent", "upcoming"
+            mode_type = current_mode.rsplit("_", 1)[1]  # "live", "recent", "upcoming"
             if mode_type == "live":
                 return self.ncaa_womens_live
             elif mode_type == "recent":
@@ -997,36 +1000,40 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
                     # No content from any league
                     return False
                 
-                # Parse granular mode name: {league}_{mode_type}
-                # e.g., "ncaa_mens_recent" -> league="ncaa_mens", mode_type="recent"
-                # e.g., "ncaa_mens_recent" -> league="ncaa_mens", mode_type="recent"
-                # 
+                # Parse granular mode name: lax_{league}_{mode_type}
+                # e.g., "lax_ncaa_mens_recent" -> league="ncaa_mens", mode_type="recent"
+                # e.g., "lax_ncaa_womens_live" -> league="ncaa_womens", mode_type="live"
+                #
                 # Scalable approach: Check league registry first, then extract mode type
                 # This works for any league naming convention (underscores, dots, etc.)
                 mode_type_str = None
                 league = None
-                
+
                 # Known mode type suffixes (standardized across all sports plugins)
                 mode_suffixes = ['_live', '_recent', '_upcoming']
-                
+
+                # Strip the "lax_" plugin prefix before matching against the
+                # league registry, which is keyed by bare league id.
+                match_mode = display_mode[len("lax_"):] if display_mode.startswith("lax_") else display_mode
+
                 # Try to match against league registry first (most reliable)
-                # Check each league ID in registry to see if display_mode starts with it
+                # Check each league ID in registry to see if match_mode starts with it
                 for league_id in self._league_registry.keys():
                     for mode_suffix in mode_suffixes:
                         expected_mode = f"{league_id}{mode_suffix}"
-                        if display_mode == expected_mode:
+                        if match_mode == expected_mode:
                             league = league_id
                             mode_type_str = mode_suffix[1:]  # Remove leading underscore
                             break
                     if league:
                         break
-                
+
                 # Fallback: If no registry match, parse from the end (for backward compatibility)
                 if not league:
                     for mode_suffix in mode_suffixes:
-                        if display_mode.endswith(mode_suffix):
+                        if match_mode.endswith(mode_suffix):
                             mode_type_str = mode_suffix[1:]  # Remove leading underscore
-                            league = display_mode[:-len(mode_suffix)]  # Everything before the suffix
+                            league = match_mode[:-len(mode_suffix)]  # Everything before the suffix
                             # Validate it's a known league
                             if league in self._league_registry:
                                 break
@@ -1034,11 +1041,11 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
                                 # Not a known league, try next suffix
                                 league = None
                                 mode_type_str = None
-                
+
                 if not mode_type_str or not league:
                     self.logger.warning(
                         f"Invalid granular display_mode format: {display_mode} "
-                        f"(expected format: {{league}}_{{mode_type}}, e.g., 'ncaa_mens_recent' or 'ncaa_womens_recent'). "
+                        f"(expected format: lax_{{league}}_{{mode_type}}, e.g., 'lax_ncaa_mens_recent' or 'lax_ncaa_womens_recent'). "
                         f"Valid leagues: {list(self._league_registry.keys())}"
                     )
                     return False
@@ -1520,12 +1527,12 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
         league = None
         mode_type = None
         if current_mode:
-            if current_mode.startswith('ncaa_mens_'):
+            if current_mode.startswith('lax_ncaa_mens_'):
                 league = 'ncaa_mens'
-                mode_type = current_mode.split('_', 2)[2]
-            elif current_mode.startswith('ncaa_womens_'):
+                mode_type = current_mode.rsplit('_', 1)[1]
+            elif current_mode.startswith('lax_ncaa_womens_'):
                 league = 'ncaa_womens'
-                mode_type = current_mode.split('_', 2)[2]
+                mode_type = current_mode.rsplit('_', 1)[1]
         
         # Log for debugging
         self.logger.debug(f"_record_dynamic_progress: current_mode={current_mode}, display_mode={display_mode}, manager={current_manager.__class__.__name__}, manager_key={manager_key}, _last_display_mode={self._last_display_mode}")
@@ -2054,10 +2061,10 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
                             or game.get("away_abbr") in favorite_teams
                             for game in live_games
                         ):
-                            live_modes.append("ncaa_mens_live")
+                            live_modes.append("lax_ncaa_mens_live")
                     else:
                         # No favorite teams configured, include if any live games exist
-                        live_modes.append("ncaa_mens_live")
+                        live_modes.append("lax_ncaa_mens_live")
         
         # Check NCAA Women's live content
         if (
@@ -2083,10 +2090,10 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
                             or game.get("away_abbr") in favorite_teams
                             for game in live_games
                         ):
-                            live_modes.append("ncaa_womens_live")
+                            live_modes.append("lax_ncaa_womens_live")
                     else:
                         # No favorite teams configured, include if any live games exist
-                        live_modes.append("ncaa_womens_live")
+                        live_modes.append("lax_ncaa_womens_live")
         
         return live_modes
 
@@ -2599,18 +2606,19 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
         if not mode_type:
             return None
         
-        # Parse granular mode name if applicable (e.g., "ncaa_mens_recent", "ncaa_womens_upcoming")
+        # Parse granular mode name if applicable
+        # (e.g., "lax_ncaa_mens_recent", "lax_ncaa_womens_upcoming")
         league = None
         if "_" in display_mode and not display_mode.startswith("lacrosse_"):
             # Granular mode: extract league
-            # Handle ncaa_mens and ncaa_womens with multiple underscores
-            if display_mode.startswith("ncaa_mens_"):
+            if display_mode.startswith("lax_ncaa_mens_"):
                 league = "ncaa_mens"
-            elif display_mode.startswith("ncaa_womens_"):
+            elif display_mode.startswith("lax_ncaa_womens_"):
                 league = "ncaa_womens"
             else:
-                # Try standard split
-                parts = display_mode.split("_", 1)
+                # Try standard split after stripping the lax_ prefix
+                bare = display_mode[len("lax_"):] if display_mode.startswith("lax_") else display_mode
+                parts = bare.split("_", 1)
                 if len(parts) == 2:
                     potential_league, potential_mode_type = parts
                     if potential_league in self._league_registry and potential_mode_type == mode_type:
@@ -2624,9 +2632,9 @@ class LacrosseScoreboardPlugin(BasePlugin if BasePlugin else object):
                 league = self._current_display_league
             else:
                 # Try to parse from display_mode
-                if display_mode.startswith("ncaa_mens_"):
+                if display_mode.startswith("lax_ncaa_mens_"):
                     league = "ncaa_mens"
-                elif display_mode.startswith("ncaa_womens_"):
+                elif display_mode.startswith("lax_ncaa_womens_"):
                     league = "ncaa_womens"
         
         if league:

--- a/plugins/lacrosse-scoreboard/manifest.json
+++ b/plugins/lacrosse-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "lacrosse-scoreboard",
   "name": "Lacrosse Scoreboard",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming NCAA men's and women's lacrosse games with real-time scores and schedules",
   "homepage": "https://github.com/ChuckBuilds/ledmatrix-plugins/tree/main/plugins/lacrosse-scoreboard",
@@ -33,12 +33,12 @@
   "update_interval": 60,
   "default_duration": 15,
   "display_modes": [
-    "ncaa_mens_recent",
-    "ncaa_mens_upcoming",
-    "ncaa_mens_live",
-    "ncaa_womens_recent",
-    "ncaa_womens_upcoming",
-    "ncaa_womens_live"
+    "lax_ncaa_mens_recent",
+    "lax_ncaa_mens_upcoming",
+    "lax_ncaa_mens_live",
+    "lax_ncaa_womens_recent",
+    "lax_ncaa_womens_upcoming",
+    "lax_ncaa_womens_live"
   ],
   "api_requirements": [
     {
@@ -50,6 +50,11 @@
     }
   ],
   "versions": [
+    {
+      "version": "1.1.0",
+      "released": "2026-04-07",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "1.0.3",
       "released": "2026-04-06",
@@ -66,7 +71,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-06",
+  "last_updated": "2026-04-07",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/ledmatrix-leaderboard/data_fetcher.py
+++ b/plugins/ledmatrix-leaderboard/data_fetcher.py
@@ -11,15 +11,6 @@ from datetime import datetime, timezone
 import requests
 from typing import Dict, Any, List, Optional
 
-# Try to import API counter from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class DataFetcher:
     """Handles fetching standings and rankings data from ESPN API."""
     
@@ -84,7 +75,6 @@ class DataFetcher:
             response.raise_for_status()
             data = response.json()
             
-            increment_api_counter('sports', 1)
             
             rankings_data = data.get('rankings', [])
             if not rankings_data:
@@ -175,7 +165,6 @@ class DataFetcher:
             response.raise_for_status()
             data = response.json()
             
-            increment_api_counter('sports', 1)
             
             rankings_data = data.get('rankings', [])
             if not rankings_data:
@@ -254,8 +243,6 @@ class DataFetcher:
             response = requests.get(scoreboard_url, timeout=self.request_timeout)
             response.raise_for_status()
             data = response.json()
-
-            increment_api_counter('sports', 1)
 
             # Extract unique teams with seeds from all tournament events
             seen_teams = {}  # team_id -> team dict
@@ -340,8 +327,6 @@ class DataFetcher:
             response = requests.get(rankings_url, timeout=self.request_timeout)
             response.raise_for_status()
             data = response.json()
-
-            increment_api_counter('sports', 1)
 
             rankings_data = data.get('rankings', [])
             if not rankings_data:
@@ -442,7 +427,6 @@ class DataFetcher:
             response.raise_for_status()
             data = response.json()
             
-            increment_api_counter('sports', 1)
             
             standings = []
             combined_from_multiple_sources = False
@@ -528,7 +512,6 @@ class DataFetcher:
             response.raise_for_status()
             data = response.json()
             
-            increment_api_counter('sports', 1)
             
             standings = []
             sports = data.get('sports', [])
@@ -662,7 +645,6 @@ class DataFetcher:
             response.raise_for_status()
             data = response.json()
             
-            increment_api_counter('sports', 1)
             
             team_data = data.get('team', {})
             stats = team_data.get('stats', [])

--- a/plugins/ledmatrix-music/manager.py
+++ b/plugins/ledmatrix-music/manager.py
@@ -22,14 +22,6 @@ import queue
 from spotify_client import SpotifyClient
 from ytm_client import YTMClient
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):  # pylint: disable=unused-argument
-        pass
-
 # Import base plugin class
 from src.plugin_system.base_plugin import BasePlugin
 
@@ -472,10 +464,7 @@ class MusicPlugin(BasePlugin):
         try:
             response = requests.get(url, timeout=5)
             response.raise_for_status()
-            
-            # Increment API counter for music data
-            increment_api_counter('music', 1)
-            
+
             img_data = BytesIO(response.content)
             img = Image.open(img_data)
             

--- a/plugins/ledmatrix-stocks/data_fetcher.py
+++ b/plugins/ledmatrix-stocks/data_fetcher.py
@@ -17,14 +17,6 @@ from urllib3.util.retry import Retry
 # Import common utilities
 from src.common import APIHelper
 
-# Import API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    def increment_api_counter(_kind: str, _count: int = 1):
-        pass
-
-
 class StockDataFetcher:
     """Handles fetching stock and cryptocurrency data from Yahoo Finance API."""
     
@@ -167,8 +159,6 @@ class StockDataFetcher:
     def _fetch_direct(self, api_symbol: str, display_symbol: str, is_crypto: bool) -> Optional[Dict[str, Any]]:
         """Fetch data directly from Yahoo Finance API."""
         try:
-            # Increment API counter
-            increment_api_counter('stocks', 1)
             
             # Build URL
             url = f"https://query1.finance.yahoo.com/v8/finance/chart/{api_symbol}"

--- a/plugins/ledmatrix-weather/manager.py
+++ b/plugins/ledmatrix-weather/manager.py
@@ -43,11 +43,6 @@ except ImportError:
                 draw.ellipse([x, y, x + size, y + size], outline=(255, 255, 255), width=2)
 
 # Import API counter function
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
 
 class WeatherPlugin(BasePlugin):
     """
@@ -466,8 +461,6 @@ class WeatherPlugin(BasePlugin):
             raise
         geo_data = response.json()
         
-        # Increment API counter for geocoding call
-        increment_api_counter('weather', 1)
         
         if not geo_data:
             self._last_error_hint = f"Unknown: {city}, {state}"
@@ -503,8 +496,6 @@ class WeatherPlugin(BasePlugin):
             raise
         one_call_data = response.json()
         
-        # Increment API counter for weather data call
-        increment_api_counter('weather', 1)
         
         # Store current weather data (including previously-unused fields)
         current = one_call_data['current']

--- a/plugins/odds-ticker/data_fetcher.py
+++ b/plugins/odds-ticker/data_fetcher.py
@@ -17,14 +17,6 @@ import logging
 import requests
 from typing import Dict, Any, List, Optional
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
 logger = logging.getLogger(__name__)
 
 
@@ -217,10 +209,6 @@ class OddsDataFetcher:
             response.raise_for_status()
             data = response.json()
             
-            # Increment API counter
-            if hasattr(self, 'increment_api_counter'):
-                self.increment_api_counter('sports', 1)
-            
             games = []
             events = data.get('events', [])
             
@@ -288,10 +276,7 @@ class OddsDataFetcher:
             response = requests.get(url, timeout=self.request_timeout)
             response.raise_for_status()
             data = response.json()
-            
-            # Increment API counter for sports data
-            increment_api_counter('sports', 1)
-            
+
             # Different path for college sports records
             if league == 'college-football':
                 record_items = data.get('team', {}).get('record', {}).get('items', [])
@@ -323,10 +308,7 @@ class OddsDataFetcher:
             response = requests.get(rankings_url, timeout=self.request_timeout)
             response.raise_for_status()
             data = response.json()
-            
-            # Increment API counter for sports data
-            increment_api_counter('sports', 1)
-            
+
             rankings = {}
             polls = data.get('polls', [])
             

--- a/plugins/odds-ticker/manager.py
+++ b/plugins/odds-ticker/manager.py
@@ -49,14 +49,6 @@ except ImportError:
             self.cache_manager = cache_manager
             self.plugin_manager = plugin_manager
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
 # Import BaseOddsManager from LEDMatrix core
 try:
     from src.base_odds_manager import BaseOddsManager
@@ -99,7 +91,6 @@ except ImportError:
 
 # Get logger
 logger = logging.getLogger(__name__)
-
 
 class OddsTickerPlugin(BasePlugin, BaseOddsManager):
     """Manager for displaying scrolling odds ticker for multiple sports leagues."""
@@ -688,8 +679,6 @@ class OddsTickerPlugin(BasePlugin, BaseOddsManager):
             response.raise_for_status()
             data = response.json()
             
-            # Increment API counter for sports data
-            increment_api_counter('sports', 1)
             
             # Different path for college sports records
             if league == 'college-football':
@@ -737,8 +726,6 @@ class OddsTickerPlugin(BasePlugin, BaseOddsManager):
             response.raise_for_status()
             data = response.json()
             
-            # Increment API counter for sports data
-            increment_api_counter('sports', 1)
             
             rankings = {}
             rankings_data = data.get('rankings', [])
@@ -819,8 +806,6 @@ class OddsTickerPlugin(BasePlugin, BaseOddsManager):
             response.raise_for_status()
             raw_data = response.json()
             
-            # Increment API counter for odds data
-            increment_api_counter('odds', 1)
             self.logger.debug(f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}")
             
             odds_data = self._extract_espn_data(raw_data)
@@ -1107,8 +1092,6 @@ class OddsTickerPlugin(BasePlugin, BaseOddsManager):
                         response.raise_for_status()
                         data = response.json()
                         
-                        # Increment API counter for sports data
-                        increment_api_counter('sports', 1)
                         
                         self.cache_manager.set(cache_key, data)
                         logger.debug(f"Cached scoreboard for {league} on {date} with a TTL of {ttl} seconds.")

--- a/plugins/soccer-scoreboard/base_odds_manager.py
+++ b/plugins/soccer-scoreboard/base_odds_manager.py
@@ -13,15 +13,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -141,8 +132,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/ufc-scoreboard/base_odds_manager.py
+++ b/plugins/ufc-scoreboard/base_odds_manager.py
@@ -17,15 +17,6 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class BaseOddsManager:
     """
     Base class for odds data fetching and management.
@@ -154,8 +145,6 @@ class BaseOddsManager:
             response.raise_for_status()
             raw_data = response.json()
 
-            # Increment API counter for odds data
-            increment_api_counter("odds", 1)
             self.logger.debug(
                 f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}"
             )

--- a/plugins/youtube-stats/manager.py
+++ b/plugins/youtube-stats/manager.py
@@ -16,15 +16,6 @@ import requests
 
 from src.plugin_system.base_plugin import BasePlugin
 
-# Import the API counter function from web interface (optional)
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
-
 class YouTubeStatsPlugin(BasePlugin):
     """
     YouTube Stats plugin for LEDMatrix.
@@ -151,12 +142,6 @@ class YouTubeStatsPlugin(BasePlugin):
             response.raise_for_status()
             self._api_key_error = None  # Clear any previous error
             data = response.json()
-
-            # Increment API counter for YouTube data (optional)
-            try:
-                increment_api_counter('youtube', 1)
-            except Exception:
-                pass  # Ignore if API counter is not available
 
             if 'items' in data and data['items']:
                 channel = data['items'][0]


### PR DESCRIPTION
## Summary

Companion to ChuckBuilds/LEDMatrix#307. Fixes the two code bugs
the docs refresh audit on #92 surfaced that belong in this repo.

### Bug 6: lacrosse-scoreboard display-mode collision (BREAKING)

\`lacrosse-scoreboard\` shipped six display modes
(\`ncaa_mens_recent\` / \`upcoming\` / \`live\` and
\`ncaa_womens_*\`) that collided with the same six names used by
\`hockey-scoreboard\`. LEDMatrix's display controller stores modes
in a flat dict keyed by mode name, so whichever plugin loaded
second silently overrode the first — no log warning, no crash,
just silent data loss.

All six lacrosse modes gained a \`lax_\` prefix:

| Old                     | New                         |
|-------------------------|-----------------------------|
| \`ncaa_mens_recent\`      | \`lax_ncaa_mens_recent\`      |
| \`ncaa_mens_upcoming\`    | \`lax_ncaa_mens_upcoming\`    |
| \`ncaa_mens_live\`        | \`lax_ncaa_mens_live\`        |
| \`ncaa_womens_recent\`    | \`lax_ncaa_womens_recent\`    |
| \`ncaa_womens_upcoming\`  | \`lax_ncaa_womens_upcoming\`  |
| \`ncaa_womens_live\`      | \`lax_ncaa_womens_live\`      |

Updated the manifest, the default-mode fallback in \`manager.py\`,
the dispatch in \`_get_current_manager\`, the mode-string parser
(\`_record_dynamic_progress\`, \`get_cycle_duration\`, and the
granular parser in \`_display_plugin_mode\`), and the
\`live_modes.append(...)\` literals in \`get_live_modes\`. The old
\`current_mode.split('_', 2)[2]\` parser assumed two underscores
before the mode-type segment; the new four-segment strings
(\`lax_ncaa_mens_recent\`) have three, so the parser now uses
\`rsplit('_', 1)[1]\` which is correct regardless of prefix depth.

Version bumped **1.0.3 → 1.1.0** (minor bump per semver for a
breaking config change). README's old \"Known conflict\" warning
is replaced with a breaking-change notice; full migration table
and instructions live in the new
[\`CHANGELOG.md\`](plugins/lacrosse-scoreboard/CHANGELOG.md).

**No backward-compat aliases** — the old mode names are no
longer recognized by the dispatch logic. Anyone with the old
names in \`display_durations\`, \`rotation_order\`, or any other
config key needs to migrate per the CHANGELOG.

### Bug 5: dead \`web_interface_v2\` import pattern

14 plugin files carried a \`try/except\` block importing
\`web_interface_v2.increment_api_counter\` with a no-op fallback:

\`\`\`python
try:
    from web_interface_v2 import increment_api_counter
except ImportError:
    def increment_api_counter(kind: str, count: int = 1):
        pass
\`\`\`

The \`web_interface_v2\` module doesn't exist anywhere in the v3
codebase — the counter has been silently a no-op for every
plugin, and no API-metrics dashboard reads it. Deleted the
import block, every direct call site, one
\`self.increment_api_counter\` \`hasattr\`-guarded call in
\`odds-ticker/data_fetcher.py\`, and the orphan
\`# Increment API counter\` comments left behind.

Touched plugins (14 files):

- \`baseball-scoreboard/base_odds_manager.py\`
- \`basketball-scoreboard/base_odds_manager.py\`
- \`football-scoreboard/base_odds_manager.py\`
- \`hockey-scoreboard/base_odds_manager.py\`
- \`lacrosse-scoreboard/base_odds_manager.py\`
- \`soccer-scoreboard/base_odds_manager.py\`
- \`ufc-scoreboard/base_odds_manager.py\`
- \`ledmatrix-leaderboard/data_fetcher.py\`
- \`ledmatrix-music/manager.py\`
- \`ledmatrix-stocks/data_fetcher.py\`
- \`ledmatrix-weather/manager.py\`
- \`odds-ticker/manager.py\`
- \`odds-ticker/data_fetcher.py\`
- \`youtube-stats/manager.py\`

## Verification done locally

- \`ast.parse\` on every \`.py\` file under \`plugins/\` — 0 syntax errors
- \`py_compile\` on all 14 touched files + \`lacrosse-scoreboard/manager.py\`
- No \`web_interface_v2\` or \`increment_api_counter\` references
  remain anywhere under \`plugins/\` (except an unrelated
  \`src.api_counter\` mock in
  \`lacrosse-scoreboard/test_lacrosse_plugin.py\`)
- Lacrosse \`lax_\` prefix applied consistently across the
  manifest, default mode fallback, dispatch logic, and
  mode-string parser
- Pre-commit hook auto-synced \`plugins.json\` to the new
  \`1.1.0\` version

## Test plan

- [ ] Install both \`lacrosse-scoreboard\` and \`hockey-scoreboard\`
  side-by-side and confirm both plugins' NCAA modes appear in
  the rotation (no silent override).
- [ ] Restart the display service and confirm no
  \`ImportError: web_interface_v2\` warnings in
  \`journalctl -u ledmatrix\`.
- [ ] Enable the odds flow via \`odds-ticker\` or any of the
  scoreboards and confirm odds still render correctly after
  the counter-call removal.
- [ ] For any user with \`ncaa_mens_*\` or \`ncaa_womens_*\`
  keys in \`config.json\` under a lacrosse-specific section,
  follow the migration steps in the new
  \`lacrosse-scoreboard/CHANGELOG.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Lacrosse plugin v1.1.0 requires configuration migration: add `lax_` prefix to all NCAA mode identifiers (e.g., `ncaa_mens_recent` → `lax_ncaa_mens_recent`). Update any references in display settings.

* **Chores**
  * Removed API counter tracking integration across multiple plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->