### PR TITLE
flight-tracker: scale layouts across display sizes (1.4.0)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-10",
+  "last_updated": "2026-04-14",
   "plugins": [
     {
       "id": "hello-world",
@@ -488,10 +488,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-03-30",
+      "last_updated": "2026-04-14",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.3.0"
+      "latest_version": "1.4.0"
     },
     {
       "id": "christmas-countdown",

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-14",
+  "last_updated": "2026-04-16",
   "plugins": [
     {
       "id": "hello-world",
@@ -702,7 +702,7 @@
       "last_updated": "2026-04-14",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.4.1"
+      "latest_version": "2.4.2"
     },
     {
       "id": "web-ui-info",

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -327,6 +327,38 @@
       "maximum": 1280,
       "default": 256
     },
+    "fonts": {
+      "type": "object",
+      "title": "Font Size Overrides",
+      "description": "Optional overrides for the three font tiers. Leave values at 0 to use the auto-sized defaults based on display height.",
+      "properties": {
+        "large_size": {
+          "type": "integer",
+          "title": "Large Font Size (px)",
+          "description": "Override size for the large font tier. 0 = auto.",
+          "minimum": 0,
+          "maximum": 32,
+          "default": 0
+        },
+        "medium_size": {
+          "type": "integer",
+          "title": "Medium Font Size (px)",
+          "description": "Override size for the medium font tier. 0 = auto.",
+          "minimum": 0,
+          "maximum": 32,
+          "default": 0
+        },
+        "small_size": {
+          "type": "integer",
+          "title": "Small Font Size (px)",
+          "description": "Override size for the small font tier. 0 = auto.",
+          "minimum": 0,
+          "maximum": 32,
+          "default": 0
+        }
+      },
+      "additionalProperties": false
+    },
     "airport_color": {
       "type": "array",
       "title": "Airport Name Color",
@@ -698,6 +730,7 @@
     "vr_unit",
     "layout",
     "widescreen_threshold",
+    "fonts",
     "header_color",
     "airport_color",
     "metric_color",

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -35,6 +35,12 @@
   "max_ledmatrix_version": "3.0.0",
   "versions": [
     {
+      "released": "2026-04-14",
+      "version": "1.4.0",
+      "notes": "Scale flight detail/area/stats layouts across 32/48/64+ px heights via adaptive row dropping; add optional fonts.* size overrides",
+      "ledmatrix_min_version": "2.0.0"
+    },
+    {
       "released": "2026-03-30",
       "version": "1.3.0",
       "ledmatrix_min_version": "2.0.0"
@@ -51,5 +57,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-03-30"
+  "last_updated": "2026-04-14"
 }

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",

--- a/plugins/ledmatrix-flights/renderer.py
+++ b/plugins/ledmatrix-flights/renderer.py
@@ -156,18 +156,24 @@ class FlightRenderer:
         return self.dm.matrix.height
 
     def _load_fonts(self) -> None:
-        """Load three named font tiers scaled to display height (overridable via config.fonts)."""
+        """Load three named font tiers scaled to display size (overridable via config.fonts).
+
+        Tier picks consider BOTH height and width — the widescreen layout at 64px
+        height on a 128-wide panel can't afford a 16pt font_large, because the
+        info zone is only 50% of the width (64px, ~4 chars at 16pt).
+        """
         h = self.height
-        if h >= 64:
+        w = self.width
+        if h >= 64 and w >= 192:
             large_sz, medium_sz, small_sz = 16, 10, 8
             small_face = "PressStart2P-Regular.ttf"
             self.sprite_scale = 2
         elif h >= 48:
             large_sz, medium_sz, small_sz = 10, 8, 6
             small_face = "4x6-font.ttf"
-            self.sprite_scale = 1
+            self.sprite_scale = 1 if w < 192 else 2
         else:
-            # Tiny display (64x32 or smaller): keep medium and small visually distinct
+            # Tiny display (64x32 or similar)
             large_sz, medium_sz, small_sz = 8, 8, 6
             small_face = "4x6-font.ttf"
             self.sprite_scale = 1
@@ -395,11 +401,12 @@ class FlightRenderer:
         # Build priority-ordered info rows; drop lowest priority if they don't fit.
         route = f"{origin}-{dest}" if origin != "---" and dest != "---" else "---"
         name_text = self._truncate(draw, null_safe(airline_name), self.font_large, info_w - 4)
+        route_text = self._truncate(draw, route, self.font_large, info_w - 4)
         type_text = self._truncate(draw, null_safe(atype, default="---"), self.font_large, info_w - 4)
 
         info_candidates = [
             ("name", self.font_large, name_text, self.header_color),
-            ("route", self.font_large, route, self.header_color),
+            ("route", self.font_large, route_text, self.header_color),
             ("atype", self.font_large, type_text, self.header_color),
         ]
         if origin_full:

--- a/plugins/ledmatrix-flights/renderer.py
+++ b/plugins/ledmatrix-flights/renderer.py
@@ -132,6 +132,18 @@ class FlightRenderer:
         except (TypeError, ValueError):
             self._wide_threshold = self.WIDE_THRESHOLD
 
+        # Optional font size overrides (0 = auto)
+        fonts_cfg = config.get("fonts") or {}
+        def _opt_int(v):
+            try:
+                n = int(v)
+                return n if n > 0 else None
+            except (TypeError, ValueError):
+                return None
+        self._font_override_large = _opt_int(fonts_cfg.get("large_size"))
+        self._font_override_medium = _opt_int(fonts_cfg.get("medium_size"))
+        self._font_override_small = _opt_int(fonts_cfg.get("small_size"))
+
         # Load fonts scaled to display
         self._load_fonts()
 
@@ -144,24 +156,59 @@ class FlightRenderer:
         return self.dm.matrix.height
 
     def _load_fonts(self) -> None:
-        """Load three named font tiers scaled to display height."""
+        """Load three named font tiers scaled to display height (overridable via config.fonts)."""
         h = self.height
         if h >= 64:
-            self.font_large = _ttf("PressStart2P-Regular.ttf", 16)
-            self.font_medium = _ttf("PressStart2P-Regular.ttf", 10)
-            self.font_small = _ttf("PressStart2P-Regular.ttf", 8)
+            large_sz, medium_sz, small_sz = 16, 10, 8
+            small_face = "PressStart2P-Regular.ttf"
             self.sprite_scale = 2
         elif h >= 48:
-            self.font_large = _ttf("PressStart2P-Regular.ttf", 10)
-            self.font_medium = _ttf("PressStart2P-Regular.ttf", 8)
-            self.font_small = _ttf("4x6-font.ttf", 6)
+            large_sz, medium_sz, small_sz = 10, 8, 6
+            small_face = "4x6-font.ttf"
             self.sprite_scale = 1
         else:
-            # Tiny display (64×32 or smaller)
-            self.font_large = _ttf("PressStart2P-Regular.ttf", 8)
-            self.font_medium = _ttf("PressStart2P-Regular.ttf", 6)
-            self.font_small = _ttf("4x6-font.ttf", 6)
+            # Tiny display (64x32 or smaller): keep medium and small visually distinct
+            large_sz, medium_sz, small_sz = 8, 8, 6
+            small_face = "4x6-font.ttf"
             self.sprite_scale = 1
+
+        if self._font_override_large is not None:
+            large_sz = self._font_override_large
+        if self._font_override_medium is not None:
+            medium_sz = self._font_override_medium
+        if self._font_override_small is not None:
+            small_sz = self._font_override_small
+
+        self.font_large = _ttf("PressStart2P-Regular.ttf", large_sz)
+        self.font_medium = _ttf("PressStart2P-Regular.ttf", medium_sz)
+        # Small tier: 4x6 below 8px, PressStart2P at 8+
+        if small_sz >= 8:
+            self.font_small = _ttf("PressStart2P-Regular.ttf", small_sz)
+        else:
+            self.font_small = _ttf(small_face, small_sz)
+
+    # --- Row fitting helper ---
+
+    def _row_plan(self, rows, avail_h, gap=0):
+        """Given an ordered list of (key, font) tuples, return the prefix whose
+        summed line heights (+ gap between rows) fits in avail_h. Rows are assumed
+        to be ordered by priority (highest first). Always returns at least the
+        first row so the layout is never blank.
+
+        Returns: (selected_rows, total_height)
+        """
+        if not rows:
+            return [], 0
+        selected = []
+        total = 0
+        for i, (_, font) in enumerate(rows):
+            lh = self._lh(font)
+            candidate_total = total + lh + (gap if selected else 0)
+            if candidate_total > avail_h and selected:
+                break
+            selected.append(rows[i])
+            total = candidate_total
+        return selected, total
 
     # --- Drawing primitives ---
 
@@ -345,34 +392,35 @@ class FlightRenderer:
         except Exception:
             pass
 
-        large_lh = self._lh(self.font_large)
-        small_lh = self._lh(self.font_small)
-
-        # Distribute rows: 3 large + 2 small, vertically centered
-        rows_h = large_lh * 3 + small_lh * 2
-        y = max(1, (h - rows_h) // 2)
-
-        # Row 1: Airline name (truncated to info zone width)
-        name_text = self._truncate(draw, null_safe(airline_name), self.font_large, info_w - 4)
-        self._draw(draw, name_text, (info_x + 2, y), self.font_large, self.header_color)
-        y += large_lh
-        # Row 2: Route IATA-IATA
+        # Build priority-ordered info rows; drop lowest priority if they don't fit.
         route = f"{origin}-{dest}" if origin != "---" and dest != "---" else "---"
-        self._draw(draw, route, (info_x + 2, y), self.font_large, self.header_color)
-        y += large_lh
-        # Row 3: Aircraft type
+        name_text = self._truncate(draw, null_safe(airline_name), self.font_large, info_w - 4)
         type_text = self._truncate(draw, null_safe(atype, default="---"), self.font_large, info_w - 4)
-        self._draw(draw, type_text, (info_x + 2, y), self.font_large, self.header_color)
-        y += large_lh
-        # Row 4: Origin full name
+
+        info_candidates = [
+            ("name", self.font_large, name_text, self.header_color),
+            ("route", self.font_large, route, self.header_color),
+            ("atype", self.font_large, type_text, self.header_color),
+        ]
         if origin_full:
-            self._draw(draw, self._truncate(draw, origin_full, self.font_small, info_w - 4),
-                       (info_x + 2, y), self.font_small, self.airport_color)
-        y += small_lh
-        # Row 5: Dest full name
+            info_candidates.append(("origin_full", self.font_small,
+                                    self._truncate(draw, origin_full, self.font_small, info_w - 4),
+                                    self.airport_color))
         if dest_full:
-            self._draw(draw, self._truncate(draw, dest_full, self.font_small, info_w - 4),
-                       (info_x + 2, y), self.font_small, self.airport_color)
+            info_candidates.append(("dest_full", self.font_small,
+                                    self._truncate(draw, dest_full, self.font_small, info_w - 4),
+                                    self.airport_color))
+
+        plan_input = [(key, font) for (key, font, _text, _color) in info_candidates]
+        selected, rows_h = self._row_plan(plan_input, h - 2)
+        selected_keys = {k for (k, _f) in selected}
+
+        y = max(1, (h - rows_h) // 2)
+        for key, font, text, color in info_candidates:
+            if key not in selected_keys:
+                continue
+            self._draw(draw, text, (info_x + 2, y), font, color)
+            y += self._lh(font)
 
         # --- METRICS ZONE ---
         alt_v = self._fmt_alt(_get("altitude"))
@@ -380,16 +428,19 @@ class FlightRenderer:
         trk_v = self._fmt_trk(_get("heading"))
         vr_v = self._fmt_vr(_get("vertical_rate"), arrows=False)
 
-        metric_rows = [
+        all_metrics = [
             f"Alt: {alt_v}",
             f"Spd: {spd_v}",
             f"Trk: {trk_v}",
             f"Vr: {vr_v}",
         ]
+        # Fit as many metric rows as the height allows (min 1)
+        metric_lh = self._lh(self.font_small)
+        max_metric_rows = max(1, min(len(all_metrics), h // max(1, metric_lh)))
+        metric_rows = all_metrics[:max_metric_rows]
         row_h = h // len(metric_rows)
         for i, text in enumerate(metric_rows):
             my = i * row_h + (row_h - self._fh(self.font_small)) // 2
-            # Right-align within metrics zone
             tw = self._tw(draw, text, self.font_small)
             mx = metric_x + metric_w - tw - 2
             self._draw(draw, text, (max(metric_x, mx), my), self.font_small, self.metric_color)
@@ -454,37 +505,31 @@ class FlightRenderer:
         atype = _get("aircraft_type", "") or "---"
         callsign = tf.identifier
 
-        med_lh = self._lh(self.font_medium)
-        sm_lh = self._lh(self.font_small)
-
-        # 5 rows: 3 medium + 2 small, centered vertically
-        rows_h = med_lh * 3 + sm_lh * 2
-        y = max(0, (h - rows_h) // 2)
-
-        # Row 1: Callsign
-        self._draw(draw, callsign, (text_x + 2, y), self.font_medium, self.header_color)
-        y += med_lh
-
-        # Row 2: Route IATA-IATA
+        # Priority-ordered rows; drop lowest priority if they don't fit.
         route = f"{origin}-{dest}" if origin != "---" and dest != "---" else "---"
-        self._draw(draw, route, (text_x + 2, y), self.font_medium, self.header_color)
-        y += med_lh
-
-        # Row 3: Aircraft type (short, max 8 chars)
         atype_short = atype[:8] if atype != "---" else "---"
-        self._draw(draw, atype_short, (text_x + 2, y), self.font_medium, self.header_color)
-        y += med_lh
-
-        # Row 4: Alt + Spd packed
         alt_v = self._fmt_alt(_get("altitude"))
         spd_v = self._fmt_spd(_get("speed"))
-        self._draw(draw, f"Alt:{alt_v},Spd:{spd_v}", (text_x + 2, y), self.font_small, self.metric_color)
-        y += sm_lh
-
-        # Row 5: Trk + Vr packed
         trk_v = self._fmt_trk(_get("heading"))
         vr_v = self._fmt_vr(_get("vertical_rate"), arrows=False)
-        self._draw(draw, f"Trk:{trk_v},Vr:{vr_v}", (text_x + 2, y), self.font_small, self.metric_color)
+
+        candidates = [
+            ("callsign", self.font_medium, callsign, self.header_color),
+            ("route", self.font_medium, route, self.header_color),
+            ("alt_spd", self.font_small, f"Alt:{alt_v},Spd:{spd_v}", self.metric_color),
+            ("atype", self.font_medium, atype_short, self.header_color),
+            ("trk_vr", self.font_small, f"Trk:{trk_v},Vr:{vr_v}", self.metric_color),
+        ]
+        plan_input = [(k, f) for (k, f, _t, _c) in candidates]
+        selected, rows_h = self._row_plan(plan_input, h)
+        selected_keys = {k for (k, _f) in selected}
+
+        y = max(0, (h - rows_h) // 2)
+        for key, font, text, color in candidates:
+            if key not in selected_keys:
+                continue
+            self._draw(draw, text, (text_x + 2, y), font, color)
+            y += self._lh(font)
 
         self.dm.image = img.copy()
         self.dm.update_display()
@@ -527,32 +572,43 @@ class FlightRenderer:
 
         rx = logo_w + 1  # right zone text start
 
-        # --- Row 1: Callsign (altitude-colored) + counter ---
+        # Adaptive top rows: callsign (P1), route/atype (P2), distance (P3). Bottom
+        # metrics row is always drawn bottom-anchored and must not collide.
+        top_candidates = [
+            ("callsign", self.font_medium),
+            ("route", self.font_medium),
+            ("dist", self.font_medium),
+        ]
+        bottom_reserved = self._fh(self.font_small) + 3  # bottom row + margin
+        top_avail = h - 2 - bottom_reserved
+        selected, _ = self._row_plan(top_candidates, top_avail, gap=0)
+        selected_keys = {k for (k, _f) in selected}
+
         y = 2
-        self._draw(draw, callsign, (rx, y), self.font_medium, color)
-        counter = f"{index + 1}/{total_count}"
-        cw = self._tw(draw, counter, self.font_small)
-        self._draw(draw, counter, (w - cw - 2, y + 1), self.font_small, (80, 80, 80))
+        if "callsign" in selected_keys:
+            self._draw(draw, callsign, (rx, y), self.font_medium, color)
+            counter = f"{index + 1}/{total_count}"
+            cw = self._tw(draw, counter, self.font_small)
+            self._draw(draw, counter, (w - cw - 2, y + 1), self.font_small, (80, 80, 80))
+            y += self._lh(self.font_medium)
 
-        # --- Row 2: Route (blue) or aircraft type ---
-        y = 2 + self._lh(self.font_medium) + 1
-        if origin and destination:
-            route = f"{origin} > {destination}"
-            self._draw(draw, route, (rx, y), self.font_medium, self.route_color)
-            # Aircraft type after route if room
-            if atype and atype != "Unknown":
-                rw_used = self._tw(draw, route, self.font_medium) + 8
-                if rx + rw_used + self._tw(draw, atype, self.font_small) < w - 2:
-                    self._draw(draw, atype, (rx + rw_used, y + 2), self.font_small, (100, 100, 100))
-        elif atype and atype != "Unknown":
-            self._draw(draw, atype, (rx, y), self.font_medium, (100, 100, 100))
+        if "route" in selected_keys:
+            if origin and destination:
+                route = f"{origin} > {destination}"
+                self._draw(draw, route, (rx, y), self.font_medium, self.route_color)
+                if atype and atype != "Unknown":
+                    rw_used = self._tw(draw, route, self.font_medium) + 8
+                    if rx + rw_used + self._tw(draw, atype, self.font_small) < w - 2:
+                        self._draw(draw, atype, (rx + rw_used, y + 2), self.font_small, (100, 100, 100))
+            elif atype and atype != "Unknown":
+                self._draw(draw, atype, (rx, y), self.font_medium, (100, 100, 100))
+            y += self._lh(self.font_medium)
 
-        # --- Row 3: Distance (amber, with label) ---
-        y = 2 + (self._lh(self.font_medium) + 1) * 2
-        self._draw(draw, "DST", (rx, y), self.font_small, (255, 255, 255))
-        self._draw(draw, dist, (rx + self._tw(draw, "DST ", self.font_small), y), self.font_medium, (220, 170, 0))
+        if "dist" in selected_keys:
+            self._draw(draw, "DST", (rx, y), self.font_small, (255, 255, 255))
+            self._draw(draw, dist, (rx + self._tw(draw, "DST ", self.font_small), y), self.font_medium, (220, 170, 0))
 
-        # --- Row 4: Labeled metrics in small font (clip to available width) ---
+        # --- Bottom row: Labeled metrics in small font (clip to available width) ---
         y = h - self._fh(self.font_small) - 2
         label_color = (255, 255, 255)
         value_color = (180, 180, 180)
@@ -614,30 +670,42 @@ class FlightRenderer:
 
         rx = logo_w + 1
 
-        # --- Row 1: Title badge + callsign ---
+        # Adaptive top rows: title+callsign (P1), hero stat (P1), route/atype (P3).
+        # Bottom metrics row is always drawn bottom-anchored.
+        top_candidates = [
+            ("title", self.font_medium),
+            ("hero", self.font_medium),
+            ("route", self.font_medium),
+        ]
+        bottom_reserved = self._fh(self.font_small) + 3
+        top_avail = h - 2 - bottom_reserved
+        selected, _ = self._row_plan(top_candidates, top_avail, gap=0)
+        selected_keys = {k for (k, _f) in selected}
+
         y = 2
-        self._draw(draw, title, (rx, y), self.font_medium, title_color)
-        cs_x = rx + self._tw(draw, title, self.font_medium) + 6
-        self._draw(draw, callsign, (cs_x, y), self.font_medium, color)
+        if "title" in selected_keys:
+            self._draw(draw, title, (rx, y), self.font_medium, title_color)
+            cs_x = rx + self._tw(draw, title, self.font_medium) + 6
+            self._draw(draw, callsign, (cs_x, y), self.font_medium, color)
+            y += self._lh(self.font_medium)
 
-        # --- Row 2: Hero stat (large, colored) ---
-        y = 2 + self._lh(self.font_medium) + 2
-        self._draw(draw, stat_label, (rx, y), self.font_small, (255, 255, 255))
-        lbl_w = self._tw(draw, stat_label + " ", self.font_small)
-        self._draw(draw, stat_value, (rx + lbl_w, y), self.font_medium, title_color)
+        if "hero" in selected_keys:
+            self._draw(draw, stat_label, (rx, y), self.font_small, (255, 255, 255))
+            lbl_w = self._tw(draw, stat_label + " ", self.font_small)
+            self._draw(draw, stat_value, (rx + lbl_w, y), self.font_medium, title_color)
+            y += self._lh(self.font_medium)
 
-        # --- Row 3: Route or aircraft type ---
-        y = 2 + (self._lh(self.font_medium) + 2) * 2
-        if origin and destination and origin != "Unknown" and destination != "Unknown":
-            self._draw(draw, f"{origin} > {destination}", (rx, y), self.font_medium, self.route_color)
-            if aircraft_type and aircraft_type != "Unknown":
-                rt_w = self._tw(draw, f"{origin} > {destination}", self.font_medium) + 8
-                if rx + rt_w + self._tw(draw, aircraft_type, self.font_small) < w - 2:
-                    self._draw(draw, aircraft_type, (rx + rt_w, y + 2), self.font_small, (130, 130, 130))
-        elif aircraft_type and aircraft_type != "Unknown":
-            self._draw(draw, aircraft_type, (rx, y), self.font_medium, (130, 130, 130))
+        if "route" in selected_keys:
+            if origin and destination and origin != "Unknown" and destination != "Unknown":
+                self._draw(draw, f"{origin} > {destination}", (rx, y), self.font_medium, self.route_color)
+                if aircraft_type and aircraft_type != "Unknown":
+                    rt_w = self._tw(draw, f"{origin} > {destination}", self.font_medium) + 8
+                    if rx + rt_w + self._tw(draw, aircraft_type, self.font_small) < w - 2:
+                        self._draw(draw, aircraft_type, (rx + rt_w, y + 2), self.font_small, (130, 130, 130))
+            elif aircraft_type and aircraft_type != "Unknown":
+                self._draw(draw, aircraft_type, (rx, y), self.font_medium, (130, 130, 130))
 
-        # --- Row 4: Complementary metrics (exclude the hero stat to avoid duplication) ---
+        # --- Bottom row: Complementary metrics (exclude the hero stat) ---
         y = h - self._fh(self.font_small) - 2
         label_color = (255, 255, 255)
         value_color = (180, 180, 180)

--- a/plugins/masters-tournament/manager.py
+++ b/plugins/masters-tournament/manager.py
@@ -21,9 +21,11 @@ from masters_renderer import MastersRenderer
 from masters_renderer_enhanced import MastersRendererEnhanced
 from logo_loader import MastersLogoLoader
 from masters_helpers import (
+    AUGUSTA_HOLES,
     calculate_tournament_countdown,
     filter_favorite_players,
     get_detailed_phase,
+    get_score_description,
     get_tournament_phase,
     sort_leaderboard,
 )
@@ -132,6 +134,15 @@ class MastersTournamentPlugin(BasePlugin):
         self._player_card_index = 0
         self._last_player_card_advance = 0.0
         self._player_card_interval = config.get("player_card_duration", 8)
+
+        # Live alert detection — track score changes between updates
+        self._previous_scores: Dict[str, int] = {}  # player_name -> score
+        self._alert_queue: List[Dict] = []  # pending birdie/eagle alerts
+        self._alert_index = 0
+        self._last_alert_advance = 0.0
+        self._alert_dwell = config.get("display_modes", {}).get(
+            "live_action", {}
+        ).get("duration", 10)
 
         # Vegas scroll mode: fixed card block width. Cards render at
         # (scroll_card_width × display_height) regardless of the panel width
@@ -331,6 +342,9 @@ class MastersTournamentPlugin(BasePlugin):
 
         sorted_board = sort_leaderboard(raw_leaderboard)
 
+        # Detect score changes for live alerts before filtering
+        self._detect_score_changes(sorted_board)
+
         favorites = self.config.get("favorite_players", [])
         top_n = self.config.get("display_modes", {}).get("leaderboard", {}).get("top_n", 10)
         always_show = self.config.get("display_modes", {}).get("leaderboard", {}).get(
@@ -341,6 +355,50 @@ class MastersTournamentPlugin(BasePlugin):
             sorted_board, favorites, top_n=top_n, always_show_favorites=always_show
         )
         self.logger.debug(f"Updated leaderboard with {len(self._leaderboard_data)} players")
+
+    def _detect_score_changes(self, leaderboard: List[Dict]) -> None:
+        """Compare current scores against previous update to detect birdies/eagles.
+
+        Only generates alerts for score improvements (birdie or better).
+        Uses the player's current_hole and Augusta's hole pars to determine
+        whether the score change was a birdie, eagle, or albatross.
+        """
+        new_scores: Dict[str, int] = {}
+        new_alerts: List[Dict] = []
+
+        for player in leaderboard:
+            name = player.get("player", "")
+            score = player.get("score", 0)
+            hole = player.get("current_hole") or 0
+            new_scores[name] = score
+
+            if not self._previous_scores or name not in self._previous_scores:
+                continue
+
+            prev_score = self._previous_scores[name]
+            change = score - prev_score  # negative = improvement
+            if change >= 0:
+                continue
+
+            # Use hole par to get an accurate description
+            hole_par = AUGUSTA_HOLES.get(hole, {}).get("par", 4)
+            desc = get_score_description(change, hole_par)
+
+            # Only alert on birdie or better
+            if desc in ("Birdie", "Eagle", "Albatross"):
+                new_alerts.append({
+                    "player": name,
+                    "hole": hole,
+                    "score_desc": desc,
+                })
+                self.logger.info(f"Live alert: {name} {desc} on hole {hole}")
+
+        self._previous_scores = new_scores
+
+        if new_alerts:
+            self._alert_queue = new_alerts
+            self._alert_index = 0
+            self._last_alert_advance = time.time()
 
     def _update_schedule(self):
         """Update schedule data from API."""
@@ -483,9 +541,32 @@ class MastersTournamentPlugin(BasePlugin):
         )
 
     def _display_live_action(self, force_clear: bool) -> bool:
-        """Show live alert if enhanced renderer available, else leaderboard."""
-        if hasattr(self.renderer, "render_live_alert") and self._leaderboard_data:
-            # Show the leader's current status as a live alert
+        """Show live birdie/eagle alerts, falling back to the leader."""
+        if not hasattr(self.renderer, "render_live_alert"):
+            return self._display_leaderboard(force_clear)
+
+        # Rotate through queued alerts on a dwell timer
+        if self._alert_queue:
+            now = time.time()
+            if now - self._last_alert_advance >= self._alert_dwell:
+                self._alert_index += 1
+                self._last_alert_advance = now
+            # Expire the queue once we've shown all alerts
+            if self._alert_index >= len(self._alert_queue):
+                self._alert_queue = []
+                self._alert_index = 0
+            else:
+                alert = self._alert_queue[self._alert_index]
+                return self._show_image(
+                    self.renderer.render_live_alert(
+                        alert["player"],
+                        alert["hole"],
+                        alert["score_desc"],
+                    )
+                )
+
+        # No pending alerts — show the leader's current status
+        if self._leaderboard_data:
             leader = self._leaderboard_data[0]
             return self._show_image(
                 self.renderer.render_live_alert(

--- a/plugins/masters-tournament/manager.py
+++ b/plugins/masters-tournament/manager.py
@@ -144,8 +144,9 @@ class MastersTournamentPlugin(BasePlugin):
         self._last_player_card_advance = 0.0
         self._player_card_interval = config.get("player_card_duration", 8)
 
-        # Live alert detection — track score changes between updates
+        # Live alert detection — track score and hole state between updates
         self._previous_scores: Dict[str, int] = {}  # player_name -> score
+        self._previous_thru: Dict[str, int] = {}  # player_name -> thru (holes completed)
         self._alert_queue: List[Dict] = []  # pending birdie/eagle alerts
         self._alert_index = 0
         self._last_alert_advance = 0.0
@@ -374,32 +375,49 @@ class MastersTournamentPlugin(BasePlugin):
     def _detect_score_changes(self, leaderboard: List[Dict]) -> None:
         """Compare current scores against previous update to detect birdies/eagles.
 
-        Only generates alerts for score improvements (birdie or better).
-        Uses the player's current_hole and Augusta's hole pars to determine
-        whether the score change was a birdie, eagle, or albatross.
+        Only generates alerts when exactly one hole was completed since the last
+        poll (previous_thru + 1 == current_thru). When multiple holes elapsed
+        between polls the aggregate delta can't be attributed to a single hole,
+        so we skip the alert and just update stored state.
         """
         new_scores: Dict[str, int] = {}
+        new_thru: Dict[str, int] = {}
         new_alerts: List[Dict] = []
 
         for player in leaderboard:
             name = player.get("player", "")
             score = player.get("score", 0)
             hole = player.get("current_hole") or 0
+            thru = player.get("thru", 0)
+            if isinstance(thru, str):
+                try:
+                    thru = int(thru) if thru.strip() not in ("", "F", "-") else 0
+                except ValueError:
+                    thru = 0
             new_scores[name] = score
+            new_thru[name] = thru
 
             if not self._previous_scores or name not in self._previous_scores:
                 continue
 
             prev_score = self._previous_scores[name]
+            prev_thru = self._previous_thru.get(name, 0)
+
             change = score - prev_score  # negative = improvement
             if change >= 0:
                 continue
 
-            # Use hole par to get an accurate description
+            # Only classify when exactly one hole was completed since last poll
+            if thru != prev_thru + 1:
+                self.logger.debug(
+                    f"Skipping alert for {name}: thru jumped {prev_thru}->{thru} "
+                    f"(score {prev_score}->{score})"
+                )
+                continue
+
             hole_par = AUGUSTA_HOLES.get(hole, {}).get("par", 4)
             desc = get_score_description(change, hole_par)
 
-            # Only alert on birdie or better
             if desc in ("Birdie", "Eagle", "Albatross"):
                 new_alerts.append({
                     "player": name,
@@ -409,6 +427,7 @@ class MastersTournamentPlugin(BasePlugin):
                 self.logger.info(f"Live alert: {name} {desc} on hole {hole}")
 
         self._previous_scores = new_scores
+        self._previous_thru = new_thru
 
         if new_alerts:
             self._alert_queue = new_alerts

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -104,7 +104,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-09",
+  "last_updated": "2026-04-10",
   "compatible_versions": [
     ">=2.0.0"
   ]

--- a/plugins/masters-tournament/masters_renderer.py
+++ b/plugins/masters-tournament/masters_renderer.py
@@ -1103,6 +1103,9 @@ class MastersRenderer:
         for word in words:
             # Break oversized words into chunks that fit.
             if self._text_width(draw, word, font) > max_w:
+                if current_line:
+                    lines.append(current_line)
+                    current_line = ""
                 for ch in word:
                     test = current_line + ch
                     if self._text_width(draw, test, font) <= max_w:


### PR DESCRIPTION
## Summary
- Fixes text-row overlap on 32px-tall panels across all flight detail/area/stats layouts.
- Adds adaptive row dropping via a priority-ordered `_row_plan()` helper — rows that don't fit on short displays are dropped lowest-priority first rather than overlapping.
- Makes the font tier selection width-aware: the 16pt `font_large` tier now requires both `height>=64` and `width>=192`, so 128×64 wide-mode no longer picks a font too large for its info zone.
- Truncates the route string (e.g. `JFK-LAX`) to the info-zone width; previously only airline name and aircraft type were truncated, so the route could overrun into the metrics zone.
- Adds optional `fonts.large_size` / `fonts.medium_size` / `fonts.small_size` config overrides (0 = auto).
- Bumps `ledmatrix-flights` to `1.4.0`.

Note: this branch was split off from `fix/masters-wrap-text-and-manifest`, so the diff includes two earlier masters-tournament commits (`17333f0`, `9ad0c67`) that are already in that branch/PR.

## Test plan
- [ ] Sideload on a 64×32 panel, confirm area/stats/condensed layouts show 2–3 rows without overlap
- [ ] Sideload on a 128×32 panel, confirm route truncation and no cross-zone overrun
- [ ] Sideload on a 128×64 panel in condensed mode (default auto-pick) to confirm no regression
- [ ] Try setting `fonts.medium_size = 8` in config and verify the override applies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable font size overrides for the LED Matrix Flights plugin
  * Implemented adaptive layout scaling for LED Matrix Flights that adjusts content based on available display space
  * Introduced live birdie and eagle score alerts for the Masters Tournament plugin

* **Bug Fixes**
  * Fixed text wrapping behavior in the Masters Tournament display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->