### PR TITLE
feat(store): add NFL Draft plugin by sarjent

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -658,6 +658,30 @@
       "latest_version": "1.2.3"
     },
     {
+      "id": "nfl-draft",
+      "name": "NFL Draft",
+      "description": "Displays projected NFL draft picks from ESPN with live draft tracking support during the annual NFL Draft event. Shows team logos, player names, positions, and pick numbers in a scrolling display.",
+      "author": "sarjent",
+      "category": "sports",
+      "tags": [
+        "nfl",
+        "draft",
+        "football",
+        "sports",
+        "espn"
+      ],
+      "repo": "https://github.com/sarjent/ledmatrix-nfl-draft",
+      "branch": "main",
+      "plugin_path": "",
+      "stars": 0,
+      "downloads": 0,
+      "last_updated": "2026-04-22",
+      "verified": false,
+      "screenshot": "",
+      "latest_version": "1.3.2",
+      "icon": "fas fa-football-ball"
+    },
+    {
       "id": "pga-tour-leaderboard",
       "name": "PGA Tour Leaderboard",
       "description": "Displays the PGA Tour leaderboard using ESPN data with horizontal scrolling. Shows tournament info, holes completed, and active players. Falls back to the most recent completed tournament when no event is live.",


### PR DESCRIPTION
## Summary

Adds [`sarjent/ledmatrix-nfl-draft`](https://github.com/sarjent/ledmatrix-nfl-draft) to the plugin store registry as a third-party plugin.

**Plugin:** NFL Draft (v1.3.2)
**Author:** sarjent
**Category:** Sports

### What it does
- Displays projected NFL draft picks (Tankathon mock draft) during the off-season
- Switches to live ESPN draft data during the draft window (April 20–27)
- Scrolling display of team logos, player names, positions, pick numbers
- Highlights the next pick in green during active drafting
- Favorite team prioritization, adjustable fonts, scroll speeds

### Registry entry
- `repo`: `https://github.com/sarjent/ledmatrix-nfl-draft`
- `plugin_path`: `""` (external repo, not in monorepo)
- `verified`: `false` (third-party)
- `latest_version`: `1.3.2`

## Test plan
- [ ] Plugin appears in the web UI plugin store
- [ ] Install succeeds and plugin loads without errors
- [ ] Draft display shows during draft window / mock draft shows outside window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NFL Draft plugin featuring ESPN-powered projected picks and live draft tracking for football fans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->