### PR TITLE
fix(calendar): bump to 1.1.1 — migrate OAuth from deprecated OOB to loopback

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-21",
+  "last_updated": "2026-04-24",
   "plugins": [
     {
       "id": "hello-world",
@@ -181,10 +181,10 @@
       "plugin_path": "plugins/calendar",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-02-25",
+      "last_updated": "2026-04-24",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.1.0"
+      "latest_version": "1.1.1"
     },
     {
       "id": "hockey-scoreboard",

--- a/plugins/calendar/manifest.json
+++ b/plugins/calendar/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "calendar",
   "name": "Google Calendar",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "ChuckBuilds",
   "description": "Display upcoming events from Google Calendar with date, time, and event details. Shows next 1-3 events with automatic rotation and timezone support.",
   "category": "productivity",
@@ -36,6 +36,11 @@
   ],
   "versions": [
     {
+      "released": "2026-04-24",
+      "version": "1.1.1",
+      "ledmatrix_min": "2.0.0"
+    },
+    {
       "released": "2026-03-02",
       "version": "1.1.0",
       "ledmatrix_min_version": "2.0.0"
@@ -46,7 +51,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-03-02",
+  "last_updated": "2026-04-24",
   "stars": 0,
   "downloads": 0,
   "verified": true,


### PR DESCRIPTION
## Summary
- Google blocked the out-of-band (OOB) OAuth flow (`urn:ietf:wg:oauth:2.0:oob`) producing \"Access blocked: invalid_request\" when users click \"Step 2: Authenticate with Google\"
- The plugin source already uses the loopback redirect (`http://127.0.0.1`) in \`calendar_registration.py\`, but the manifest version was never bumped from 1.1.0, so the store did not offer installed plugins the fixed code
- Bumps manifest to 1.1.1 so installations upgrade off the broken OOB flow
- Pre-commit hook synced \`plugins.json\` automatically

## Test plan
- [ ] Update the calendar plugin from the store on a device running 1.1.0
- [ ] Click \"Step 2: Authenticate with Google\" — expect a working Google consent screen (no \"Access blocked\" error)
- [ ] Complete authentication, verify \`token.pickle\` is created and the calendar list loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Calendar plugin updated to version 1.1.1, released April 24, 2026, with minimum ledmatrix 2.0.0 requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->