### PR TITLE
fix(masters): dynamic font fallback prevents countdown hours from being clipped (v2.5.1)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-28",
+  "last_updated": "2026-05-04",
   "plugins": [
     {
       "id": "hello-world",
@@ -699,10 +699,10 @@
       "plugin_path": "plugins/masters-tournament",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-21",
+      "last_updated": "2026-05-04",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.5.0"
+      "latest_version": "2.5.1"
     },
     {
       "id": "web-ui-info",

--- a/plugins/masters-tournament/manifest.json
+++ b/plugins/masters-tournament/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "masters-tournament",
   "name": "Masters Tournament",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Broadcast-quality Masters Tournament display with real ESPN player headshots, accurate Augusta National hole layouts, fun facts, past champions, live leaderboards, and pixel-perfect LED matrix rendering",
   "author": "ChuckBuilds",
   "class_name": "MastersTournamentPlugin",
@@ -43,6 +43,11 @@
     "height": 64
   },
   "versions": [
+    {
+      "version": "2.5.1",
+      "released": "2026-05-04",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "2.5.0",
       "released": "2026-04-21",
@@ -144,7 +149,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-21",
+  "last_updated": "2026-05-04",
   "compatible_versions": [
     ">=2.0.0"
   ]

--- a/plugins/masters-tournament/masters_renderer.py
+++ b/plugins/masters-tournament/masters_renderer.py
@@ -1482,14 +1482,24 @@ class MastersRenderer:
                 right_cx = right_x + right_w // 2
 
                 detail_h = self._text_height(draw, "A", self.font_detail)
-                count_h = self._text_height(draw, count_text, self.font_countdown)
+
+                # Fall back to a smaller font if count_text overflows the right column
+                countdown_font = self.font_countdown
+                tw = self._text_width(draw, count_text, countdown_font)
+                if tw > right_w:
+                    countdown_font = self.font_score
+                    tw = self._text_width(draw, count_text, countdown_font)
+                    if tw > right_w:
+                        countdown_font = self.font_detail
+                        tw = self._text_width(draw, count_text, countdown_font)
+
+                count_h = self._text_height(draw, count_text, countdown_font)
                 # Big number on top, label underneath
                 block_h = count_h + 3 + detail_h
                 block_y = max(2, (h - block_h) // 2)
 
-                tw = self._text_width(draw, count_text, self.font_countdown)
                 self._text_shadow(draw, (right_cx - tw // 2, block_y),
-                                  count_text, self.font_countdown, COLORS["masters_yellow"])
+                                  count_text, countdown_font, COLORS["masters_yellow"])
 
                 label = unit_text
                 lw = self._text_width(draw, label, self.font_detail)


### PR DESCRIPTION
## Summary

- The two-column countdown layout rendered the big number (`"365d 23h"`, `"12h:30"`, etc.) at the xl (10 px PressStart2P) font with no check that the text fit within the right-column width
- Long strings overflowed the column, clipping the hours portion on the right edge of the display
- Fix cascades through `font_countdown → font_score → font_detail` (descending size), using the first font whose rendered width fits `right_w` — matching the guard already in place for the label text beneath it

## Test plan

- [ ] Countdown enabled on a large display (width > 64 px) — verify `"Xd Yh"` text renders fully without clipping at all days/hours combinations
- [ ] Verify compact layout (small/tiny tier) is unaffected
- [ ] Verify label fallback (`"TO MASTERS"`) still triggers correctly when label overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced countdown text rendering with dynamic font sizing to prevent overflow and ensure optimal display within available space.

* **Chores**
  * Released masters-tournament plugin version 2.5.1 with improved countdown display performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->