### PR TITLE
fix(stock-news): add missing PIL import causing crash on display (v1.0.3)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-09",
+  "last_updated": "2026-05-15",
   "plugins": [
     {
       "id": "hello-world",
@@ -440,10 +440,10 @@
       "plugin_path": "plugins/stock-news",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2025-10-19",
+      "last_updated": "2026-05-15",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.2"
+      "latest_version": "1.0.3"
     },
     {
       "id": "stocks",

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -24,6 +24,7 @@ import re
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
 
 from src.plugin_system.base_plugin import BasePlugin
 

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "ChuckBuilds",
   "description": "Displays scrolling stock-specific news headlines and financial updates from RSS feeds, focused on market news and company updates",
   "entry_point": "manager.py",
@@ -25,12 +25,17 @@
   "plugin_path": "plugins/stock-news",
   "versions": [
     {
+      "released": "2026-05-15",
+      "version": "1.0.3",
+      "ledmatrix_min_version": "2.0.0"
+    },
+    {
       "released": "2025-10-19",
       "version": "1.0.2",
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2025-10-19",
+  "last_updated": "2026-05-15",
   "stars": 0,
   "downloads": 0,
   "verified": true,


### PR DESCRIPTION
## Summary

- `Image`, `ImageDraw`, and `ImageFont` were used throughout `manager.py` but never imported from Pillow, causing every display attempt to crash with `name 'Image' is not defined`
- Added `from PIL import Image, ImageDraw, ImageFont` to match the pattern used by every other rendering plugin (stocks, news, etc.)
- Bumped version `1.0.2 → 1.0.3`; `plugins.json` registry auto-updated by pre-commit hook

## Test plan

- [ ] Restart ledmatrix service and confirm `stock_news_ticker` mode displays headlines without errors
- [ ] Confirm no `name 'Image' is not defined` entries in the journal (`journalctl -u ledmatrix -f`)
- [ ] Confirm mode no longer falls through to `stocks` with "No content to display"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stock-news plugin to version 1.0.3
  * Refreshed plugin metadata timestamps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/ledmatrix-plugins/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->