### PR TITLE
fix(nfl-draft): correct post-draft window when year rolls to next season (v1.3.10)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-28",
+  "last_updated": "2026-05-04",
   "plugins": [
     {
       "id": "hello-world",
@@ -768,10 +768,10 @@
       "plugin_path": "plugins/nfl-draft",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-26",
+      "last_updated": "2026-05-04",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.3.9",
+      "latest_version": "1.3.10",
       "icon": "fas fa-football-ball"
     }
   ]

--- a/plugins/nfl-draft/manager.py
+++ b/plugins/nfl-draft/manager.py
@@ -197,11 +197,21 @@ class NFLDraftPlugin(BasePlugin):
     def _get_current_draft_year(self) -> int:
         """Determine the current/upcoming draft year."""
         now = datetime.now()
-        # If before May, show current year's draft
-        # If May or later, show next year's draft
-        if now.month < 5:
-            return now.year
-        return now.year + 1
+        year = now.year
+        # Stay on the current year's draft until its post-draft window has closed.
+        # Using a hard month cutoff (< 5) would flip to next year on May 1 — before
+        # the window expires — causing _is_post_draft_window() to compute dates for
+        # the wrong year. Instead, compute the actual window end and advance only
+        # after it has passed.
+        post_draft_days = self.config.get("post_draft_days", 7)
+        last_april = datetime(year, 4, 30)
+        days_back = (last_april.weekday() - 5) % 7
+        draft_end = (last_april - timedelta(days=days_back)).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+        if now > draft_end + timedelta(days=post_draft_days):
+            return year + 1
+        return year
 
     def _fetch_draft_data(self) -> Dict[str, Any]:
         """
@@ -730,8 +740,26 @@ class NFLDraftPlugin(BasePlugin):
         """True if the draft just completed and we are within the post_draft_days window."""
         if self.draft_status != "complete":
             return False
-        window_end = self._get_draft_end_date() + timedelta(days=self.post_draft_days)
-        return datetime.now() <= window_end
+        # Anchor the window to the most recently *completed* draft, not simply
+        # now.year. Using now.year naively fails in Jan-Apr of the following year:
+        # the current year's draft hasn't happened yet, so last_april would point
+        # to a future date and window_end would be months away — keeping the plugin
+        # active all winter. Instead, compute this year's draft_end first; if now
+        # is still before it, the most recent completed draft was last year.
+        now = datetime.now()
+        probe = datetime(now.year, 4, 30)
+        probe_days_back = (probe.weekday() - 5) % 7
+        this_year_draft_end = (probe - timedelta(days=probe_days_back)).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+        completed_year = now.year if now > this_year_draft_end else now.year - 1
+        last_april = datetime(completed_year, 4, 30)
+        days_back = (last_april.weekday() - 5) % 7
+        draft_end = (last_april - timedelta(days=days_back)).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+        window_end = draft_end + timedelta(days=self.post_draft_days)
+        return now <= window_end
 
     def _is_off_season(self) -> bool:
         """True during the NFL off-season (May through January).

--- a/plugins/nfl-draft/manifest.json
+++ b/plugins/nfl-draft/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "nfl-draft",
   "name": "NFL Draft",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "author": "ChuckBuilds",
   "description": "Displays projected NFL draft picks from ESPN with live draft tracking support during the annual NFL Draft event. Includes simulate_live mode to replay a completed draft using real ESPN core API data. Shows team logos, player names, positions, and pick numbers in a scrolling display.",
   "entry_point": "manager.py",
@@ -24,6 +24,11 @@
   ],
   "icon": "fas fa-football-ball",
   "versions": [
+    {
+      "version": "1.3.10",
+      "released": "2026-05-04",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "version": "1.3.9",
       "released": "2026-04-26",


### PR DESCRIPTION
## Summary

- The ESPN draft site API has no `{year}` in its URL — it always returns the most recently completed draft as `state="post"` → `draft_status="complete"`
- `_get_current_draft_year()` flipped `draft_year` to the next season on May 1st (hardcoded `month < 5` cutoff), before the post-draft window closed
- This caused `_is_post_draft_window()` to call `_get_draft_end_date()` with next year's April date, pushing `window_end` ~12 months into the future — the plugin kept rotating through draft picks indefinitely instead of going silent

## Fixes

**`_is_post_draft_window()`** — now computes the window against the current calendar year directly, independent of `self.draft_year`:
```python
now = datetime.now()
last_april = datetime(now.year, 4, 30)
# ... compute draft_end from last Saturday of April ...
window_end = draft_end + timedelta(days=self.post_draft_days)
return now <= window_end
```

**`_get_current_draft_year()`** — delays the year rollover until the post-draft window has actually closed (using `post_draft_days` from config), so `draft_year` stays accurate for cache keys and prospect fetches during the overlap window.

## Test plan

- [ ] Verify plugin goes silent when run after the post-draft window expires (e.g. today, May 4 with `post_draft_days: 7` and a window that closed May 2)
- [ ] Verify plugin still shows results when run within the post-draft window (e.g. `post_draft_days: 30` from April 25 → May 25)
- [ ] Verify `draft_year` resolves to the correct year on both sides of the window boundary
- [ ] Verify live-draft and simulate modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NFL Draft plugin updated to version 1.3.10. Fixed an issue where the plugin would incorrectly transition to the next draft season during May when the post-draft window for the current year was still active. Improved draft year and post-draft period timing calculations for more accurate seasonal tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->