### PR TITLE
fix(masters-tournament): repoint to live ESPN endpoints, fix <1d countdown

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-04-09",
   "plugins": [
     {
       "id": "hello-world",
@@ -699,10 +699,10 @@
       "plugin_path": "plugins/masters-tournament",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-01",
+      "last_updated": "2026-04-09",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.0.0"
+      "latest_version": "2.1.0"
     },
     {
       "id": "web-ui-info",

--- a/plugins.json
+++ b/plugins.json
@@ -702,7 +702,7 @@
       "last_updated": "2026-04-09",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.1.0"
+      "latest_version": "2.1.1"
     },
     {
       "id": "web-ui-info",

--- a/plugins.json
+++ b/plugins.json
@@ -702,7 +702,7 @@
       "last_updated": "2026-04-09",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.1.1"
+      "latest_version": "2.1.2"
     },
     {
       "id": "web-ui-info",

--- a/plugins/masters-tournament/manager.py
+++ b/plugins/masters-tournament/manager.py
@@ -58,6 +58,14 @@ class MastersTournamentPlugin(BasePlugin):
         self.logo_loader = MastersLogoLoader(os.path.dirname(os.path.abspath(__file__)))
         self.data_source = MastersDataSource(cache_manager, config)
 
+        # Live tournament metadata (start/end dates, status, round).
+        # Populated from ESPN on first fetch; drives countdown + phase detection.
+        self._tournament_meta: Optional[Dict] = None
+        try:
+            self._tournament_meta = self.data_source.fetch_tournament_meta()
+        except Exception as e:
+            self.logger.warning(f"Initial tournament meta fetch failed: {e}")
+
         # Use enhanced renderer for 64x32+, base for tiny displays
         if self.display_width >= 64:
             self.renderer = MastersRendererEnhanced(
@@ -83,9 +91,10 @@ class MastersTournamentPlugin(BasePlugin):
         self._last_update = 0
         self._update_interval = config.get("update_interval", 30)
 
-        # Tournament phase
-        self._tournament_phase = get_tournament_phase()
-        self._detailed_phase = get_detailed_phase()
+        # Tournament phase — date-driven from live meta when available
+        meta_start, meta_end = self._meta_dates()
+        self._tournament_phase = get_tournament_phase(start_date=meta_start, end_date=meta_end)
+        self._detailed_phase = get_detailed_phase(start_date=meta_start, end_date=meta_end)
 
         # Build enabled modes (phase-aware)
         self.modes = self._build_enabled_modes()
@@ -211,6 +220,11 @@ class MastersTournamentPlugin(BasePlugin):
         ],
     }
 
+    def _meta_dates(self):
+        """Return (start_date, end_date) from cached meta, or (None, None)."""
+        meta = self._tournament_meta or {}
+        return meta.get("start_date"), meta.get("end_date")
+
     def _build_enabled_modes(self) -> List[str]:
         """Build mode list based on current tournament phase and time of day.
 
@@ -218,7 +232,8 @@ class MastersTournamentPlugin(BasePlugin):
         the user sees and in what order. Modes listed multiple times get
         proportionally more screen time.
         """
-        phase = get_detailed_phase()
+        meta_start, meta_end = self._meta_dates()
+        phase = get_detailed_phase(start_date=meta_start, end_date=meta_end)
         phase_modes = self.PHASE_MODES.get(phase, self.PHASE_MODES["off-season"])
 
         # Filter by user config (respect per-mode enabled/disabled)
@@ -259,14 +274,26 @@ class MastersTournamentPlugin(BasePlugin):
 
         self.logger.info("Updating Masters Tournament data...")
         self._last_update = now
-        self._tournament_phase = get_tournament_phase()
+
+        # Refresh tournament meta (cheap — reads cache populated by leaderboard fetch)
+        try:
+            self._tournament_meta = self.data_source.fetch_tournament_meta()
+        except Exception as e:
+            self.logger.warning(f"Tournament meta refresh failed: {e}")
+
+        meta_start, meta_end = self._meta_dates()
+        self._tournament_phase = get_tournament_phase(
+            start_date=meta_start, end_date=meta_end
+        )
 
         # Refresh modes based on current phase/time of day
         # This lets modes shift automatically (e.g., morning → live → evening)
         new_modes = self._build_enabled_modes()
         if new_modes != self.modes:
             old_phase = self._detailed_phase
-            self._detailed_phase = get_detailed_phase()
+            self._detailed_phase = get_detailed_phase(
+                start_date=meta_start, end_date=meta_end
+            )
             self.modes = new_modes
             self.logger.info(
                 f"Phase changed: {old_phase} -> {self._detailed_phase}, "
@@ -474,12 +501,16 @@ class MastersTournamentPlugin(BasePlugin):
         return result
 
     def _display_countdown(self, force_clear: bool) -> bool:
-        # Compute next Masters Thursday dynamically (approx second Thursday of April)
-        now = datetime.utcnow()
-        year = now.year
-        target = datetime(year, 4, 10, 12, 0, 0)
-        if now > target:
-            target = datetime(year + 1, 4, 10, 12, 0, 0)
+        # Use live ESPN-derived tournament start date. Falls back to a computed
+        # second-Thursday-of-April inside the data source if ESPN isn't serving
+        # the Masters (off-season).
+        meta = self._tournament_meta or self.data_source.fetch_tournament_meta()
+        if meta and meta.get("start_date"):
+            target = meta["start_date"]
+        else:
+            # Hard fallback — should be unreachable, but keep the screen alive.
+            now = datetime.utcnow()
+            target = datetime(now.year, 4, 10, 12, 0, 0)
         countdown = calculate_tournament_countdown(target)
         return self._show_image(
             self.renderer.render_countdown(

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -44,12 +44,17 @@
   },
   "versions": [
     {
+      "version": "2.1.0",
+      "released": "2026-04-09",
+      "ledmatrix_min_version": "2.0.0"
+    },
+    {
       "version": "2.0.0",
       "released": "2026-04-07",
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-07",
+  "last_updated": "2026-04-09",
   "compatible_versions": [
     ">=2.0.0"
   ]

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.1.1",
+      "released": "2026-04-09",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.1.0",
       "released": "2026-04-09",

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.1.2",
+      "released": "2026-04-09",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.1.1",
       "released": "2026-04-09",

--- a/plugins/masters-tournament/masters_data.py
+++ b/plugins/masters-tournament/masters_data.py
@@ -8,7 +8,7 @@ Enriches player data with real ESPN headshot URLs and country codes.
 
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -17,26 +17,41 @@ from masters_helpers import ESPN_HEADSHOT_URL, ESPN_PLAYER_IDS, get_espn_headsho
 
 logger = logging.getLogger(__name__)
 
+# Cache keys
+CACHE_KEY_LEADERBOARD = "masters_leaderboard"
+CACHE_KEY_META = "masters_tournament_meta"
+CACHE_KEY_SCHEDULE = "masters_schedule"
+
 
 class MastersDataSource:
     """Fetches and caches Masters Tournament data from ESPN Golf API."""
 
-    LEADERBOARD_URL = "https://site.api.espn.com/apis/site/v2/sports/golf/pga/leaderboard"
-    SCHEDULE_URL = "https://site.api.espn.com/apis/site/v2/sports/golf/pga/schedule"
-    NEWS_URL = "https://site.api.espn.com/apis/site/v2/sports/golf/pga/news"
+    # NOTE: ESPN's legacy `/sports/golf/pga/leaderboard` path now 404s.
+    # The current working endpoint drops the `pga` segment.
+    LEADERBOARD_URL = "https://site.api.espn.com/apis/site/v2/sports/golf/leaderboard"
+    NEWS_URL = "https://site.api.espn.com/apis/site/v2/sports/golf/news"
+    # Athlete bio + overview live on site.web.api (common/v3), not site.api.
+    ATHLETE_URL = "https://site.web.api.espn.com/apis/common/v3/sports/golf/pga/athletes/{player_id}"
+    ATHLETE_OVERVIEW_URL = "https://site.web.api.espn.com/apis/common/v3/sports/golf/pga/athletes/{player_id}/overview"
+
+    HTTP_HEADERS = {"User-Agent": "LEDMatrix Masters Plugin/2.1"}
 
     def __init__(self, cache_manager, config: Dict[str, Any]):
         self.cache_manager = cache_manager
         self.config = config
         self.mock_mode = config.get("mock_data", False)
         self.logger = logging.getLogger(__name__)
+        # Last-seen raw leaderboard payload so schedule/meta can piggyback without re-fetching.
+        self._last_raw_leaderboard: Optional[Dict] = None
+
+    # ── Leaderboard ──────────────────────────────────────────────
 
     def fetch_leaderboard(self) -> List[Dict]:
         """Fetch current Masters leaderboard with caching."""
         if self.mock_mode:
             return self._generate_mock_leaderboard()
 
-        cache_key = "masters_leaderboard"
+        cache_key = CACHE_KEY_LEADERBOARD
         ttl = self._get_cache_ttl()
 
         cached = self.cache_manager.get(cache_key, max_age=ttl)
@@ -48,13 +63,19 @@ class MastersDataSource:
             response = requests.get(
                 self.LEADERBOARD_URL,
                 timeout=10,
-                headers={"User-Agent": "LEDMatrix Masters Plugin/2.0"},
+                headers=self.HTTP_HEADERS,
             )
             response.raise_for_status()
             data = response.json()
+            self._last_raw_leaderboard = data
 
-            is_masters = self._is_masters_tournament(data)
-            if not is_masters:
+            # Parse and cache tournament meta alongside the leaderboard so
+            # countdown / phase / TTL all flow from one HTTP call.
+            meta = self._parse_tournament_meta(data)
+            if meta:
+                self.cache_manager.set(CACHE_KEY_META, meta, ttl=ttl)
+
+            if not meta or not meta.get("is_masters"):
                 self.logger.info("Masters not currently in ESPN API, using mock data")
                 mock = self._generate_mock_leaderboard()
                 self.cache_manager.set(cache_key, mock, ttl=3600)
@@ -68,28 +89,149 @@ class MastersDataSource:
             self.logger.error(f"Failed to fetch leaderboard: {e}")
             return self._get_fallback_data(cache_key)
 
+    # ── Tournament metadata (start/end dates, status, round) ────
+
+    def fetch_tournament_meta(self) -> Optional[Dict]:
+        """Return tournament metadata, refreshing via fetch_leaderboard() if needed.
+
+        Meta shape:
+            {
+                "name": str,
+                "start_date": datetime (UTC, tz-aware),
+                "end_date": datetime (UTC, tz-aware),
+                "status": "pre" | "in" | "post",
+                "current_round": int,
+                "is_masters": bool,
+            }
+        """
+        cached = self.cache_manager.get(CACHE_KEY_META, max_age=self._get_cache_ttl())
+        if cached:
+            return cached
+
+        # Meta lives alongside the leaderboard payload; a leaderboard fetch
+        # will populate it as a side effect.
+        try:
+            self.fetch_leaderboard()
+        except Exception as e:
+            self.logger.warning(f"fetch_tournament_meta: leaderboard fetch failed: {e}")
+
+        cached = self.cache_manager.get(CACHE_KEY_META, max_age=None)
+        if cached:
+            return cached
+
+        # Final fallback: compute the Masters as the second Thursday of April
+        # so off-season countdowns still work.
+        return self._computed_fallback_meta()
+
+    def _parse_tournament_meta(self, data: Dict) -> Optional[Dict]:
+        """Extract tournament meta from an ESPN leaderboard response."""
+        try:
+            events = data.get("events", [])
+            if not events:
+                return None
+            event = events[0]
+            name = event.get("name", "") or ""
+            is_masters = any(
+                kw in name.lower() for kw in ("masters", "augusta national", "augusta")
+            )
+
+            start_date = self._parse_iso_utc(event.get("date"))
+            end_date = self._parse_iso_utc(event.get("endDate")) or (
+                start_date + timedelta(days=3) if start_date else None
+            )
+
+            status_obj = {}
+            competitions = event.get("competitions", [])
+            if competitions:
+                status_obj = competitions[0].get("status", {}) or {}
+            status_type = (status_obj.get("type") or {}).get("state", "pre")
+            current_round = int(status_obj.get("period", 0) or 0)
+
+            if not start_date:
+                return None
+
+            return {
+                "name": name or "Masters Tournament",
+                "start_date": start_date,
+                "end_date": end_date,
+                "status": status_type,
+                "current_round": current_round,
+                "is_masters": is_masters,
+            }
+        except Exception as e:
+            self.logger.error(f"Error parsing tournament meta: {e}")
+            return None
+
+    @staticmethod
+    def _parse_iso_utc(value: Optional[str]) -> Optional[datetime]:
+        """Parse an ISO-8601 timestamp from ESPN into a tz-aware UTC datetime."""
+        if not value:
+            return None
+        try:
+            # ESPN uses trailing 'Z'; datetime.fromisoformat handles +00:00
+            cleaned = value.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(cleaned)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+        except Exception:
+            return None
+
+    def _computed_fallback_meta(self) -> Dict:
+        """Compute a best-guess Masters window: second Thursday of April.
+
+        Used only when ESPN doesn't currently return the Masters (off-season).
+        """
+        now = datetime.now(timezone.utc)
+        year = now.year
+        start = self._second_thursday_of_april(year)
+        if now > start + timedelta(days=4):
+            start = self._second_thursday_of_april(year + 1)
+        end = start + timedelta(days=3)
+        return {
+            "name": "Masters Tournament",
+            "start_date": start,
+            "end_date": end,
+            "status": "pre",
+            "current_round": 0,
+            "is_masters": False,
+        }
+
+    @staticmethod
+    def _second_thursday_of_april(year: int) -> datetime:
+        """Second Thursday of April at 12:00 UTC (≈ 8am ET tee-off)."""
+        d = datetime(year, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+        # weekday(): Mon=0 … Thu=3
+        days_to_first_thursday = (3 - d.weekday()) % 7
+        first_thursday = d + timedelta(days=days_to_first_thursday)
+        return first_thursday + timedelta(days=7)
+
+    # ── Schedule / tee times ─────────────────────────────────────
+
     def fetch_schedule(self) -> List[Dict]:
-        """Fetch Masters schedule with tee times and pairings."""
+        """Fetch Masters tee times and pairings from the live leaderboard payload."""
         if self.mock_mode:
             return self._generate_mock_schedule()
 
-        cache_key = "masters_schedule"
-        ttl = 300
+        cache_key = CACHE_KEY_SCHEDULE
+        ttl = self._get_cache_ttl()
 
         cached = self.cache_manager.get(cache_key, max_age=ttl)
         if cached:
             return cached
 
+        # Reuse the leaderboard payload — tee times live on the leaderboard
+        # endpoint, not on /schedule (which returns the season list).
         try:
-            response = requests.get(
-                self.SCHEDULE_URL,
-                timeout=10,
-                headers={"User-Agent": "LEDMatrix Masters Plugin/2.0"},
-            )
-            response.raise_for_status()
-            data = response.json()
+            if self._last_raw_leaderboard is None:
+                # Force a leaderboard refresh to populate _last_raw_leaderboard
+                self.fetch_leaderboard()
 
-            parsed = self._parse_schedule(data)
+            data = self._last_raw_leaderboard
+            if not data:
+                return self._get_fallback_data(cache_key)
+
+            parsed = self._parse_tee_times_from_leaderboard(data)
             self.cache_manager.set(cache_key, parsed, ttl=ttl)
             return parsed
 
@@ -97,16 +239,140 @@ class MastersDataSource:
             self.logger.error(f"Failed to fetch schedule: {e}")
             return self._get_fallback_data(cache_key)
 
+    # ── Player details ───────────────────────────────────────────
+
     def fetch_player_details(self, player_id: str) -> Optional[Dict]:
-        """Fetch detailed player statistics."""
+        """Fetch player bio + season stats from ESPN's athlete + overview endpoints."""
+        if not player_id or str(player_id).startswith("mock_"):
+            return None
+
         cache_key = f"masters_player_{player_id}"
         ttl = self._get_cache_ttl()
 
         cached = self.cache_manager.get(cache_key, max_age=ttl)
         if cached:
+            self.logger.debug(f"Using cached player details for {player_id}")
             return cached
 
-        return None
+        try:
+            bio_resp = requests.get(
+                self.ATHLETE_URL.format(player_id=player_id),
+                timeout=10,
+                headers=self.HTTP_HEADERS,
+            )
+            if bio_resp.status_code != 200:
+                self.logger.warning(
+                    f"Player bio HTTP {bio_resp.status_code} for {player_id}"
+                )
+                return None
+            bio_data = bio_resp.json()
+
+            overview_data = None
+            try:
+                overview_resp = requests.get(
+                    self.ATHLETE_OVERVIEW_URL.format(player_id=player_id),
+                    timeout=10,
+                    headers=self.HTTP_HEADERS,
+                )
+                if overview_resp.status_code == 200:
+                    overview_data = overview_resp.json()
+            except Exception as e:
+                self.logger.debug(f"Player overview fetch failed for {player_id}: {e}")
+
+            parsed = self._parse_player_details(bio_data, overview_data)
+            if parsed:
+                self.cache_manager.set(cache_key, parsed, ttl=ttl)
+            return parsed
+        except Exception as e:
+            self.logger.warning(f"Failed to fetch player details for {player_id}: {e}")
+            return None
+
+    def _parse_player_details(
+        self, bio_data: Dict, overview_data: Optional[Dict]
+    ) -> Optional[Dict]:
+        """Combine bio + overview into a single player details dict."""
+        try:
+            athlete = bio_data.get("athlete") or bio_data
+            if not isinstance(athlete, dict):
+                return None
+
+            headshot = (athlete.get("headshot") or {}).get("href")
+            flag = (athlete.get("flag") or {}).get("href")
+            flag_alt = (athlete.get("flag") or {}).get("alt")
+
+            # birthPlace is {city, state, country, countryAbbreviation}
+            birth_place = athlete.get("birthPlace") or {}
+            if isinstance(birth_place, dict):
+                birth_parts = [
+                    (birth_place.get("city") or "").strip(),
+                    (birth_place.get("state") or "").strip(),
+                    (birth_place.get("country") or "").strip(),
+                ]
+                birth_place_str = ", ".join(p for p in birth_parts if p)
+            else:
+                birth_place_str = str(birth_place) if birth_place else ""
+
+            college = athlete.get("college")
+            if isinstance(college, dict):
+                college = college.get("name")
+
+            stats: Dict[str, Any] = {}
+            rankings: Dict[str, Any] = {}
+            overview_display = None
+
+            if overview_data:
+                stat_block = overview_data.get("statistics") or {}
+                overview_display = stat_block.get("displayName")
+                labels = stat_block.get("names") or stat_block.get("labels") or []
+                splits = stat_block.get("splits") or []
+                # Prefer the PGA TOUR split over Majors when present
+                chosen_split = None
+                if isinstance(splits, list):
+                    for sp in splits:
+                        if (sp.get("displayName") or "").upper() == "PGA TOUR":
+                            chosen_split = sp
+                            break
+                    if chosen_split is None and splits:
+                        chosen_split = splits[0]
+                if chosen_split:
+                    values = chosen_split.get("stats") or []
+                    for label, value in zip(labels, values):
+                        if label:
+                            stats[label] = value
+
+                # seasonRankings.categories is a rich list of ranked stats.
+                sr = overview_data.get("seasonRankings") or {}
+                categories = sr.get("categories") or []
+                for cat in categories:
+                    key = cat.get("shortDisplayName") or cat.get("displayName") or cat.get("name")
+                    if not key:
+                        continue
+                    rankings[key] = {
+                        "value": cat.get("displayValue"),
+                        "rank": cat.get("rankDisplayValue") or cat.get("rank"),
+                    }
+
+            return {
+                "player_id": athlete.get("id"),
+                "display_name": athlete.get("displayName"),
+                "first_name": athlete.get("firstName"),
+                "last_name": athlete.get("lastName"),
+                "age": athlete.get("age"),
+                "height": athlete.get("displayHeight") or athlete.get("height"),
+                "weight": athlete.get("displayWeight") or athlete.get("weight"),
+                "college": college,
+                "turned_pro": athlete.get("turnedPro"),
+                "birth_place": birth_place_str,
+                "country": flag_alt,
+                "headshot_url": headshot,
+                "flag_url": flag,
+                "stats_display_name": overview_display,
+                "stats": stats,
+                "rankings": rankings,
+            }
+        except Exception as e:
+            self.logger.error(f"Error parsing player details: {e}")
+            return None
 
     def _is_masters_tournament(self, data: Dict) -> bool:
         """Check if the current tournament in ESPN data is the Masters."""
@@ -118,6 +384,58 @@ class MastersDataSource:
             return any(kw in name for kw in ["masters", "augusta national", "augusta"])
         except Exception:
             return False
+
+    def _parse_tee_times_from_leaderboard(self, data: Dict) -> List[Dict]:
+        """Extract tee-time pairings from an ESPN leaderboard payload.
+
+        Each group is {"time": ISO UTC str, "players": [name, ...]}.
+        Groups are reconstructed by clustering competitors with identical tee times.
+        """
+        groups: Dict[str, List[str]] = {}
+        try:
+            events = data.get("events", [])
+            if not events:
+                return []
+            competitions = events[0].get("competitions", [])
+            if not competitions:
+                return []
+
+            # Preferred shape: explicit teeTimes list on the competition.
+            explicit = competitions[0].get("teeTimes") or []
+            if explicit:
+                result = []
+                for tt in explicit:
+                    players_list = []
+                    for competitor in tt.get("competitors", []) or []:
+                        athlete = competitor.get("athlete", {}) or {}
+                        players_list.append(athlete.get("displayName", "Unknown"))
+                    result.append({
+                        "time": tt.get("startTime", "TBD"),
+                        "players": players_list,
+                    })
+                result.sort(key=lambda g: g.get("time") or "")
+                return result
+
+            # Fallback: group competitors by their status.teeTime.
+            competitors = competitions[0].get("competitors", []) or []
+            for entry in competitors:
+                athlete = entry.get("athlete", {}) or {}
+                status = entry.get("status", {}) or {}
+                tee_time = status.get("teeTime")
+                if not tee_time:
+                    continue
+                name = athlete.get("displayName", "Unknown")
+                groups.setdefault(tee_time, []).append(name)
+
+            result = [
+                {"time": t, "players": players}
+                for t, players in groups.items()
+            ]
+            result.sort(key=lambda g: g["time"])
+            return result
+        except Exception as e:
+            self.logger.error(f"Error parsing tee times: {e}")
+            return []
 
     def _parse_leaderboard(self, data: Dict) -> List[Dict]:
         """Extract and enrich fields from ESPN leaderboard API response."""
@@ -135,41 +453,69 @@ class MastersDataSource:
             competitors = competitions[0].get("competitors", [])
 
             for entry in competitors:
-                athlete = entry.get("athlete", {})
-                status = entry.get("status", {})
-                score_data = entry.get("score", {})
+                athlete = entry.get("athlete", {}) or {}
+                status = entry.get("status", {}) or {}
+                score_data = entry.get("score", {}) or {}
 
                 player_name = athlete.get("displayName", "Unknown")
                 player_id = athlete.get("id", "")
 
-                # Get headshot - prefer ESPN API data, fall back to our DB
-                headshot_url = athlete.get("headshot", {}).get("href")
+                # Get headshot - prefer ESPN API data, fall back to our DB,
+                # last resort construct from player_id (same URL template ESPN uses).
+                headshot_url = (athlete.get("headshot") or {}).get("href")
                 if not headshot_url:
                     headshot_url = get_espn_headshot_url(player_name)
+                if not headshot_url and player_id:
+                    headshot_url = (
+                        f"https://a.espncdn.com/i/headshots/golf/players/full/{player_id}.png"
+                    )
 
-                # Get country from our DB if not in API
-                country = ""
-                flag_data = athlete.get("flag", {})
-                if flag_data:
-                    country = flag_data.get("alt", "")
-                    # Normalize to 3-letter code
-                    if len(country) > 3:
-                        country = get_player_country(player_name) or ""
+                # Country: prefer our hardcoded DB for a clean 3-letter code,
+                # then fall back to extracting the ISO code from ESPN's flag URL
+                # (.../countries/500/usa.png → USA).
+                country = get_player_country(player_name) or ""
                 if not country:
-                    country = get_player_country(player_name) or ""
+                    flag_data = athlete.get("flag") or {}
+                    flag_href = flag_data.get("href", "") or ""
+                    if "/countries/" in flag_href:
+                        try:
+                            code = flag_href.rsplit("/", 1)[-1].split(".", 1)[0]
+                            country = code.upper()[:3]
+                        except Exception:
+                            country = ""
+                    if not country:
+                        alt = (flag_data.get("alt") or "").strip()
+                        if 0 < len(alt) <= 3:
+                            country = alt.upper()
+
+                # Position: ESPN's current shape has position at status.position.displayName
+                # (e.g. "T1", "2", "-"), with sortOrder as the numeric leaderboard rank.
+                # The legacy `entry.position` field is typically null now.
+                status_position = (status.get("position") or {}).get("displayName")
+                position = status_position or entry.get("position") or entry.get("sortOrder") or "-"
+
+                # thru: 0 before teeing off is shown as "-"
+                thru_val = status.get("thru")
+                if thru_val is None or thru_val == 0:
+                    thru_display = "-"
+                elif thru_val == 18:
+                    thru_display = "F"
+                else:
+                    thru_display = thru_val
 
                 players.append({
-                    "position": entry.get("position", 0),
+                    "position": position,
                     "player": player_name,
                     "player_id": player_id,
                     "country": country,
                     "score": self._calculate_score_to_par(entry),
                     "today": self._get_today_score(score_data),
-                    "thru": status.get("thru", "F"),
+                    "thru": thru_display,
                     "rounds": self._extract_round_scores(entry),
                     "headshot_url": headshot_url,
                     "current_hole": status.get("hole"),
                     "status": status.get("displayValue", ""),
+                    "tee_time": status.get("teeTime"),
                 })
 
         except Exception as e:
@@ -180,20 +526,23 @@ class MastersDataSource:
     def _calculate_score_to_par(self, entry: Dict) -> int:
         """Calculate player's score relative to par."""
         try:
-            display_value = entry.get("score", {}).get("displayValue", "E")
-            if display_value == "E":
+            display_value = (entry.get("score") or {}).get("displayValue", "E")
+            if not display_value or display_value in ("-", "E"):
                 return 0
-            elif display_value.startswith("+"):
+            if display_value.startswith("+"):
                 return int(display_value[1:])
-            elif display_value.startswith("-"):
+            if display_value.startswith("-") and len(display_value) > 1:
                 return int(display_value)
             return 0
         except Exception:
             return 0
 
     def _get_today_score(self, score_data: Dict) -> Optional[int]:
-        """Get today's round score relative to par."""
+        """Get today's round score relative to par (None when not yet playing)."""
         try:
+            dv = score_data.get("displayValue")
+            if dv in (None, "", "-"):
+                return None
             value = score_data.get("value")
             if value is not None:
                 return int(value)
@@ -202,58 +551,44 @@ class MastersDataSource:
         return None
 
     def _extract_round_scores(self, entry: Dict) -> List[Optional[int]]:
-        """Extract scores for each round."""
+        """Extract scores for each round. Placeholder values (value=0 and
+        displayValue=='-') are treated as 'not yet completed' and left as None.
+        """
         rounds = [None, None, None, None]
         try:
-            linescores = entry.get("linescores", [])
+            linescores = entry.get("linescores", []) or []
             for i, linescore in enumerate(linescores[:4]):
                 value = linescore.get("value")
-                if value is not None:
-                    rounds[i] = int(value)
+                display = linescore.get("displayValue")
+                if value is None:
+                    continue
+                if display in (None, "", "-"):
+                    continue
+                rounds[i] = int(value)
         except Exception:
             pass
         return rounds
 
-    def _parse_schedule(self, data: Dict) -> List[Dict]:
-        """Parse schedule data from ESPN API."""
-        schedule = []
-        try:
-            events = data.get("events", [])
-            if events:
-                competitions = events[0].get("competitions", [])
-                for comp in competitions:
-                    tee_times = comp.get("teeTimes", [])
-                    for tt in tee_times:
-                        players_list = []
-                        for competitor in tt.get("competitors", []):
-                            athlete = competitor.get("athlete", {})
-                            players_list.append(athlete.get("displayName", "Unknown"))
-                        schedule.append({
-                            "time": tt.get("startTime", "TBD"),
-                            "players": players_list,
-                        })
-        except Exception as e:
-            self.logger.error(f"Error parsing schedule: {e}")
-        return schedule
-
     def _get_cache_ttl(self) -> int:
-        """Get appropriate cache TTL based on tournament phase."""
-        phase = self._detect_tournament_phase()
-        if phase == "tournament":
-            return 30
-        elif phase == "practice":
-            return 300
-        return 3600
+        """TTL derived from cached tournament meta, with safe hardcoded fallback.
 
-    def _detect_tournament_phase(self) -> str:
-        """Detect if it's practice rounds, tournament, or off-season."""
-        now = datetime.now()
-        if now.month == 4:
-            if 7 <= now.day <= 9:
-                return "practice"
-            elif 10 <= now.day <= 13:
-                return "tournament"
-        return "off-season"
+        Avoids calling fetch_tournament_meta() (which could recurse into
+        fetch_leaderboard) — only reads whatever is already in cache.
+        """
+        meta = self.cache_manager.get(CACHE_KEY_META, max_age=None)
+        if meta:
+            status = meta.get("status")
+            if status == "in":
+                return 30
+            start = meta.get("start_date")
+            end = meta.get("end_date")
+            now = datetime.now(timezone.utc)
+            if start and end and start <= now <= end:
+                return 30
+            if start and timedelta(0) <= start - now <= timedelta(days=3):
+                return 300
+            return 3600
+        return 3600
 
     def _get_fallback_data(self, cache_key: str) -> List[Dict]:
         """Get stale cached data or mock data as fallback."""

--- a/plugins/masters-tournament/masters_data.py
+++ b/plugins/masters-tournament/masters_data.py
@@ -41,8 +41,6 @@ class MastersDataSource:
         self.config = config
         self.mock_mode = config.get("mock_data", False)
         self.logger = logging.getLogger(__name__)
-        # Last-seen raw leaderboard payload so schedule/meta can piggyback without re-fetching.
-        self._last_raw_leaderboard: Optional[Dict] = None
 
     # ── Leaderboard ──────────────────────────────────────────────
 
@@ -67,7 +65,6 @@ class MastersDataSource:
             )
             response.raise_for_status()
             data = response.json()
-            self._last_raw_leaderboard = data
 
             # Parse and cache tournament meta alongside the leaderboard so
             # countdown / phase / TTL all flow from one HTTP call.
@@ -79,10 +76,23 @@ class MastersDataSource:
                 self.logger.info("Masters not currently in ESPN API, using mock data")
                 mock = self._generate_mock_leaderboard()
                 self.cache_manager.set(cache_key, mock, ttl=3600)
+                # Clear any stale tee-time cache so we don't surface tee times
+                # from a previous tournament / non-Masters event.
+                self.cache_manager.set(CACHE_KEY_SCHEDULE, [], ttl=3600)
                 return mock
 
             parsed = self._parse_leaderboard(data)
             self.cache_manager.set(cache_key, parsed, ttl=ttl)
+
+            # Derive tee times from the same payload and cache them directly,
+            # so fetch_schedule() is a pure cache read and never has to
+            # re-parse stale in-memory state.
+            try:
+                tee_times = self._parse_tee_times_from_leaderboard(data)
+                self.cache_manager.set(CACHE_KEY_SCHEDULE, tee_times, ttl=ttl)
+            except Exception as e:
+                self.logger.warning(f"Tee-time parsing failed: {e}")
+
             return parsed
 
         except Exception as e:
@@ -136,9 +146,16 @@ class MastersDataSource:
             )
 
             start_date = self._parse_iso_utc(event.get("date"))
-            end_date = self._parse_iso_utc(event.get("endDate")) or (
-                start_date + timedelta(days=3) if start_date else None
-            )
+            end_date = self._parse_iso_utc(event.get("endDate"))
+            if end_date is None and start_date is not None:
+                # Fallback: Masters is always a 4-day (Thu–Sun) event.
+                end_date = start_date + timedelta(days=3)
+            if end_date is not None:
+                # ESPN reports endDate as the *start* of the final day in ET
+                # (e.g. 2026-04-12T04:00Z = Sun Apr 12 00:00 ET). Push to end
+                # of that calendar day so phase checks treat all of Sunday's
+                # play as in-tournament rather than post-tournament.
+                end_date = end_date + timedelta(hours=23, minutes=59, seconds=59)
 
             status_obj = {}
             competitions = event.get("competitions", [])
@@ -187,7 +204,9 @@ class MastersDataSource:
         start = self._second_thursday_of_april(year)
         if now > start + timedelta(days=4):
             start = self._second_thursday_of_april(year + 1)
-        end = start + timedelta(days=3)
+        # Cover all four calendar days (Thu–Sun) through end-of-day, matching
+        # the normalization applied to ESPN's parsed endDate.
+        end = start + timedelta(days=3, hours=23, minutes=59, seconds=59)
         return {
             "name": "Masters Tournament",
             "start_date": start,
@@ -209,7 +228,14 @@ class MastersDataSource:
     # ── Schedule / tee times ─────────────────────────────────────
 
     def fetch_schedule(self) -> List[Dict]:
-        """Fetch Masters tee times and pairings from the live leaderboard payload."""
+        """Return Masters tee-time pairings.
+
+        Tee times are derived from the leaderboard payload and cached inside
+        fetch_leaderboard(), so this is a pure cache read. If the cache is
+        cold (e.g. first call after startup), it triggers a leaderboard
+        refresh to populate it — but only when meta reports is_masters, to
+        avoid parsing a non-Masters PGA event's tee times during off-season.
+        """
         if self.mock_mode:
             return self._generate_mock_schedule()
 
@@ -217,27 +243,22 @@ class MastersDataSource:
         ttl = self._get_cache_ttl()
 
         cached = self.cache_manager.get(cache_key, max_age=ttl)
-        if cached:
+        if cached is not None:
             return cached
 
-        # Reuse the leaderboard payload — tee times live on the leaderboard
-        # endpoint, not on /schedule (which returns the season list).
+        # Cold cache — ask the leaderboard path to refresh everything.
+        # fetch_leaderboard() populates CACHE_KEY_SCHEDULE as a side effect
+        # when meta.is_masters is true.
         try:
-            if self._last_raw_leaderboard is None:
-                # Force a leaderboard refresh to populate _last_raw_leaderboard
-                self.fetch_leaderboard()
-
-            data = self._last_raw_leaderboard
-            if not data:
-                return self._get_fallback_data(cache_key)
-
-            parsed = self._parse_tee_times_from_leaderboard(data)
-            self.cache_manager.set(cache_key, parsed, ttl=ttl)
-            return parsed
-
+            self.fetch_leaderboard()
         except Exception as e:
-            self.logger.error(f"Failed to fetch schedule: {e}")
+            self.logger.error(f"fetch_schedule: leaderboard refresh failed: {e}")
             return self._get_fallback_data(cache_key)
+
+        cached = self.cache_manager.get(cache_key, max_age=None)
+        if cached is not None:
+            return cached
+        return []
 
     # ── Player details ───────────────────────────────────────────
 

--- a/plugins/masters-tournament/masters_data.py
+++ b/plugins/masters-tournament/masters_data.py
@@ -66,10 +66,13 @@ class MastersDataSource:
             response.raise_for_status()
             data = response.json()
 
-            # Parse and cache tournament meta alongside the leaderboard so
-            # countdown / phase / TTL all flow from one HTTP call.
+            # Parse tournament meta from the leaderboard payload. Only cache
+            # it when ESPN is actually serving the Masters — otherwise a
+            # non-Masters PGA event (e.g. RBC Heritage during off-season)
+            # would poison the cache and drive the countdown / phase to
+            # the wrong tournament.
             meta = self._parse_tournament_meta(data)
-            if meta:
+            if meta and meta.get("is_masters"):
                 self.cache_manager.set(CACHE_KEY_META, meta, ttl=ttl)
 
             if not meta or not meta.get("is_masters"):
@@ -193,6 +196,25 @@ class MastersDataSource:
             return dt.astimezone(timezone.utc)
         except Exception:
             return None
+
+    @classmethod
+    def _format_tee_time_et(cls, iso_value: Optional[str]) -> str:
+        """Render an ESPN ISO tee time as compact Augusta-local display text.
+
+        Example: '2026-04-09T14:07Z' -> '10:07 AM'. Returns 'TBD' for
+        unparseable or empty values. The Masters is always played in the
+        second week of April, which is after US DST starts, so EDT (UTC-4)
+        is always correct — no tz database lookup needed.
+        """
+        dt = cls._parse_iso_utc(iso_value)
+        if dt is None:
+            return "TBD"
+        et = dt - timedelta(hours=4)  # EDT
+        hour = et.hour
+        minute = et.minute
+        suffix = "AM" if hour < 12 else "PM"
+        display_hour = hour % 12 or 12
+        return f"{display_hour}:{minute:02d} {suffix}"
 
     def _computed_fallback_meta(self) -> Dict:
         """Compute a best-guess Masters window: second Thursday of April.
@@ -430,11 +452,13 @@ class MastersDataSource:
                     for competitor in tt.get("competitors", []) or []:
                         athlete = competitor.get("athlete", {}) or {}
                         players_list.append(athlete.get("displayName", "Unknown"))
+                    iso = tt.get("startTime") or ""
                     result.append({
-                        "time": tt.get("startTime", "TBD"),
+                        "time": self._format_tee_time_et(iso),
+                        "time_raw": iso,
                         "players": players_list,
                     })
-                result.sort(key=lambda g: g.get("time") or "")
+                result.sort(key=lambda g: g.get("time_raw") or "")
                 return result
 
             # Fallback: group competitors by their status.teeTime.
@@ -449,10 +473,14 @@ class MastersDataSource:
                 groups.setdefault(tee_time, []).append(name)
 
             result = [
-                {"time": t, "players": players}
+                {
+                    "time": self._format_tee_time_et(t),
+                    "time_raw": t,
+                    "players": players,
+                }
                 for t, players in groups.items()
             ]
-            result.sort(key=lambda g: g["time"])
+            result.sort(key=lambda g: g["time_raw"])
             return result
         except Exception as e:
             self.logger.error(f"Error parsing tee times: {e}")

--- a/plugins/masters-tournament/masters_helpers.py
+++ b/plugins/masters-tournament/masters_helpers.py
@@ -298,9 +298,27 @@ def _to_eastern(date: Optional[datetime]) -> datetime:
     return date.astimezone(_EDT)
 
 
-def get_tournament_phase(date: Optional[datetime] = None) -> str:
-    """Determine current Masters tournament phase (basic)."""
+def get_tournament_phase(
+    date: Optional[datetime] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> str:
+    """Determine current Masters tournament phase (basic).
+
+    When start_date/end_date are provided (e.g. from the live ESPN feed),
+    phase is computed by comparison. Otherwise falls back to a hardcoded
+    second-week-of-April heuristic for backwards compatibility.
+    """
     date = _to_eastern(date)
+
+    if start_date is not None and end_date is not None:
+        start_e = _to_eastern(start_date)
+        end_e = _to_eastern(end_date)
+        if start_e <= date <= end_e:
+            return "tournament"
+        if timedelta(0) <= (start_e - date) <= timedelta(days=3):
+            return "practice"
+        return "off-season"
 
     if date.month == 4:
         if 7 <= date.day <= 9:
@@ -311,7 +329,11 @@ def get_tournament_phase(date: Optional[datetime] = None) -> str:
     return "off-season"
 
 
-def get_detailed_phase(date: Optional[datetime] = None) -> str:
+def get_detailed_phase(
+    date: Optional[datetime] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> str:
     """
     Determine detailed tournament phase including time-of-day awareness.
 
@@ -326,6 +348,33 @@ def get_detailed_phase(date: Optional[datetime] = None) -> str:
         "post-tournament"     - Sunday evening / Monday after Masters
     """
     date = _to_eastern(date)
+
+    # Date-driven path (preferred): when the live ESPN feed supplies real
+    # tournament dates, compute phase by comparison so we don't rely on
+    # hardcoded April day numbers.
+    if start_date is not None and end_date is not None:
+        start_e = _to_eastern(start_date)
+        end_e = _to_eastern(end_date)
+        hour = date.hour
+
+        if start_e <= date <= end_e:
+            if hour < 6:
+                return "tournament-overnight"
+            if hour < 8:
+                return "tournament-morning"
+            if hour < 19:
+                return "tournament-live"
+            return "tournament-evening"
+
+        if date > end_e and (date - end_e) <= timedelta(days=1):
+            return "post-tournament"
+
+        delta = start_e - date
+        if timedelta(0) < delta <= timedelta(days=3):
+            return "practice"
+        if timedelta(0) < delta <= timedelta(days=14):
+            return "pre-tournament"
+        return "off-season"
 
     month = date.month
     day = date.day

--- a/plugins/masters-tournament/masters_renderer.py
+++ b/plugins/masters-tournament/masters_renderer.py
@@ -825,13 +825,17 @@ class MastersRenderer:
         img = self._draw_gradient_bg(COLORS["masters_dark"], COLORS["masters_green"])
         draw = ImageDraw.Draw(img)
 
-        # Countdown text — show days + hours for context, or hours:minutes when < 1 day
+        # Countdown text — show days + hours for context, hours:minutes when
+        # under 1 day, minutes-only in the final hour, then "NOW".
         if days > 0:
             count_text = f"{days}d {hours}h"
             unit_text = "UNTIL THE MASTERS"
         elif hours > 0:
             count_text = f"{hours}:{minutes:02d}"
             unit_text = "HOURS TO GO"
+        elif minutes > 0:
+            count_text = f"{minutes}m"
+            unit_text = "MINUTES TO GO"
         else:
             count_text = "NOW"
             unit_text = ""


### PR DESCRIPTION
## Summary

- ESPN retired `/sports/golf/pga/leaderboard` (404), so the plugin was silently serving mock data for the 2026 Masters. Repointed to the working `/sports/golf/leaderboard` endpoint, plus `site.web.api.espn.com/.../common/v3/.../athletes/{id}` + `/overview` for player details.
- The countdown was hardcoded to Apr 10 12:00 UTC (2025 Masters Thursday) and appeared "stuck at 23 hours" all day on Apr 9 2026 — the day the 2026 tournament actually started. Countdown target is now pulled from the live ESPN feed (`events[0].date`), with a computed-second-Thursday-of-April fallback for off-season. Renderer also gained a sub-hour branch so the final hour ticks down as "`{m}m` MINUTES TO GO" instead of jumping straight from hours to "NOW".
- Phase detection (`get_tournament_phase` / `get_detailed_phase`) now accepts `start_date`/`end_date` and computes phase by comparison, so mode rotation and cache TTL follow the real tournament window. TTL drops to 30s during live play.
- Leaderboard parser fixes surfaced by the real payload: position now reads `status.position.displayName` (top-level `position` is `null`); `_calculate_score_to_par` guards `"-"` placeholders; `_extract_round_scores` skips pre-round `value=0.0 / displayValue="-"` entries; country codes are pulled from the flag URL path (`.../countries/500/usa.png` → `USA`); headshot URLs fall back to the ESPN CDN template built from `player_id`.
- `fetch_player_details()` was a stub returning `None`. Now hits both the athlete endpoint (bio: age, height, weight, college, birth place, flag, headshot) and `/overview` (season stats + `seasonRankings.categories`).
- `fetch_schedule()` no longer calls the dead `/sports/golf/pga/schedule` endpoint — tee-time pairings are parsed out of the leaderboard payload we already fetch, grouped by identical `status.teeTime`.
- Manifest bump 2.0.0 → 2.1.0 (pre-commit hook auto-synced `plugins.json`).

## Test plan

Validated live against ESPN for the 2026 Masters on 2026-04-09:

- [x] `fetch_leaderboard()` — **91/91** real players, all with `player_id`, country code, and headshot URL
- [x] `fetch_tournament_meta()` — `name=Masters Tournament`, `start=2026-04-09 04:00 UTC`, `end=2026-04-12 04:00 UTC`, `status=in`, `round=1`, `is_masters=True`
- [x] `fetch_schedule()` — 31 tee-time pairings, 91 players, sorted by startTime
- [x] `fetch_player_details("9478")` — full Scheffler bio + 6 stats + 9 season rankings
- [x] `_get_cache_ttl()` during live tournament → 30s
- [x] `get_tournament_phase` / `get_detailed_phase` with live meta → `tournament` / `tournament-live`
- [x] `calculate_tournament_countdown(live_start)` → `0/0/0` → renders "NOW"
- [x] `calculate_tournament_countdown(now + 45m)` → `0/0/44` → renders "44m MINUTES TO GO"
- [x] Countdown PNGs rendered for all branches (days / hours / minutes / NOW) — visual check passed
- [x] `python test_plugin_standalone.py` — all green
- [ ] Smoke test on a real LEDMatrix Pi with `update_interval=30`, watch the leaderboard refresh and phase transition through the 4-day tournament (requires hardware — cannot be validated in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live tournament metadata caching for accurate event dates and countdowns
  * Expanded player detail retrieval (biography, stats, headshots)
  * Plugin release advanced to version 2.1.2

* **Improvements**
  * Tournament phase detection now uses actual event dates for accuracy
  * Leaderboard parsing improved (tee times, positions, scores, round/thru)
  * Countdown shows minutes-only in final hour and has safer fallbacks when metadata is missing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->