### PR TITLE
feat(flights): add adsb.fi/adsb.lol free cloud ADS-B sources (v1.5.0)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -491,7 +491,7 @@
       "last_updated": "2026-05-06",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.5.1"
+      "latest_version": "1.5.2"
     },
     {
       "id": "christmas-countdown",

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-04",
+  "last_updated": "2026-05-06",
   "plugins": [
     {
       "id": "hello-world",
@@ -472,7 +472,7 @@
     {
       "id": "ledmatrix-flights",
       "name": "Flight Tracker",
-      "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
+      "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
       "author": "ChuckBuilds",
       "category": "custom",
       "tags": [
@@ -488,10 +488,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-04-14",
+      "last_updated": "2026-05-06",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.4.0"
+      "latest_version": "1.5.0"
     },
     {
       "id": "christmas-countdown",

--- a/plugins.json
+++ b/plugins.json
@@ -491,7 +491,7 @@
       "last_updated": "2026-05-06",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.5.0"
+      "latest_version": "1.5.1"
     },
     {
       "id": "christmas-countdown",

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -11,25 +11,25 @@
     },
     "data_source": {
       "type": "string",
-      "title": "Data Source",
-      "description": "Aircraft data source. 'skyaware' requires a local ADS-B receiver (dump1090/SkyAware). 'flightradar24' uses the FlightRadar24 feed. 'opensky' uses the free OpenSky Network API.",
+      "title": "Aircraft Data Source",
+      "description": "Where to get live aircraft position data. Choose one setup path: (1) Local receiver — 'skyaware': requires a PiAware/dump1090 ADS-B receiver on your network, most accurate data. (2) Free cloud — 'adsbfi': free global ADS-B feed from adsb.fi, no account or hardware needed. 'adsblol': same idea via adsb.lol. Both free cloud options work worldwide with no sign-up.",
       "enum": [
         "skyaware",
-        "flightradar24",
-        "opensky"
+        "adsbfi",
+        "adsblol"
       ],
       "default": "skyaware"
     },
     "fr24_enrichment": {
       "type": "boolean",
-      "title": "FR24 Route Enrichment",
-      "description": "When using SkyAware, also fetch origin/destination/aircraft type from FlightRadar24 in the background. Replaces the need for a FlightAware API key for route data.",
+      "title": "Free Route Data (FR24 Enrichment)",
+      "description": "Fetch origin/destination and aircraft type for free in the background using FlightRadar24 data. Works with all data sources. This is the recommended free alternative to a paid FlightAware API key — leave enabled unless you have a specific reason to turn it off.",
       "default": true
     },
     "fr24_enrichment_interval": {
       "type": "integer",
-      "title": "FR24 Enrichment Interval (seconds)",
-      "description": "How often (in seconds) to refresh FR24 enrichment data when using SkyAware as the primary data source.",
+      "title": "Route Data Refresh Interval (seconds)",
+      "description": "How often to refresh free FR24 route data in the background. Applies when fr24_enrichment is enabled.",
       "minimum": 30,
       "maximum": 600,
       "default": 60
@@ -55,7 +55,8 @@
     },
     "skyaware_url": {
       "type": "string",
-      "description": "URL to SkyAware aircraft.json endpoint (only used when data_source is 'skyaware')",
+      "title": "SkyAware / dump1090 URL",
+      "description": "URL to your local ADS-B receiver's aircraft.json endpoint. Only used when data_source is 'skyaware'. Change this to match your receiver's IP address.",
       "default": "http://192.168.86.30/skyaware/data/aircraft.json",
       "pattern": "^(https?://.*)?$"
     },
@@ -433,14 +434,13 @@
     },
     "enrichment_provider": {
       "type": "string",
-      "title": "Enrichment Provider",
-      "description": "Route enrichment source. 'auto': free sources first, FlightAware if key present. 'opensky': free OpenSky only. 'flightaware': requires API key.",
+      "title": "Route Enrichment Provider",
+      "description": "Fallback source for origin/destination data not covered by FR24 enrichment. 'adsbnet': free route lookups via adsb.lol — good coverage for major airlines, no account needed (recommended). 'flightaware': paid FlightAware AeroAPI — highest coverage but requires a paid subscription configured in the FlightAware section below.",
       "enum": [
-        "auto",
-        "opensky",
+        "adsbnet",
         "flightaware"
       ],
-      "default": "auto"
+      "default": "adsbnet"
     },
     "header_color": {
       "type": "array",
@@ -515,32 +515,32 @@
     },
     "opensky_username": {
       "type": "string",
-      "title": "OpenSky Username",
-      "description": "OpenSky Network username for higher rate limits (optional \u2014 works without for basic use).",
+      "title": "OpenSky Username (Advanced)",
+      "description": "OpenSky Network username. Only needed if you have manually set enrichment_provider to 'opensky' via direct config edit. Leave blank for the standard free setup.",
       "x-secret": true,
       "default": ""
     },
     "opensky_password": {
       "type": "string",
-      "title": "OpenSky Password",
-      "description": "OpenSky Network password.",
+      "title": "OpenSky Password (Advanced)",
+      "description": "OpenSky Network password. Only needed alongside opensky_username above.",
       "x-secret": true,
       "default": ""
     },
     "flightaware": {
       "type": "object",
       "title": "FlightAware AeroAPI (Paid - Optional)",
-      "description": "FlightAware AeroAPI provides detailed flight plan data (origin, destination, aircraft type). Requires a paid API subscription. Most users can skip this section \u2014 FR24 enrichment provides similar data for free.",
+      "description": "OPTIONAL PAID SERVICE \u2014 skip this section entirely unless you have a FlightAware AeroAPI subscription. Enabling this will make API calls that are billed at $0.005 each. Free route data via FR24 enrichment (above) works well for most users without any cost.",
       "properties": {
         "api_key": {
           "type": "string",
-          "description": "FlightAware AeroAPI key (optional \u2014 all features work without it via free data sources). Get your API key at https://flightaware.com/aeroapi/",
+          "description": "Your FlightAware AeroAPI key. Leave blank if you are not using FlightAware \u2014 the plugin works fully without this.",
           "x-secret": true,
           "default": ""
         },
         "enabled": {
           "type": "boolean",
-          "description": "Enable flight plan fetching from FlightAware API. Note: FR24 enrichment (fr24_enrichment) also provides origin/destination data for free without this setting.",
+          "description": "Enable paid FlightAware API calls. Must be true AND api_key must be set for FlightAware to be used. Disabled by default \u2014 do not enable unless you have a paid subscription.",
           "default": false
         },
         "max_api_calls_per_hour": {
@@ -630,8 +630,8 @@
     },
     "flightaware_api_key": {
       "type": "string",
-      "title": "FlightAware API Key (deprecated - use FlightAware section)",
-      "description": "Deprecated: moved to FlightAware section. Kept for backward compatibility.",
+      "title": "FlightAware API Key (deprecated)",
+      "description": "Deprecated — use the FlightAware section above instead. Kept only for backward compatibility with older configs.",
       "default": "",
       "x-secret": true
     },
@@ -702,21 +702,19 @@
   "x-propertyOrder": [
     "enabled",
     "data_source",
+    "skyaware_url",
+    "center_latitude",
+    "center_longitude",
+    "map_radius_miles",
+    "fr24_enrichment",
+    "fr24_enrichment_interval",
+    "enrichment_provider",
+    "route_cache_ttl",
     "display_mode",
     "display_duration",
     "update_interval",
     "live_priority",
-    "center_latitude",
-    "center_longitude",
-    "map_radius_miles",
     "zoom_factor",
-    "skyaware_url",
-    "fr24_enrichment",
-    "fr24_enrichment_interval",
-    "opensky_username",
-    "opensky_password",
-    "enrichment_provider",
-    "route_cache_ttl",
     "max_aircraft",
     "min_altitude_ft",
     "max_altitude_ft",
@@ -746,6 +744,8 @@
     "use_offline_database",
     "offline_database_auto_update",
     "offline_database_update_interval_days",
+    "opensky_username",
+    "opensky_password",
     "flightaware"
   ]
 }

--- a/plugins/ledmatrix-flights/enrichment/__init__.py
+++ b/plugins/ledmatrix-flights/enrichment/__init__.py
@@ -3,6 +3,7 @@
 from enrichment.base import EnrichmentProvider
 from enrichment.opensky import OpenSkyEnrichment
 from enrichment.flightaware import FlightAwareEnrichment
+from enrichment.adsbnet import AdsbNetEnrichment
 from enrichment.stub import StubEnrichment
 
 
@@ -10,19 +11,22 @@ def create_enrichment_provider(config: dict, cache_manager=None) -> EnrichmentPr
     """Factory: create the appropriate enrichment provider based on config.
 
     Priority:
-      - If ``enrichment_provider`` is ``"flightaware"`` AND a key is present: FlightAware
-      - If ``enrichment_provider`` is ``"opensky"`` or ``"auto"``: OpenSky (free)
+      - ``"flightaware"`` + key present: FlightAware AeroAPI (paid)
+      - ``"adsbnet"`` or ``"auto"`` (default): adsb.lol callsign lookup (free)
+      - ``"opensky"``: OpenSky Network (legacy, kept for manual config compat)
       - Fallback: StubEnrichment (no-op)
     """
-    provider = config.get("enrichment_provider", "auto")
+    provider = config.get("enrichment_provider", "adsbnet")
     fa_key = config.get("flightaware_api_key", "")
 
     if provider == "flightaware" and fa_key:
         return FlightAwareEnrichment(config, cache_manager)
 
-    if provider in ("auto", "opensky"):
-        # In auto mode, prefer OpenSky (free) but also return FlightAware if key is present
-        # The manager can chain them
+    if provider in ("adsbnet", "auto"):
+        route_ttl = config.get("route_cache_ttl", 300)
+        return AdsbNetEnrichment(cache_manager=cache_manager, route_cache_ttl=route_ttl)
+
+    if provider == "opensky":
         username = config.get("opensky_username", "")
         password = config.get("opensky_password", "")
         route_ttl = config.get("route_cache_ttl", 300)

--- a/plugins/ledmatrix-flights/enrichment/__init__.py
+++ b/plugins/ledmatrix-flights/enrichment/__init__.py
@@ -1,6 +1,10 @@
 """Enrichment providers for the Flight Tracker plugin."""
 
+import logging
+
 from enrichment.base import EnrichmentProvider
+
+logger = logging.getLogger(__name__)
 from enrichment.opensky import OpenSkyEnrichment
 from enrichment.flightaware import FlightAwareEnrichment
 from enrichment.adsbnet import AdsbNetEnrichment
@@ -19,8 +23,12 @@ def create_enrichment_provider(config: dict, cache_manager=None) -> EnrichmentPr
     provider = config.get("enrichment_provider", "adsbnet")
     fa_key = config.get("flightaware_api_key", "")
 
-    if provider == "flightaware" and fa_key:
-        return FlightAwareEnrichment(config, cache_manager)
+    if provider == "flightaware":
+        if fa_key:
+            return FlightAwareEnrichment(config, cache_manager)
+        # Key not configured — fall back to free adsbnet rather than silently no-op
+        logger.warning("[Flight Tracker] enrichment_provider=flightaware but no API key — falling back to adsbnet")
+        provider = "adsbnet"
 
     if provider in ("adsbnet", "auto"):
         route_ttl = config.get("route_cache_ttl", 300)

--- a/plugins/ledmatrix-flights/enrichment/adsbnet.py
+++ b/plugins/ledmatrix-flights/enrichment/adsbnet.py
@@ -1,0 +1,117 @@
+"""
+adsb.lol route enrichment provider (FREE).
+
+Uses the adsb.lol callsign endpoint which returns aircraft state plus route
+data from their accumulated flight database:
+  - /v2/callsign/{callsign} — aircraft matching a callsign, with optional route
+
+Route coverage is best for major commercial flights (AAL, UAL, DAL, etc.).
+Charter/private/cargo flights may have no route data — the provider returns
+whatever is available and gracefully omits missing fields.
+"""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from data_model import TrackedFlight
+from enrichment.base import EnrichmentProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AdsbNetEnrichment(EnrichmentProvider):
+    """Free route enrichment via adsb.lol callsign lookup."""
+
+    BASE_URL = "https://api.adsb.lol"
+
+    def __init__(self, cache_manager: Any = None, route_cache_ttl: int = 300):
+        self.cache_manager = cache_manager
+        self.route_cache_ttl = route_cache_ttl
+
+    def _get(self, endpoint: str) -> Optional[dict]:
+        url = f"{self.BASE_URL}{endpoint}"
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as e:
+            logger.warning(f"[Flight Tracker] adsbnet request failed ({endpoint}): {e}")
+            return None
+
+    def get_flight_route(self, callsign: str) -> Optional[Dict]:
+        """Look up route + aircraft type for a callsign via adsb.lol.
+
+        Returns a dict with available keys: origin, destination, aircraft_type, source.
+        Returns None if the callsign is not found at all.
+        """
+        if not callsign:
+            return None
+
+        cs = callsign.strip().upper()
+        cache_key = f"adsbnet_route_{cs}"
+
+        if self.cache_manager:
+            cached = self.cache_manager.get(cache_key, max_age=self.route_cache_ttl)
+            if cached:
+                return cached
+
+        data = self._get(f"/v2/callsign/{cs}")
+        if not data:
+            return None
+
+        aircraft = data.get("ac", [])
+        if not aircraft:
+            return None
+
+        ac = aircraft[0]
+        result: Dict[str, Any] = {"source": "adsbnet"}
+
+        aircraft_type = (ac.get("t") or "").strip()
+        if aircraft_type:
+            result["aircraft_type"] = aircraft_type
+
+        # route field: array like ["KJFK", "KLAX"] or ["KJFK-KLAX"] or absent
+        route = ac.get("route")
+        if isinstance(route, list) and len(route) >= 2:
+            result["origin"] = route[0].strip()
+            result["destination"] = route[-1].strip()
+        elif isinstance(route, list) and len(route) == 1:
+            # Sometimes packed as ["KJFK-KLAX"]
+            parts = route[0].split("-")
+            if len(parts) == 2:
+                result["origin"] = parts[0].strip()
+                result["destination"] = parts[1].strip()
+        elif isinstance(route, str) and "-" in route:
+            parts = route.split("-")
+            if len(parts) >= 2:
+                result["origin"] = parts[0].strip()
+                result["destination"] = parts[-1].strip()
+
+        if self.cache_manager:
+            self.cache_manager.set(cache_key, result)
+
+        return result
+
+    def lookup_tracked_flight(self, identifier: str) -> Optional[TrackedFlight]:
+        """Look up a tracked flight via adsb.lol."""
+        if not identifier:
+            return None
+
+        route = self.get_flight_route(identifier)
+        if not route:
+            return TrackedFlight(identifier=identifier, status="UNKNOWN")
+
+        return TrackedFlight(
+            identifier=identifier,
+            status="UNKNOWN",
+            origin=route.get("origin", ""),
+            destination=route.get("destination", ""),
+            last_updated=time.time(),
+        )
+
+    def get_airport_flights(self, airport_icao: str, mode: str = "arrival") -> List[Dict]:
+        """Not supported by adsb.lol — returns empty list."""
+        return []

--- a/plugins/ledmatrix-flights/fetcher.py
+++ b/plugins/ledmatrix-flights/fetcher.py
@@ -451,6 +451,113 @@ class OpenSkyFetcher(AircraftFetcher):
         return result
 
 
+# ---------------------------------------------------------------------------
+# adsb.fi / adsb.lol (free cloud ADS-B, ADSBexchange v2 format)
+# ---------------------------------------------------------------------------
+
+_ADSBNET_PROVIDERS = {
+    "adsbfi": ("https://opendata.adsb.fi/api", 250),
+    "adsblol": ("https://api.adsb.lol", 100),
+}
+
+
+class AdsbNetFetcher(AircraftFetcher):
+    """Fetch aircraft from adsb.fi or adsb.lol (free, no auth required).
+
+    Both services implement the ADSBexchange v2 response format.
+    Useful for users without a local ADS-B receiver.
+    """
+
+    def __init__(self, provider: str = "adsbfi", request_timeout: int = 10):
+        base_url, max_nm = _ADSBNET_PROVIDERS.get(provider, _ADSBNET_PROVIDERS["adsbfi"])
+        self.base_url = base_url
+        self.max_nm = max_nm
+        self.provider = provider
+        self.timeout = request_timeout
+
+    def fetch(self, center_lat, center_lon, radius_miles, altitude_colors):
+        # Convert statute miles → nautical miles, cap at provider limit
+        radius_nm = int(round(radius_miles * 0.868976))
+        if radius_nm > self.max_nm:
+            logger.warning(
+                f"[Flight Tracker] {self.provider}: radius {radius_nm}nm exceeds "
+                f"{self.max_nm}nm limit — capping"
+            )
+            radius_nm = self.max_nm
+
+        url = f"{self.base_url}/v2/lat/{center_lat}/lon/{center_lon}/dist/{radius_nm}"
+        try:
+            response = requests.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+        except Exception:
+            logger.exception(f"[Flight Tracker] {self.provider} fetch failed")
+            return None
+
+        aircraft_list = data.get("ac", [])
+        if not aircraft_list:
+            logger.info(f"[Flight Tracker] {self.provider}: no aircraft in range ({radius_miles}mi)")
+            return {}
+
+        current_time = time.time()
+        result: Dict[str, Dict] = {}
+
+        for ac in aircraft_list:
+            icao = (ac.get("hex") or "").upper().strip()
+            if not icao:
+                continue
+
+            lat = ac.get("lat")
+            lon = ac.get("lon")
+            if lat is None or lon is None:
+                continue
+
+            distance_miles = haversine_miles(lat, lon, center_lat, center_lon)
+            if distance_miles > radius_miles:
+                continue
+
+            alt_baro = ac.get("alt_baro")
+            alt_geom = ac.get("alt_geom")
+            if alt_baro == "ground":
+                altitude = 0
+            elif isinstance(alt_baro, (int, float)):
+                altitude = alt_baro
+            elif isinstance(alt_geom, (int, float)):
+                altitude = alt_geom
+            else:
+                altitude = 0
+
+            callsign = (ac.get("flight") or "").strip() or icao
+            speed = ac.get("gs", 0) or 0
+            heading = ac.get("track", ac.get("true_heading", 0)) or 0
+            registration = (ac.get("r") or "").strip()
+            aircraft_type = (ac.get("t") or "").strip() or "Unknown"
+            vertical_rate = ac.get("baro_rate", ac.get("geom_rate"))
+
+            color = altitude_to_color(altitude, altitude_colors)
+
+            result[icao] = {
+                "icao": icao,
+                "callsign": callsign,
+                "registration": registration,
+                "lat": lat,
+                "lon": lon,
+                "altitude": altitude,
+                "speed": speed,
+                "heading": heading,
+                "aircraft_type": aircraft_type,
+                "distance_miles": distance_miles,
+                "color": color,
+                "last_seen": current_time,
+                "vertical_rate": vertical_rate,
+            }
+
+        logger.info(
+            f"[Flight Tracker] {self.provider}: {len(result)} aircraft in range ({radius_miles}mi)"
+        )
+        return result
+
+
 def create_fetcher(config: Dict[str, Any], cache_manager: Any) -> AircraftFetcher:
     """Factory: create the appropriate fetcher based on config['data_source']."""
     source = config.get('data_source', 'skyaware')
@@ -461,6 +568,8 @@ def create_fetcher(config: Dict[str, Any], cache_manager: Any) -> AircraftFetche
         username = config.get('opensky_username', '')
         password = config.get('opensky_password', '')
         return OpenSkyFetcher(username=username, password=password)
+    elif source in ('adsbfi', 'adsblol'):
+        return AdsbNetFetcher(provider=source)
     else:
         url = config.get('skyaware_url', 'http://192.168.86.30/skyaware/data/aircraft.json')
         return SkyAwareFetcher(url, cache_manager)

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -842,11 +842,18 @@ class FlightTrackerPlugin(BasePlugin):
 
         The fetcher returns pre-normalized dicts (icao, callsign, aircraft_type, …)
         rather than raw SkyAware JSON, so this bypasses _process_aircraft_data.
+
+        Fetches with a wider stats radius so all_aircraft_data covers more than the
+        map display area, matching the SkyAware behaviour where stats are computed
+        from the full receiver range rather than just the map radius subset.
         """
+        # Fetch a wider area for stats (3× map radius, capped at 100 miles so we
+        # don't hammer the public API with enormous bounding boxes).
+        stats_radius = min(self.map_radius_miles * 3, 100)
         result = self._fetcher.fetch(
             self.center_lat,
             self.center_lon,
-            self.map_radius_miles,
+            stats_radius,
             self.altitude_colors,
         )
         if result is None:
@@ -874,10 +881,16 @@ class FlightTrackerPlugin(BasePlugin):
                         if field in existing and field not in new_info:
                             new_info[field] = existing[field]
 
+            # all_aircraft_data = full stats pool (everything in stats_radius)
+            # aircraft_data = map/area display (only within map_radius_miles)
             self.all_aircraft_data[icao] = new_info
-            self.aircraft_data[icao] = new_info
+            if new_info['distance_miles'] <= self.map_radius_miles:
+                self.aircraft_data[icao] = new_info
+            elif icao in self.aircraft_data:
+                del self.aircraft_data[icao]
+                self.aircraft_trails.pop(icao, None)
 
-            if self.show_trails:
+            if self.show_trails and new_info['distance_miles'] <= self.map_radius_miles:
                 if icao not in self.aircraft_trails:
                     self.aircraft_trails[icao] = []
                 self.aircraft_trails[icao].append((new_info['lat'], new_info['lon'], current_time))
@@ -928,6 +941,13 @@ class FlightTrackerPlugin(BasePlugin):
                     ac['airline_name'] = fr24_info['airline_name']
                 if not ac.get('fr24_id') and fr24_info.get('fr24_id'):
                     ac['fr24_id'] = fr24_info['fr24_id']
+
+                # Queue for FR24 detail fetch (airline full name, airport coords, timing)
+                fr24_id = ac.get('fr24_id')
+                if fr24_id and fr24_id not in self.pending_fr24_details:
+                    if self._is_callsign_worth_fetching(ac.get('callsign', '')):
+                        self.pending_fr24_details[fr24_id] = icao
+
                 matched += 1
 
         self.logger.info(f"[Flight Tracker] FR24 enrichment matched {matched}/{len(self.aircraft_data)} tracked aircraft")
@@ -1972,7 +1992,7 @@ class FlightTrackerPlugin(BasePlugin):
                 self.logger.info("[Flight Tracker] Fetching aircraft data from FlightRadar24")
                 self._update_from_fr24()
                 self.logger.info(f"[Flight Tracker] Currently tracking {len(self.aircraft_data)} aircraft")
-            elif self.data_source in ('adsbfi', 'adsblol'):
+            elif self.data_source in ('adsbfi', 'adsblol', 'opensky'):
                 self.logger.info(f"[Flight Tracker] Fetching aircraft data from {self.data_source}")
                 self._update_from_fetcher()
                 self.logger.info(f"[Flight Tracker] Currently tracking {len(self.aircraft_data)} aircraft")

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -837,6 +837,66 @@ class FlightTrackerPlugin(BasePlugin):
 
         self._update_flight_records()
 
+    def _update_from_fetcher(self) -> None:
+        """Fetch aircraft data via self._fetcher (adsbfi, adsblol, opensky) and integrate results.
+
+        The fetcher returns pre-normalized dicts (icao, callsign, aircraft_type, …)
+        rather than raw SkyAware JSON, so this bypasses _process_aircraft_data.
+        """
+        result = self._fetcher.fetch(
+            self.center_lat,
+            self.center_lon,
+            self.map_radius_miles,
+            self.altitude_colors,
+        )
+        if result is None:
+            self.logger.warning(f"[Flight Tracker] {self.data_source}: no data received")
+            return
+
+        current_time = time.time()
+        _ENRICH_PRESERVE = (
+            'origin', 'destination', 'airline_name', 'airline_icao',
+            'fr24_id', 'origin_lat', 'origin_lon', 'dest_lat', 'dest_lon', 'fr24_time',
+        )
+
+        for icao, new_info in result.items():
+            # Derive airline_icao from callsign prefix when not already set (e.g. UAL410 → UAL)
+            if not new_info.get('airline_icao'):
+                cs = new_info.get('callsign', '')
+                if cs and len(cs) >= 4 and cs[:3].isalpha() and cs[:3].upper() != cs.upper():
+                    new_info['airline_icao'] = cs[:3].upper()
+
+            # Preserve previously enriched fields (FR24 enrichment, adsbnet, etc.)
+            for store in (self.all_aircraft_data, self.aircraft_data):
+                existing = store.get(icao)
+                if existing:
+                    for field in _ENRICH_PRESERVE:
+                        if field in existing and field not in new_info:
+                            new_info[field] = existing[field]
+
+            self.all_aircraft_data[icao] = new_info
+            self.aircraft_data[icao] = new_info
+
+            if self.show_trails:
+                if icao not in self.aircraft_trails:
+                    self.aircraft_trails[icao] = []
+                self.aircraft_trails[icao].append((new_info['lat'], new_info['lon'], current_time))
+                if len(self.aircraft_trails[icao]) > self.trail_length:
+                    self.aircraft_trails[icao] = self.aircraft_trails[icao][-self.trail_length:]
+
+        # Remove stale aircraft
+        stale = [icao for icao, info in self.aircraft_data.items()
+                 if current_time - info['last_seen'] > 60]
+        for icao in stale:
+            del self.aircraft_data[icao]
+            self.aircraft_trails.pop(icao, None)
+        stale_all = [icao for icao, info in self.all_aircraft_data.items()
+                     if current_time - info['last_seen'] > 60]
+        for icao in stale_all:
+            del self.all_aircraft_data[icao]
+
+        self._update_flight_records()
+
     def _maybe_refresh_fr24_enrichment(self) -> None:
         """Enrichment mode: call FR24 feed on a slower cadence to fill in
         origin/destination/aircraft type for aircraft already tracked via SkyAware."""
@@ -1373,7 +1433,7 @@ class FlightTrackerPlugin(BasePlugin):
             for store in (self.all_aircraft_data, self.aircraft_data):
                 existing = store.get(icao)
                 if existing:
-                    for field in ('origin', 'destination', 'airline_name', 'fr24_id',
+                    for field in ('origin', 'destination', 'airline_name', 'airline_icao', 'fr24_id',
                                   'origin_lat', 'origin_lon', 'dest_lat', 'dest_lon', 'fr24_time'):
                         if field in existing and field not in aircraft_info:
                             aircraft_info[field] = existing[field]
@@ -1912,6 +1972,14 @@ class FlightTrackerPlugin(BasePlugin):
                 self.logger.info("[Flight Tracker] Fetching aircraft data from FlightRadar24")
                 self._update_from_fr24()
                 self.logger.info(f"[Flight Tracker] Currently tracking {len(self.aircraft_data)} aircraft")
+            elif self.data_source in ('adsbfi', 'adsblol'):
+                self.logger.info(f"[Flight Tracker] Fetching aircraft data from {self.data_source}")
+                self._update_from_fetcher()
+                self.logger.info(f"[Flight Tracker] Currently tracking {len(self.aircraft_data)} aircraft")
+                if self.fr24_enrichment:
+                    self._maybe_refresh_fr24_enrichment()
+                self._queue_interesting_callsigns()
+                self._enrich_from_offline_db()
             else:
                 self.logger.info(f"[Flight Tracker] Fetching aircraft data from {self.skyaware_url}")
                 data = self._fetch_aircraft_data()

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.4.0",
-  "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
+  "version": "1.5.0",
+  "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
   "class_name": "FlightTrackerPlugin",
@@ -35,6 +35,12 @@
   "max_ledmatrix_version": "3.0.0",
   "versions": [
     {
+      "released": "2026-05-06",
+      "version": "1.5.0",
+      "notes": "Add adsb.fi and adsb.lol as free cloud ADS-B data sources (no local receiver required); add adsbnet enrichment provider for free route lookups via adsb.lol",
+      "ledmatrix_min_version": "2.0.0"
+    },
+    {
       "released": "2026-04-14",
       "version": "1.4.0",
       "notes": "Scale flight detail/area/stats layouts across 32/48/64+ px heights via adaptive row dropping; add optional fonts.* size overrides",
@@ -57,5 +63,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-04-14"
+  "last_updated": "2026-05-06"
 }

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-05-06",
+      "version": "1.5.1",
+      "notes": "Fix adsbfi/adsblol data sources not being called (update loop was falling through to SkyAware path); fix airline_icao dropped from enrichment cache on each update cycle",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "released": "2026-05-06",
       "version": "1.5.0",

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-05-06",
+      "version": "1.5.2",
+      "notes": "Fix stats pool only covering map radius (fetch wider area, split all_aircraft_data vs aircraft_data); fix FR24 detail enrichment never queued for adsbfi/adsblol; fix flightaware enrichment with no key silently returning no-op instead of adsbnet fallback; fix opensky data_source bypassing fetcher",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "released": "2026-05-06",
       "version": "1.5.1",


### PR DESCRIPTION
## Summary

- **New data sources**: `adsbfi` and `adsblol` — free global ADS-B via adsb.fi and adsb.lol, no account or hardware required. Users without a local ADS-B receiver can now use the plugin for free.
- **New enrichment provider**: `adsbnet` — free route lookups via adsb.lol's callsign endpoint. Returns origin/destination for known commercial callsigns. Replaces OpenSky as the default free enrichment option.
- **Config UI cleanup**: Removed `flightradar24` and `opensky` from `data_source` enum to steer users toward the three supported paths (local SkyAware, free cloud adsb.fi/adsb.lol, paid FlightAware). FlightAware section now leads with an explicit paid-service warning. Property order reorganized so setup fields appear first and advanced/paid fields appear last.
- **Default change**: `enrichment_provider` default changed from `"auto"` (→ OpenSky) to `"adsbnet"` (→ adsb.lol, better coverage, no rate limits).

## Setup paths after this PR

| Path | `data_source` | `enrichment_provider` | Cost |
|---|---|---|---|
| Local receiver | `skyaware` | `adsbnet` (default) | Free |
| Free cloud | `adsbfi` or `adsblol` | `adsbnet` (default) | Free |
| Paid full coverage | `skyaware` or cloud | `flightaware` + API key | Paid |

## Files changed

- `plugins/ledmatrix-flights/fetcher.py` — `AdsbNetFetcher` class + factory update
- `plugins/ledmatrix-flights/enrichment/adsbnet.py` — new `AdsbNetEnrichment` provider
- `plugins/ledmatrix-flights/enrichment/__init__.py` — factory wiring, default updated
- `plugins/ledmatrix-flights/config_schema.json` — enum cleanup, descriptions, property order
- `plugins/ledmatrix-flights/manifest.json` — version bump 1.4.0 → 1.5.0
- `plugins.json` — registry synced by pre-commit hook

## Test plan

- [ ] Set `data_source: "adsbfi"`, verify aircraft appear at configured lat/lon radius
- [ ] Set `data_source: "adsblol"`, same check
- [ ] Set `enrichment_provider: "adsbnet"`, confirm a major airline callsign returns origin/destination
- [ ] Confirm `enrichment_provider: "adsbnet"` with unknown callsign shows blank route gracefully
- [ ] Confirm `data_source: "skyaware"` still works unchanged
- [ ] Confirm `enrichment_provider: "flightaware"` with no key falls back to adsbnet (no crash)
- [ ] Open plugin config in web UI — verify data_source shows 3 options, FlightAware section has paid warning, property order is logical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two free ADS‑B data sources (adsb.fi, adsb.lol) and integrated them into aircraft tracking.
  * Introduced AdsbNet as a route enrichment provider and added a corresponding fetcher path.
  * Exposed OpenSky username/password fields and clarified FlightAware AeroAPI (Paid - Optional).
  * Improved configuration layout and backward-compatible deprecated aliases.
  * Plugin metadata updated (version 1.5.1, refreshed description and last_updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->