### PR TITLE
feat(masters): phase-aware Vegas scroll, crisp countdown rendering, stale-date guard (v2.5.0)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -702,7 +702,7 @@
       "last_updated": "2026-04-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.4.4"
+      "latest_version": "2.4.5"
     },
     {
       "id": "web-ui-info",

--- a/plugins.json
+++ b/plugins.json
@@ -699,10 +699,10 @@
       "plugin_path": "plugins/masters-tournament",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-19",
+      "last_updated": "2026-04-21",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.4.5"
+      "latest_version": "2.4.6"
     },
     {
       "id": "web-ui-info",

--- a/plugins.json
+++ b/plugins.json
@@ -702,7 +702,7 @@
       "last_updated": "2026-04-21",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.4.6"
+      "latest_version": "2.5.0"
     },
     {
       "id": "web-ui-info",

--- a/plugins.json
+++ b/plugins.json
@@ -699,10 +699,10 @@
       "plugin_path": "plugins/masters-tournament",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-16",
+      "last_updated": "2026-04-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.4.3"
+      "latest_version": "2.4.4"
     },
     {
       "id": "web-ui-info",

--- a/plugins/masters-tournament/manager.py
+++ b/plugins/masters-tournament/manager.py
@@ -709,6 +709,12 @@ class MastersTournamentPlugin(BasePlugin):
                 return None
             meta = self._tournament_meta or {}
             target = meta.get("start_date")
+            # If the cached start_date is already in the past (stale meta from a
+            # prior year), treat it as missing so we fall back to the computed date.
+            if target is not None:
+                t_aware = target if target.tzinfo else target.replace(tzinfo=timezone.utc)
+                if t_aware <= datetime.now(timezone.utc):
+                    target = None
             if target is None:
                 target = self.data_source._computed_fallback_meta().get("start_date")
             if not target:

--- a/plugins/masters-tournament/manager.py
+++ b/plugins/masters-tournament/manager.py
@@ -685,11 +685,46 @@ class MastersTournamentPlugin(BasePlugin):
         this gives you a smoothly-scrolling ticker of ~128-wide blocks
         instead of one full-panel card at a time. Matches the pattern used
         by the other sports scoreboard plugins.
+
+        Content is phase-aware:
+          off-season / pre-tournament  → countdown card only
+          practice / tournament / post → leaderboard + holes + fun facts
         """
-        cards = []
+        meta_start, meta_end = self._meta_dates()
+        phase = get_detailed_phase(
+            start_date=meta_start,
+            end_date=meta_end,
+            post_tournament_display_days=self._post_tournament_display_days,
+        )
+
         cw = self._scroll_card_width
         ch = self.display_height
 
+        # Off-season and pre-tournament: countdown card only.
+        if phase in ("off-season", "pre-tournament"):
+            countdown_enabled = self.config.get("display_modes", {}).get(
+                "countdown", {}
+            ).get("enabled", True)
+            if not countdown_enabled:
+                return None
+            meta = self._tournament_meta or {}
+            target = meta.get("start_date")
+            if target is None:
+                target = self.data_source._computed_fallback_meta().get("start_date")
+            if not target:
+                return None
+            countdown = calculate_tournament_countdown(target)
+            card = self.renderer.render_countdown(
+                countdown["days"], countdown["hours"], countdown["minutes"]
+            )
+            if not card:
+                return None
+            if card.size != (cw, ch):
+                card = card.resize((cw, ch), Image.Resampling.LANCZOS)
+            return [card]
+
+        # Practice / tournament / post-tournament: leaderboard + holes + fun facts.
+        cards = []
         for player in self._leaderboard_data[:10]:
             card = self.renderer.render_player_card(
                 player, card_width=cw, card_height=ch,
@@ -707,8 +742,6 @@ class MastersTournamentPlugin(BasePlugin):
             if card:
                 cards.append(card)
 
-        # Fun facts — respect user's enabled setting.
-        # Use single-line wide cards so horizontal scroll reveals the full text.
         fun_facts_enabled = self.config.get("display_modes", {}).get(
             "fun_facts", {}
         ).get("enabled", True)

--- a/plugins/masters-tournament/manager.py
+++ b/plugins/masters-tournament/manager.py
@@ -715,12 +715,11 @@ class MastersTournamentPlugin(BasePlugin):
                 return None
             countdown = calculate_tournament_countdown(target)
             card = self.renderer.render_countdown(
-                countdown["days"], countdown["hours"], countdown["minutes"]
+                countdown["days"], countdown["hours"], countdown["minutes"],
+                card_width=cw, card_height=ch,
             )
             if not card:
                 return None
-            if card.size != (cw, ch):
-                card = card.resize((cw, ch), Image.Resampling.LANCZOS)
             return [card]
 
         # Practice / tournament / post-tournament: leaderboard + holes + fun facts.

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.4.5",
+      "released": "2026-04-19",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.4.4",
       "released": "2026-04-19",

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.4.6",
+  "version": "2.5.0",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.5.0",
+      "released": "2026-04-21",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.4.6",
       "released": "2026-04-21",

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.4.6",
+      "released": "2026-04-21",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.4.5",
       "released": "2026-04-19",
@@ -134,7 +139,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-19",
+  "last_updated": "2026-04-21",
   "compatible_versions": [
     ">=2.0.0"
   ]

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.4.4",
+      "released": "2026-04-19",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.4.3",
       "released": "2026-04-16",
@@ -124,7 +129,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-16",
+  "last_updated": "2026-04-19",
   "compatible_versions": [
     ">=2.0.0"
   ]

--- a/plugins/masters-tournament/masters_data.py
+++ b/plugins/masters-tournament/masters_data.py
@@ -209,6 +209,14 @@ class MastersDataSource:
                 # of that calendar day so phase checks treat all of Sunday's
                 # play as in-tournament rather than post-tournament.
                 end_date = end_date + timedelta(hours=23, minutes=59, seconds=59)
+            if start_date is not None and end_date is not None:
+                # Cap end_date to Sunday of tournament week. ESPN keeps the
+                # event active for days after the final round (results/stats
+                # pages), which causes the plugin to think the tournament is
+                # still running. The Masters always ends on Sunday = start + 3d.
+                max_end = start_date + timedelta(days=3, hours=23, minutes=59, seconds=59)
+                if end_date > max_end:
+                    end_date = max_end
 
             status_obj = {}
             competitions = event.get("competitions", [])

--- a/plugins/masters-tournament/masters_renderer.py
+++ b/plugins/masters-tournament/masters_renderer.py
@@ -340,12 +340,12 @@ class MastersRenderer:
             self.font_header = _load_font("small")
             self.font_score = _load_font("small")
 
-        # Countdown gets its own font — always the largest that fits the display
-        # height so the number dominates the screen regardless of the tier
-        # overrides above (wide-short panels especially benefit from this).
-        if self.height >= 20:
+        # Countdown gets its own font — largest that fits both height and width.
+        # "xl" is 10px PressStart2P; on narrow panels (tier != "large") that
+        # overflows long strings like "364d 12h", so gate it on tier too.
+        if self.height >= 20 and self.tier == "large":
             self.font_countdown = _load_font("xl")      # 10px PressStart2P
-        elif self.height >= 14:
+        elif self.height >= 14 and self.tier != "tiny":
             self.font_countdown = _load_font("medium")  # 8px PressStart2P
         else:
             self.font_countdown = _load_font("small")   # 6px 4x6-font
@@ -1442,8 +1442,13 @@ class MastersRenderer:
         if logo:
             img.paste(logo, (lx, ly), logo if logo.mode == "RGBA" else None)
 
-    def render_countdown(self, days: int, hours: int, minutes: int) -> Optional[Image.Image]:
-        img = self._draw_gradient_bg(COLORS["masters_dark"], COLORS["masters_green"])
+    def render_countdown(self, days: int, hours: int, minutes: int,
+                         card_width: Optional[int] = None,
+                         card_height: Optional[int] = None) -> Optional[Image.Image]:
+        w = card_width if card_width is not None else self.width
+        h = card_height if card_height is not None else self.height
+        img = self._draw_gradient_bg(COLORS["masters_dark"], COLORS["masters_green"],
+                                     width=w, height=h)
         draw = ImageDraw.Draw(img)
 
         # Countdown text — show days + hours for context, hours:minutes when
@@ -1465,25 +1470,25 @@ class MastersRenderer:
         min_right_width = 40
         if self.tier == "large":
             logo = self.logo_loader.get_masters_logo(
-                max_width=int(self.width * 0.45),
-                max_height=self.height - 4,
+                max_width=int(w * 0.45),
+                max_height=h - 4,
             )
-            if logo and (self.width - logo.width - 12) >= min_right_width:
+            if logo and (w - logo.width - 12) >= min_right_width:
                 lx = 3
-                ly = (self.height - logo.height) // 2
+                ly = (h - logo.height) // 2
                 self._draw_logo_with_glow(img, logo, lx, ly)
                 right_x = lx + logo.width + 6
-                right_w = self.width - right_x - 2
+                right_w = w - right_x - 2
                 right_cx = right_x + right_w // 2
 
                 detail_h = self._text_height(draw, "A", self.font_detail)
                 count_h = self._text_height(draw, count_text, self.font_countdown)
                 # Big number on top, label underneath
                 block_h = count_h + 3 + detail_h
-                block_y = max(2, (self.height - block_h) // 2)
+                block_y = max(2, (h - block_h) // 2)
 
-                cw = self._text_width(draw, count_text, self.font_countdown)
-                self._text_shadow(draw, (right_cx - cw // 2, block_y),
+                tw = self._text_width(draw, count_text, self.font_countdown)
+                self._text_shadow(draw, (right_cx - tw // 2, block_y),
                                   count_text, self.font_countdown, COLORS["masters_yellow"])
 
                 label = unit_text
@@ -1497,17 +1502,17 @@ class MastersRenderer:
 
         # Compact layout: logo centered at top (larger), countdown below
         logo = self.logo_loader.get_masters_logo(
-            max_width=min(self.width - 6, 56),
-            max_height=min(int(self.height * 0.45), 28),
+            max_width=min(w - 6, 56),
+            max_height=min(int(h * 0.45), 28),
         )
         logo_bottom = 3
         if logo:
-            lx = (self.width - logo.width) // 2
+            lx = (w - logo.width) // 2
             self._draw_logo_with_glow(img, logo, lx, 2)
             logo_bottom = 2 + logo.height + 2
 
         # Position text below logo: label once, then big countdown
-        remaining = self.height - logo_bottom
+        remaining = h - logo_bottom
         detail_h = self._text_height(draw, "A", self.font_detail)
         count_h = self._text_height(draw, count_text, self.font_countdown)
 
@@ -1519,12 +1524,12 @@ class MastersRenderer:
         text_block_h = count_h + 2 + detail_h
         text_y = logo_bottom + max(0, (remaining - text_block_h) // 2)
 
-        cw = self._text_width(draw, count_text, self.font_countdown)
-        self._text_shadow(draw, ((self.width - cw) // 2, text_y),
+        tw = self._text_width(draw, count_text, self.font_countdown)
+        self._text_shadow(draw, ((w - tw) // 2, text_y),
                           count_text, self.font_countdown, COLORS["masters_yellow"])
 
         lw = self._text_width(draw, label, self.font_detail)
-        draw.text(((self.width - lw) // 2, text_y + count_h + 2),
+        draw.text(((w - lw) // 2, text_y + count_h + 2),
                   label, fill=COLORS["light_gray"], font=self.font_detail)
 
         return img

--- a/plugins/masters-tournament/masters_renderer.py
+++ b/plugins/masters-tournament/masters_renderer.py
@@ -340,6 +340,16 @@ class MastersRenderer:
             self.font_header = _load_font("small")
             self.font_score = _load_font("small")
 
+        # Countdown gets its own font — always the largest that fits the display
+        # height so the number dominates the screen regardless of the tier
+        # overrides above (wide-short panels especially benefit from this).
+        if self.height >= 20:
+            self.font_countdown = _load_font("xl")      # 10px PressStart2P
+        elif self.height >= 14:
+            self.font_countdown = _load_font("medium")  # 8px PressStart2P
+        else:
+            self.font_countdown = _load_font("small")   # 6px 4x6-font
+
     # ═══════════════════════════════════════════════════════════
     # DRAWING HELPERS
     # ═══════════════════════════════════════════════════════════
@@ -1467,14 +1477,14 @@ class MastersRenderer:
                 right_cx = right_x + right_w // 2
 
                 detail_h = self._text_height(draw, "A", self.font_detail)
-                count_h = self._text_height(draw, count_text, self.font_score)
+                count_h = self._text_height(draw, count_text, self.font_countdown)
                 # Big number on top, label underneath
                 block_h = count_h + 3 + detail_h
                 block_y = max(2, (self.height - block_h) // 2)
 
-                cw = self._text_width(draw, count_text, self.font_score)
+                cw = self._text_width(draw, count_text, self.font_countdown)
                 self._text_shadow(draw, (right_cx - cw // 2, block_y),
-                                  count_text, self.font_score, COLORS["masters_yellow"])
+                                  count_text, self.font_countdown, COLORS["masters_yellow"])
 
                 label = unit_text
                 lw = self._text_width(draw, label, self.font_detail)
@@ -1499,7 +1509,7 @@ class MastersRenderer:
         # Position text below logo: label once, then big countdown
         remaining = self.height - logo_bottom
         detail_h = self._text_height(draw, "A", self.font_detail)
-        count_h = self._text_height(draw, count_text, self.font_score)
+        count_h = self._text_height(draw, count_text, self.font_countdown)
 
         if self.tier == "tiny":
             label = "TO MASTERS"
@@ -1509,9 +1519,9 @@ class MastersRenderer:
         text_block_h = count_h + 2 + detail_h
         text_y = logo_bottom + max(0, (remaining - text_block_h) // 2)
 
-        cw = self._text_width(draw, count_text, self.font_score)
+        cw = self._text_width(draw, count_text, self.font_countdown)
         self._text_shadow(draw, ((self.width - cw) // 2, text_y),
-                          count_text, self.font_score, COLORS["masters_yellow"])
+                          count_text, self.font_countdown, COLORS["masters_yellow"])
 
         lw = self._text_width(draw, label, self.font_detail)
         draw.text(((self.width - lw) // 2, text_y + count_h + 2),


### PR DESCRIPTION
## Summary

- **Vegas scroll phase-aware** — `get_vegas_content()` previously rendered the full leaderboard and course cards regardless of tournament phase. Off-season and pre-tournament now show a countdown card only; practice/tournament/post-tournament show the full leaderboard + hole + fun-fact strip.
- **Countdown card drawn at scroll size** — `render_countdown()` now accepts optional `card_width`/`card_height` params (matching `render_player_card`/`render_hole_card`), so Vegas scroll draws the card at the target dimensions directly instead of post-scaling a full-panel render with LANCZOS (which blurred pixel fonts).
- **Larger countdown font on wide-short displays** — Added a dedicated `font_countdown` so the countdown number uses a large font independently of the compact leaderboard font override applied on wide-short panels like 192×32.
- **Narrow-panel font guard** — `font_countdown` now gates "xl" (10px PressStart2P) on `tier == "large"` (width > 64). Narrow-tall panels (e.g. 32×64, 64×64) previously selected xl and overflowed on long strings like "364d 12h"; they now get "medium" (8px).
- **ESPN `endDate` cap** — ESPN keeps the Masters event active post-tournament and extends `endDate` well past Sunday, causing the plugin to stay in tournament phase and never transition to countdown. Fixed by capping parsed `endDate` to `start_date + 3 days 23:59:59` in `_parse_leaderboard_event()`, preventing an annual stale-cache bug.
- **Off-season countdown weighting** — `PHASE_MODES["off-season"]` now lists `masters_countdown` 3× (out of 10 entries) so it gets ~30% of screen time during the off-season rotation.
- **`_computed_fallback_meta()` microseconds** — Fixed `thu_midnight_edt` to zero microseconds to avoid sub-second drift in phase boundary calculations.
- **Non-ASCII character** — Replaced `×` (U+00D7) with `x` in an inline comment to satisfy RUF003 linter.
- **Narrowed broad `except`** — `get_player_headshot()` download path now catches only `(requests.exceptions.RequestException, UnidentifiedImageError, OSError)` instead of bare `Exception`.

## Files changed

| File | Change |
|---|---|
| `manager.py` | Phase-aware `get_vegas_content()`, countdown called with `card_width`/`card_height`, off-season countdown weighting |
| `masters_renderer.py` | `render_countdown()` `card_width`/`card_height` params, `font_countdown` with tier+height guard |
| `masters_data.py` | ESPN `endDate` cap, `_computed_fallback_meta()` microsecond fix |
| `masters_helpers.py` | Non-ASCII comment fix |
| `logo_loader.py` | Narrowed broad `except` in headshot download |
| `manifest.json` | Version bumps 2.4.3 → 2.4.6 |

## Test plan

- [ ] Off-season: Vegas scroll shows countdown card only (no leaderboard or hole cards)
- [ ] Pre-tournament: same countdown-only behavior
- [ ] During tournament: Vegas scroll shows leaderboard + holes + fun facts
- [ ] Post-tournament (within configured days): leaderboard cards visible
- [ ] Post-tournament (beyond configured days): transitions to countdown
- [ ] 192×32 display: countdown number renders at 10px, crisp (no blur)
- [ ] 32×64 or 64×64 display: countdown text fits without overflow
- [ ] Confirm `endDate` cap prevents stale phase after tournament Sunday

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Masters Tournament plugin now shows phase-aware content: countdown-only cards in off-season/pre-tournament and full leaderboard/cards during active phases.

* **Bug Fixes**
  * Tournament end date clamped to the expected tournament week to avoid extended displays.

* **Chores**
  * Masters Tournament plugin bumped to 2.5.0; global plugin metadata updated (including lacrosse-scoreboard to 1.2.1) and overall plugins list timestamp refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->