### PR TITLE
feat(stock-news): full rewrite — real data, logos, spread fetching, display adaptation (v2.3.1)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -422,7 +422,7 @@
     {
       "id": "stock-news",
       "name": "Stock News Ticker",
-      "description": "Displays scrolling stock-specific news headlines and financial updates from RSS feeds, focused on market news and company updates",
+      "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
       "author": "ChuckBuilds",
       "category": "financial",
       "tags": [
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.1.0"
+      "latest_version": "2.0.0"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.1.0"
+      "latest_version": "2.2.0"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.2.0"
+      "latest_version": "2.3.0"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.3.2"
+      "latest_version": "2.3.3"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.3.0"
+      "latest_version": "2.3.1"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.0.0"
+      "latest_version": "2.1.0"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -422,7 +422,7 @@
     {
       "id": "stock-news",
       "name": "Stock News Ticker",
-      "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
+      "description": "Live stock headlines via Yahoo Finance search API with RSS fallback, company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
       "author": "ChuckBuilds",
       "category": "financial",
       "tags": [
@@ -443,7 +443,7 @@
       "last_updated": "2026-05-19",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.3.1"
+      "latest_version": "2.3.2"
     },
     {
       "id": "stocks",

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -128,6 +128,16 @@
           "maximum": 10,
           "description": "Number of full scroll cycles before rotating to the next headline"
         },
+        "shuffle_headlines": {
+          "type": "boolean",
+          "default": true,
+          "description": "Randomise headline order on fetch and after each full rotation cycle"
+        },
+        "show_publisher": {
+          "type": "boolean",
+          "default": true,
+          "description": "Append the news source (e.g. '• Reuters') after each headline"
+        },
         "max_headlines_per_symbol": {
           "type": "integer",
           "default": 1,

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -47,6 +47,11 @@
           "default": false,
           "description": "Show current market price (e.g. '$189.42') before the headline"
         },
+        "sync_with_stocks_plugin": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically track the same stocks watched in the Stock Ticker plugin (ledmatrix-stocks). Synced symbols are merged with any symbols configured above."
+        },
         "item_gap": {
           "type": "integer",
           "default": 0,
@@ -193,7 +198,7 @@
           "default": 2,
           "minimum": 1,
           "maximum": 10,
-          "description": "Data older than update_interval × this factor dims the ticker colours"
+          "description": "Data older than update_interval_seconds × this factor dims the ticker colours"
         },
         "logo_fetch_enabled": {
           "type": "boolean",
@@ -244,7 +249,7 @@
           "uniqueItems": true,
           "maxItems": 50,
           "default": ["AAPL", "GOOGL", "MSFT"],
-          "description": "Stock symbols — headlines fetched from Yahoo Finance. Fetches are spread across update_interval."
+          "description": "Stock symbols — headlines fetched from Yahoo Finance. Fetches are spread across update_interval_seconds."
         },
         "custom_feeds": {
           "type": "object",

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -202,10 +202,10 @@
         },
         "logo_size": {
           "type": "integer",
-          "default": 16,
-          "minimum": 8,
-          "maximum": 48,
-          "description": "Logo height in pixels (width scales proportionally)"
+          "default": 0,
+          "minimum": 0,
+          "maximum": 128,
+          "description": "Logo height in pixels. Set to 0 for auto (= display height). Width scales freely to maintain aspect ratio."
         },
         "logo_url_template": {
           "type": "string",

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -17,74 +17,71 @@
           "default": 30,
           "minimum": 10,
           "maximum": 300,
-          "description": "Duration in seconds to display the stock news ticker"
+          "description": "Duration in seconds to display the ticker when dynamic duration is disabled"
         },
-        "update_interval": {
+        "update_interval_seconds": {
           "type": "integer",
-          "default": 3600,
-          "minimum": 60,
-          "maximum": 3600,
-          "description": "How often to fetch new stock news headlines (seconds)"
+          "default": 900,
+          "minimum": 300,
+          "maximum": 7200,
+          "description": "How often to fetch fresh headlines (seconds). Default: 15 minutes"
+        },
+        "max_daily_requests": {
+          "type": "integer",
+          "default": 200,
+          "minimum": 10,
+          "maximum": 1000,
+          "description": "Maximum total RSS requests per day across all symbols and feeds"
+        },
+        "max_requests_per_hour": {
+          "type": "integer",
+          "default": 50,
+          "minimum": 5,
+          "maximum": 200,
+          "description": "Maximum RSS requests per rolling hour"
+        },
+        "display_style": {
+          "type": "string",
+          "enum": ["logo_and_ticker", "ticker_only", "logo_only"],
+          "default": "logo_and_ticker",
+          "description": "What to show per news item: logo + ticker text, text only, or logo + symbol only"
+        },
+        "logo_fetch_enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically download company logos and cache them to disk"
+        },
+        "logo_size": {
+          "type": "integer",
+          "default": 16,
+          "minimum": 8,
+          "maximum": 48,
+          "description": "Logo height in pixels (width scales proportionally to maintain aspect ratio)"
+        },
+        "logo_url_template": {
+          "type": "string",
+          "default": "https://financialmodelingprep.com/image-stock/{symbol}.png",
+          "description": "URL template for logo downloads. Use {symbol} as placeholder (e.g. AAPL)"
         },
         "scroll_speed": {
           "type": "number",
           "default": 1,
           "minimum": 0.1,
           "maximum": 10,
-          "description": "Scrolling speed multiplier"
+          "description": "Legacy scroll speed multiplier (used when scroll_pixels_per_second is not set)"
         },
         "scroll_delay": {
           "type": "number",
           "default": 0.01,
           "minimum": 0.001,
           "maximum": 0.1,
-          "description": "Delay between scroll steps in seconds"
-        },
-        "max_headlines_per_symbol": {
-          "type": "integer",
-          "default": 1,
-          "minimum": 1,
-          "maximum": 5,
-          "description": "Maximum headlines to show per stock symbol"
-        },
-        "headlines_per_rotation": {
-          "type": "integer",
-          "default": 2,
-          "minimum": 1,
-          "maximum": 10,
-          "description": "Number of headlines to show per rotation"
-        },
-        "dynamic_duration": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable dynamic duration based on content width"
-        },
-        "min_duration": {
-          "type": "integer",
-          "default": 30,
-          "minimum": 10,
-          "maximum": 300,
-          "description": "Minimum display duration when dynamic duration is enabled"
-        },
-        "max_duration": {
-          "type": "integer",
-          "default": 300,
-          "minimum": 30,
-          "maximum": 600,
-          "description": "Maximum display duration when dynamic duration is enabled"
-        },
-        "duration_buffer": {
-          "type": "number",
-          "default": 0.1,
-          "minimum": 0.01,
-          "maximum": 1.0,
-          "description": "Duration buffer for dynamic duration calculation"
+          "description": "Legacy delay between scroll steps in seconds (used when scroll_target_fps is not set)"
         },
         "scroll_pixels_per_second": {
           "type": "number",
           "default": 25.0,
           "minimum": 5.0,
-          "maximum": 50.0,
+          "maximum": 100.0,
           "description": "Scroll speed in pixels per second"
         },
         "scroll_target_fps": {
@@ -92,38 +89,65 @@
           "default": 100.0,
           "minimum": 30.0,
           "maximum": 200.0,
-          "description": "Target FPS for scrolling"
-        },
-        "scroll_mode": {
-          "type": "string",
-          "enum": ["one_shot", "continuous"],
-          "default": "one_shot",
-          "description": "Scrolling mode"
+          "description": "Target FPS for the scroll animation"
         },
         "scroll_direction": {
           "type": "string",
           "enum": ["left", "right"],
           "default": "left",
-          "description": "Scroll direction"
+          "description": "Direction the ticker scrolls"
         },
-        "enable_scroll_metrics": {
+        "dynamic_duration": {
           "type": "boolean",
-          "default": false,
-          "description": "Enable scroll performance metrics"
+          "default": true,
+          "description": "Automatically set display duration based on total content width"
+        },
+        "min_duration": {
+          "type": "integer",
+          "default": 30,
+          "minimum": 10,
+          "maximum": 300,
+          "description": "Minimum display duration when dynamic duration is enabled (seconds)"
+        },
+        "max_duration": {
+          "type": "integer",
+          "default": 300,
+          "minimum": 30,
+          "maximum": 600,
+          "description": "Maximum display duration when dynamic duration is enabled (seconds)"
+        },
+        "rotation_enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Rotate through headlines so each one gets screen time after each scroll cycle"
+        },
+        "rotation_threshold": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Number of full scroll cycles before rotating to the next headline"
+        },
+        "max_headlines_per_symbol": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 5,
+          "description": "Maximum headlines to show per stock symbol per update"
         },
         "headlines_per_rotation": {
           "type": "integer",
           "default": 2,
           "minimum": 1,
           "maximum": 10,
-          "description": "Number of headlines to show per rotation"
+          "description": "Maximum headlines to pull from each custom RSS feed"
         },
         "font_size": {
           "type": "integer",
           "default": 10,
           "minimum": 8,
           "maximum": 16,
-          "description": "Font size for headlines"
+          "description": "Font size for headline and symbol text (pixels)"
         },
         "background_service": {
           "type": "object",
@@ -138,21 +162,21 @@
               "default": 30,
               "minimum": 10,
               "maximum": 120,
-              "description": "Request timeout in seconds"
+              "description": "HTTP request timeout in seconds"
             },
             "max_retries": {
               "type": "integer",
-              "default": 5,
+              "default": 3,
               "minimum": 1,
               "maximum": 10,
-              "description": "Maximum number of retries for failed requests"
+              "description": "Maximum retries for failed requests"
             },
             "priority": {
               "type": "integer",
               "default": 2,
               "minimum": 1,
               "maximum": 5,
-              "description": "Priority for background requests (1=highest, 5=lowest)"
+              "description": "Background request priority (1=highest, 5=lowest)"
             }
           },
           "additionalProperties": false
@@ -167,13 +191,13 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[A-Z]{1,5}$",
-            "description": "Stock symbol (e.g., AAPL, GOOGL)"
+            "pattern": "^[A-Z]{1,10}$",
+            "description": "Stock ticker symbol (e.g. AAPL, GOOGL, BRK.B)"
           },
           "uniqueItems": true,
           "maxItems": 50,
           "default": ["AAPL", "GOOGL", "MSFT"],
-          "description": "List of stock symbols to track news for"
+          "description": "Stock symbols to fetch live headlines for (via Yahoo Finance RSS)"
         },
         "custom_feeds": {
           "type": "object",
@@ -185,15 +209,11 @@
             }
           },
           "additionalProperties": false,
-          "description": "Custom RSS feed URLs with user-defined names"
+          "description": "Additional RSS feeds keyed by display name (any financial RSS URL)"
         },
         "text_color": {
           "type": "array",
-          "items": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 255
-          },
+          "items": {"type": "integer", "minimum": 0, "maximum": 255},
           "minItems": 3,
           "maxItems": 3,
           "default": [0, 255, 0],
@@ -201,27 +221,11 @@
         },
         "symbol_color": {
           "type": "array",
-          "items": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 255
-          },
+          "items": {"type": "integer", "minimum": 0, "maximum": 255},
           "minItems": 3,
           "maxItems": 3,
           "default": [255, 255, 0],
-          "description": "RGB color for stock symbols"
-        },
-        "separator_color": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 255
-          },
-          "minItems": 3,
-          "maxItems": 3,
-          "default": [255, 0, 0],
-          "description": "RGB color for separators between headlines"
+          "description": "RGB color for stock symbol labels"
         }
       },
       "additionalProperties": false

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -11,96 +11,19 @@
     },
     "global": {
       "type": "object",
+      "title": "Display & Scroll Settings",
       "properties": {
         "display_duration": {
           "type": "number",
           "default": 30,
           "minimum": 10,
           "maximum": 300,
-          "description": "Duration in seconds to display the ticker when dynamic duration is disabled"
-        },
-        "update_interval_seconds": {
-          "type": "integer",
-          "default": 900,
-          "minimum": 300,
-          "maximum": 7200,
-          "description": "How often to fetch fresh headlines (seconds). Default: 15 minutes"
-        },
-        "max_daily_requests": {
-          "type": "integer",
-          "default": 200,
-          "minimum": 10,
-          "maximum": 1000,
-          "description": "Maximum total RSS requests per day across all symbols and feeds"
-        },
-        "max_requests_per_hour": {
-          "type": "integer",
-          "default": 50,
-          "minimum": 5,
-          "maximum": 200,
-          "description": "Maximum RSS requests per rolling hour"
-        },
-        "display_style": {
-          "type": "string",
-          "enum": ["logo_and_ticker", "ticker_only", "logo_only"],
-          "default": "logo_and_ticker",
-          "description": "What to show per news item: logo + ticker text, text only, or logo + symbol only"
-        },
-        "logo_fetch_enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically download company logos and cache them to disk"
-        },
-        "logo_size": {
-          "type": "integer",
-          "default": 16,
-          "minimum": 8,
-          "maximum": 48,
-          "description": "Logo height in pixels (width scales proportionally to maintain aspect ratio)"
-        },
-        "logo_url_template": {
-          "type": "string",
-          "default": "https://financialmodelingprep.com/image-stock/{symbol}.png",
-          "description": "URL template for logo downloads. Use {symbol} as placeholder (e.g. AAPL)"
-        },
-        "scroll_speed": {
-          "type": "number",
-          "default": 1,
-          "minimum": 0.1,
-          "maximum": 10,
-          "description": "Legacy scroll speed multiplier (used when scroll_pixels_per_second is not set)"
-        },
-        "scroll_delay": {
-          "type": "number",
-          "default": 0.01,
-          "minimum": 0.001,
-          "maximum": 0.1,
-          "description": "Legacy delay between scroll steps in seconds (used when scroll_target_fps is not set)"
-        },
-        "scroll_pixels_per_second": {
-          "type": "number",
-          "default": 25.0,
-          "minimum": 5.0,
-          "maximum": 100.0,
-          "description": "Scroll speed in pixels per second"
-        },
-        "scroll_target_fps": {
-          "type": "number",
-          "default": 100.0,
-          "minimum": 30.0,
-          "maximum": 200.0,
-          "description": "Target FPS for the scroll animation"
-        },
-        "scroll_direction": {
-          "type": "string",
-          "enum": ["left", "right"],
-          "default": "left",
-          "description": "Direction the ticker scrolls"
+          "description": "Fallback display duration in seconds (used when dynamic duration is disabled)"
         },
         "dynamic_duration": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically set display duration based on total content width"
+          "description": "Automatically set display time based on how long the ticker takes to scroll"
         },
         "min_duration": {
           "type": "integer",
@@ -116,17 +39,70 @@
           "maximum": 600,
           "description": "Maximum display duration when dynamic duration is enabled (seconds)"
         },
+        "display_style": {
+          "type": "string",
+          "enum": ["logo_and_ticker", "ticker_only", "logo_only"],
+          "default": "logo_and_ticker",
+          "x-widget": "radio",
+          "description": "What to render per news item: company logo + ticker text, text only, or logo + symbol only"
+        },
+        "font_path": {
+          "type": "string",
+          "default": "assets/fonts/PressStart2P-Regular.ttf",
+          "description": "Path to a TTF font file. Falls back to 4x6-font.ttf then PIL default if not found."
+        },
+        "font_size": {
+          "type": "integer",
+          "default": 10,
+          "minimum": 6,
+          "maximum": 24,
+          "description": "Font size in pixels for all ticker text"
+        },
+        "scroll_pixels_per_second": {
+          "type": "number",
+          "default": 25.0,
+          "minimum": 5.0,
+          "maximum": 100.0,
+          "description": "Scroll speed in pixels per second (preferred over legacy scroll_speed)"
+        },
+        "scroll_target_fps": {
+          "type": "number",
+          "default": 100.0,
+          "minimum": 30.0,
+          "maximum": 200.0,
+          "description": "Target frames per second for the scroll animation"
+        },
+        "scroll_direction": {
+          "type": "string",
+          "enum": ["left", "right"],
+          "default": "left",
+          "description": "Direction the ticker scrolls"
+        },
+        "scroll_speed": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0.1,
+          "maximum": 10,
+          "description": "Legacy scroll speed multiplier (used when scroll_pixels_per_second is absent)"
+        },
+        "scroll_delay": {
+          "type": "number",
+          "default": 0.01,
+          "minimum": 0.001,
+          "maximum": 0.1,
+          "description": "Legacy delay between scroll steps (used when scroll_target_fps is absent)"
+        },
         "rotation_enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Rotate through headlines so each one gets screen time after each scroll cycle"
+          "description": "Rotate headlines after each scroll cycle so every story gets screen time"
         },
         "rotation_threshold": {
           "type": "integer",
           "default": 1,
           "minimum": 1,
           "maximum": 10,
-          "description": "Number of full scroll cycles before rotating to the next headline"
+          "description": "Number of full scroll cycles before advancing to the next headline"
         },
         "shuffle_headlines": {
           "type": "boolean",
@@ -136,14 +112,35 @@
         "show_publisher": {
           "type": "boolean",
           "default": true,
-          "description": "Append the news source (e.g. '• Reuters') after each headline"
+          "description": "Append the news source (e.g. '• Reuters') to each headline when available"
+        },
+        "update_interval_seconds": {
+          "type": "integer",
+          "default": 900,
+          "minimum": 300,
+          "maximum": 7200,
+          "description": "How often to fetch fresh headlines (seconds). Default: 15 minutes"
+        },
+        "max_daily_requests": {
+          "type": "integer",
+          "default": 200,
+          "minimum": 10,
+          "maximum": 1000,
+          "description": "Maximum HTTP requests per day across all symbols and feeds"
+        },
+        "max_requests_per_hour": {
+          "type": "integer",
+          "default": 50,
+          "minimum": 5,
+          "maximum": 200,
+          "description": "Maximum HTTP requests per rolling hour"
         },
         "max_headlines_per_symbol": {
           "type": "integer",
           "default": 1,
           "minimum": 1,
           "maximum": 5,
-          "description": "Maximum headlines to show per stock symbol per update"
+          "description": "Maximum headlines to display per stock symbol"
         },
         "headlines_per_rotation": {
           "type": "integer",
@@ -152,15 +149,26 @@
           "maximum": 10,
           "description": "Maximum headlines to pull from each custom RSS feed"
         },
-        "font_size": {
+        "logo_fetch_enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically download company logos on first use and cache them to disk"
+        },
+        "logo_size": {
           "type": "integer",
-          "default": 10,
+          "default": 16,
           "minimum": 8,
-          "maximum": 16,
-          "description": "Font size for headline and symbol text (pixels)"
+          "maximum": 48,
+          "description": "Logo height in pixels (width scales proportionally)"
+        },
+        "logo_url_template": {
+          "type": "string",
+          "default": "https://financialmodelingprep.com/image-stock/{symbol}.png",
+          "description": "URL template for logo downloads. {symbol} is replaced with the ticker (e.g. AAPL)"
         },
         "background_service": {
           "type": "object",
+          "title": "Background Service",
           "properties": {
             "enabled": {
               "type": "boolean",
@@ -170,7 +178,7 @@
             "request_timeout": {
               "type": "integer",
               "default": 30,
-              "minimum": 10,
+              "minimum": 5,
               "maximum": 120,
               "description": "HTTP request timeout in seconds"
             },
@@ -179,14 +187,14 @@
               "default": 3,
               "minimum": 1,
               "maximum": 10,
-              "description": "Maximum retries for failed requests"
+              "description": "Maximum retries on network failure (uses exponential backoff)"
             },
             "priority": {
               "type": "integer",
               "default": 2,
               "minimum": 1,
               "maximum": 5,
-              "description": "Background request priority (1=highest, 5=lowest)"
+              "description": "Background request priority (1 = highest, 5 = lowest)"
             }
           },
           "additionalProperties": false
@@ -196,33 +204,37 @@
     },
     "feeds": {
       "type": "object",
+      "title": "Feeds & Colors",
       "properties": {
         "stock_symbols": {
           "type": "array",
+          "x-widget": "tag-input",
           "items": {
             "type": "string",
-            "pattern": "^[A-Z]{1,10}$",
+            "pattern": "^[A-Z0-9.]{1,10}$",
             "description": "Stock ticker symbol (e.g. AAPL, GOOGL, BRK.B)"
           },
           "uniqueItems": true,
           "maxItems": 50,
           "default": ["AAPL", "GOOGL", "MSFT"],
-          "description": "Stock symbols to fetch live headlines for (via Yahoo Finance RSS)"
+          "description": "Stock ticker symbols to track. Headlines fetched from Yahoo Finance."
         },
         "custom_feeds": {
           "type": "object",
+          "x-widget": "key-value",
           "patternProperties": {
             ".*": {
               "type": "string",
               "format": "uri",
-              "description": "Custom RSS feed URL"
+              "description": "RSS feed URL"
             }
           },
           "additionalProperties": false,
-          "description": "Additional RSS feeds keyed by display name (any financial RSS URL)"
+          "description": "Additional RSS feeds keyed by display name (any financial news RSS URL)"
         },
         "text_color": {
           "type": "array",
+          "x-widget": "color-picker",
           "items": {"type": "integer", "minimum": 0, "maximum": 255},
           "minItems": 3,
           "maxItems": 3,
@@ -231,11 +243,12 @@
         },
         "symbol_color": {
           "type": "array",
+          "x-widget": "color-picker",
           "items": {"type": "integer", "minimum": 0, "maximum": 255},
           "minItems": 3,
           "maxItems": 3,
           "default": [255, 255, 0],
-          "description": "RGB color for stock symbol labels"
+          "description": "RGB color for stock symbol labels (e.g. 'AAPL:')"
         }
       },
       "additionalProperties": false

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Stock News Ticker Plugin Configuration",
-  "description": "Configuration schema for the Stock News Ticker plugin",
+  "description": "Live financial headlines with logos, price, publisher, relative age, and Vegas scroll",
   "type": "object",
   "properties": {
     "enabled": {
@@ -13,17 +13,92 @@
       "type": "object",
       "title": "Display & Scroll Settings",
       "properties": {
+        "display_style": {
+          "type": "string",
+          "enum": ["logo_and_ticker", "ticker_only", "logo_only"],
+          "default": "logo_and_ticker",
+          "x-widget": "radio",
+          "description": "What to render per story: logo + full text, text only, or logo + symbol only"
+        },
+        "font_path": {
+          "type": "string",
+          "default": "assets/fonts/PressStart2P-Regular.ttf",
+          "description": "Path to a TTF font. Falls back to 4x6-font.ttf then PIL default if missing."
+        },
+        "font_size": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 24,
+          "description": "Font size in pixels. Set to 0 for auto (display_height ÷ 3, clamped 6–16)."
+        },
+        "show_publisher": {
+          "type": "boolean",
+          "default": true,
+          "description": "Append the news source (e.g. '• Reuters') after each headline"
+        },
+        "show_age": {
+          "type": "boolean",
+          "default": true,
+          "description": "Append relative publish time (e.g. '• 2h ago') after each headline"
+        },
+        "show_price": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show current market price (e.g. '$189.42') before the headline"
+        },
+        "item_gap": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 512,
+          "description": "Blank pixels between stories. Set to 0 for auto (= display width)."
+        },
+        "scroll_pixels_per_second": {
+          "type": "number",
+          "default": 25.0,
+          "minimum": 5.0,
+          "maximum": 100.0,
+          "description": "Scroll speed in pixels per second"
+        },
+        "scroll_target_fps": {
+          "type": "number",
+          "default": 100.0,
+          "minimum": 30.0,
+          "maximum": 200.0,
+          "description": "Target frames per second for scroll animation"
+        },
+        "scroll_direction": {
+          "type": "string",
+          "enum": ["left", "right"],
+          "default": "left",
+          "description": "Direction the ticker scrolls"
+        },
+        "scroll_speed": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0.1,
+          "maximum": 10,
+          "description": "Legacy speed multiplier (used when scroll_pixels_per_second is absent)"
+        },
+        "scroll_delay": {
+          "type": "number",
+          "default": 0.01,
+          "minimum": 0.001,
+          "maximum": 0.1,
+          "description": "Legacy frame delay in seconds (used when scroll_target_fps is absent)"
+        },
+        "dynamic_duration": {
+          "type": "boolean",
+          "default": true,
+          "description": "Let display time match actual scroll time (recommended)"
+        },
         "display_duration": {
           "type": "number",
           "default": 30,
           "minimum": 10,
           "maximum": 300,
-          "description": "Fallback display duration in seconds (used when dynamic duration is disabled)"
-        },
-        "dynamic_duration": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically set display time based on how long the ticker takes to scroll"
+          "description": "Fallback display duration in seconds when dynamic_duration is off"
         },
         "min_duration": {
           "type": "integer",
@@ -39,120 +114,91 @@
           "maximum": 600,
           "description": "Maximum display duration when dynamic duration is enabled (seconds)"
         },
-        "display_style": {
-          "type": "string",
-          "enum": ["logo_and_ticker", "ticker_only", "logo_only"],
-          "default": "logo_and_ticker",
-          "x-widget": "radio",
-          "description": "What to render per news item: company logo + ticker text, text only, or logo + symbol only"
-        },
-        "font_path": {
-          "type": "string",
-          "default": "assets/fonts/PressStart2P-Regular.ttf",
-          "description": "Path to a TTF font file. Falls back to 4x6-font.ttf then PIL default if not found."
-        },
-        "font_size": {
-          "type": "integer",
-          "default": 10,
-          "minimum": 6,
-          "maximum": 24,
-          "description": "Font size in pixels for all ticker text"
-        },
-        "scroll_pixels_per_second": {
-          "type": "number",
-          "default": 25.0,
-          "minimum": 5.0,
-          "maximum": 100.0,
-          "description": "Scroll speed in pixels per second (preferred over legacy scroll_speed)"
-        },
-        "scroll_target_fps": {
-          "type": "number",
-          "default": 100.0,
-          "minimum": 30.0,
-          "maximum": 200.0,
-          "description": "Target frames per second for the scroll animation"
-        },
-        "scroll_direction": {
-          "type": "string",
-          "enum": ["left", "right"],
-          "default": "left",
-          "description": "Direction the ticker scrolls"
-        },
-        "scroll_speed": {
-          "type": "number",
-          "default": 1,
-          "minimum": 0.1,
-          "maximum": 10,
-          "description": "Legacy scroll speed multiplier (used when scroll_pixels_per_second is absent)"
-        },
-        "scroll_delay": {
-          "type": "number",
-          "default": 0.01,
-          "minimum": 0.001,
-          "maximum": 0.1,
-          "description": "Legacy delay between scroll steps (used when scroll_target_fps is absent)"
-        },
         "rotation_enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Rotate headlines after each scroll cycle so every story gets screen time"
+          "description": "Rotate through headlines after each scroll cycle"
         },
         "rotation_threshold": {
           "type": "integer",
           "default": 1,
           "minimum": 1,
           "maximum": 10,
-          "description": "Number of full scroll cycles before advancing to the next headline"
+          "description": "Scroll cycles before advancing to the next headline"
         },
         "shuffle_headlines": {
           "type": "boolean",
           "default": true,
           "description": "Randomise headline order on fetch and after each full rotation cycle"
         },
-        "show_publisher": {
-          "type": "boolean",
-          "default": true,
-          "description": "Append the news source (e.g. '• Reuters') to each headline when available"
-        },
-        "update_interval_seconds": {
-          "type": "integer",
-          "default": 900,
-          "minimum": 300,
-          "maximum": 7200,
-          "description": "How often to fetch fresh headlines (seconds). Default: 15 minutes"
-        },
-        "max_daily_requests": {
-          "type": "integer",
-          "default": 200,
-          "minimum": 10,
-          "maximum": 1000,
-          "description": "Maximum HTTP requests per day across all symbols and feeds"
-        },
-        "max_requests_per_hour": {
-          "type": "integer",
-          "default": 50,
-          "minimum": 5,
-          "maximum": 200,
-          "description": "Maximum HTTP requests per rolling hour"
-        },
         "max_headlines_per_symbol": {
-          "type": "integer",
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "description": "Apply the same limit to every symbol"
+            },
+            {
+              "type": "object",
+              "description": "Per-symbol overrides, e.g. {\"AAPL\": 2, \"default\": 1}",
+              "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 5}
+            }
+          ],
           "default": 1,
-          "minimum": 1,
-          "maximum": 5,
-          "description": "Maximum headlines to display per stock symbol"
+          "description": "Max headlines per symbol. Use int for all symbols, or object for per-symbol control."
         },
         "headlines_per_rotation": {
           "type": "integer",
           "default": 2,
           "minimum": 1,
           "maximum": 10,
-          "description": "Maximum headlines to pull from each custom RSS feed"
+          "description": "Max headlines pulled from each custom RSS feed"
+        },
+        "update_interval_seconds": {
+          "type": "integer",
+          "default": 900,
+          "minimum": 60,
+          "maximum": 7200,
+          "description": "Full refresh cycle length in seconds. Symbol fetches are spread evenly within this window."
+        },
+        "max_daily_requests": {
+          "type": "integer",
+          "default": 200,
+          "minimum": 10,
+          "maximum": 2000,
+          "description": "Hard cap on total HTTP requests per day"
+        },
+        "max_requests_per_hour": {
+          "type": "integer",
+          "default": 50,
+          "minimum": 5,
+          "maximum": 500,
+          "description": "Rolling hourly request limit"
+        },
+        "respect_market_hours": {
+          "type": "boolean",
+          "default": true,
+          "description": "Slow down fetching outside US equity market hours (Mon–Fri ~9am–4:30pm ET)"
+        },
+        "off_hours_multiplier": {
+          "type": "integer",
+          "default": 4,
+          "minimum": 1,
+          "maximum": 24,
+          "description": "Multiply per-symbol fetch interval by this amount during off-hours"
+        },
+        "stale_threshold_multiplier": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Data older than update_interval × this factor dims the ticker colours"
         },
         "logo_fetch_enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically download company logos on first use and cache them to disk"
+          "description": "Download company logos on first use and cache them to disk"
         },
         "logo_size": {
           "type": "integer",
@@ -164,38 +210,19 @@
         "logo_url_template": {
           "type": "string",
           "default": "https://financialmodelingprep.com/image-stock/{symbol}.png",
-          "description": "URL template for logo downloads. {symbol} is replaced with the ticker (e.g. AAPL)"
+          "description": "URL template for logo downloads. {symbol} is replaced with the ticker."
         },
         "background_service": {
           "type": "object",
           "title": "Background Service",
           "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": true,
-              "description": "Enable background data fetching"
-            },
-            "request_timeout": {
-              "type": "integer",
-              "default": 30,
-              "minimum": 5,
-              "maximum": 120,
-              "description": "HTTP request timeout in seconds"
-            },
-            "max_retries": {
-              "type": "integer",
-              "default": 3,
-              "minimum": 1,
-              "maximum": 10,
-              "description": "Maximum retries on network failure (uses exponential backoff)"
-            },
-            "priority": {
-              "type": "integer",
-              "default": 2,
-              "minimum": 1,
-              "maximum": 5,
-              "description": "Background request priority (1 = highest, 5 = lowest)"
-            }
+            "enabled": {"type": "boolean", "default": true},
+            "request_timeout": {"type": "integer", "default": 30, "minimum": 5, "maximum": 120,
+                                "description": "HTTP timeout in seconds"},
+            "max_retries": {"type": "integer", "default": 3, "minimum": 1, "maximum": 10,
+                            "description": "Retries with exponential backoff on failure"},
+            "priority": {"type": "integer", "default": 2, "minimum": 1, "maximum": 5,
+                         "description": "Background priority (1 = highest)"}
           },
           "additionalProperties": false
         }
@@ -211,26 +238,22 @@
           "x-widget": "tag-input",
           "items": {
             "type": "string",
-            "pattern": "^[A-Z0-9.]{1,10}$",
-            "description": "Stock ticker symbol (e.g. AAPL, GOOGL, BRK.B)"
+            "pattern": "^[A-Z0-9.\\-]{1,10}$",
+            "description": "Ticker symbol (AAPL, GOOGL, BRK.B)"
           },
           "uniqueItems": true,
           "maxItems": 50,
           "default": ["AAPL", "GOOGL", "MSFT"],
-          "description": "Stock ticker symbols to track. Headlines fetched from Yahoo Finance."
+          "description": "Stock symbols — headlines fetched from Yahoo Finance. Fetches are spread across update_interval."
         },
         "custom_feeds": {
           "type": "object",
           "x-widget": "key-value",
           "patternProperties": {
-            ".*": {
-              "type": "string",
-              "format": "uri",
-              "description": "RSS feed URL"
-            }
+            ".*": {"type": "string", "format": "uri"}
           },
           "additionalProperties": false,
-          "description": "Additional RSS feeds keyed by display name (any financial news RSS URL)"
+          "description": "Extra RSS feeds keyed by display name (any financial news RSS URL)"
         },
         "text_color": {
           "type": "array",
@@ -249,6 +272,15 @@
           "maxItems": 3,
           "default": [255, 255, 0],
           "description": "RGB color for stock symbol labels (e.g. 'AAPL:')"
+        },
+        "publisher_color": {
+          "type": "array",
+          "x-widget": "color-picker",
+          "items": {"type": "integer", "minimum": 0, "maximum": 255},
+          "minItems": 3,
+          "maxItems": 3,
+          "default": [110, 110, 110],
+          "description": "RGB color for publisher and age suffix (e.g. '• Reuters • 2h ago')"
         }
       },
       "additionalProperties": false

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -1,17 +1,25 @@
 """
 Stock News Ticker Plugin for LEDMatrix
 
-Displays scrolling stock-specific news headlines and financial updates from RSS feeds.
-Shows market news, company announcements, and financial updates for tracked stocks.
+Live financial headlines with company logos, multi-colour segment rendering,
+spread symbol fetching, market-hours throttling, and Vegas scroll integration.
 
 Features:
-- Real Yahoo Finance RSS headlines per stock symbol
-- Company logo rendering (logo+ticker, ticker only, logo only modes)
-- Configurable per-day / per-hour request budget
-- ScrollHelper-based horizontal scrolling at high FPS
-- Vegas scroll mode integration
-- Custom RSS feed support
-- Fully configurable colors, fonts, scroll speed, and display style
+- Yahoo Finance search API (publisher, price, timestamp) with RSS fallback
+- Auto font size derived from display height when not configured
+- Display styles: logo_and_ticker, ticker_only, logo_only
+- Per-segment colours: symbol (yellow), headline (green), publisher/age (dim)
+- Optional stock price display alongside headline
+- Relative age display ("2h ago") from real publish timestamps
+- Symbol fetches spread across update_interval — no budget burst
+- Market-hours throttling to save requests overnight/weekends
+- Per-day + per-hour request budget with startup adequacy warning
+- Per-symbol max-headlines override (int or {AAPL: 2, default: 1})
+- Stale-data indicator: dims colours when data is overdue
+- Configurable item_gap between stories
+- Vegas scroll integration with content caching
+- on_config_change() live reload without plugin restart
+- requests.Session with 4x retry + exponential backoff
 """
 
 import logging
@@ -23,7 +31,7 @@ import html
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 from PIL import Image, ImageDraw, ImageFont
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -39,16 +47,6 @@ _YAHOO_RSS = "https://feeds.finance.yahoo.com/rss/2.0/headline?s={symbol}&region
 
 
 class StockNewsTickerPlugin(BasePlugin):
-    """
-    Stock news ticker plugin for displaying real financial headlines.
-
-    Fetches live headlines from Yahoo Finance RSS per symbol and renders them
-    as a scrolling horizontal ticker with optional company logos.
-
-    Configuration options:
-        global: Scroll, display, rate-limit, and logo settings
-        feeds: Stock symbols, custom RSS feeds, and text colors
-    """
 
     def __init__(self, plugin_id: str, config: Dict[str, Any],
                  display_manager, cache_manager, plugin_manager):
@@ -61,55 +59,19 @@ class StockNewsTickerPlugin(BasePlugin):
         self.display_width = self.display_manager.matrix.width
         self.display_height = self.display_manager.matrix.height
 
-        # Scroll / display settings
-        self.display_duration = self.global_config.get('display_duration', 30)
-        self.scroll_speed = self.global_config.get('scroll_speed', 1)
-        self.scroll_delay = self.global_config.get('scroll_delay', 0.01)
-        self.dynamic_duration = self.global_config.get('dynamic_duration', True)
-        self.min_duration = self.global_config.get('min_duration', 30)
-        self.max_duration = self.global_config.get('max_duration', 300)
-        self.max_headlines_per_symbol = self.global_config.get('max_headlines_per_symbol', 1)
-        self.headlines_per_rotation = self.global_config.get('headlines_per_rotation', 2)
-        self.font_size = self.global_config.get('font_size', 10)
-        self.rotation_enabled = self.global_config.get('rotation_enabled', True)
-        self.rotation_threshold = self.global_config.get('rotation_threshold', 1)
-        self.shuffle_headlines = self.global_config.get('shuffle_headlines', True)
-        self.show_publisher = self.global_config.get('show_publisher', True)
+        self._apply_config()
 
-        # Fetch rate limiting
-        self.update_interval = self.global_config.get('update_interval_seconds', 900)
-        self.max_daily_requests = self.global_config.get('max_daily_requests', 200)
-        self.max_requests_per_hour = self.global_config.get('max_requests_per_hour', 50)
-        self._requests_today: int = 0
-        self._last_reset_date: str = ''
-        self._request_timestamps: list = []
-
-        # Display style
-        self.display_style = self.global_config.get('display_style', 'logo_and_ticker')
-        self.logo_size = self.global_config.get('logo_size', min(self.display_height, 32))
-        self.logo_fetch_enabled = self.global_config.get('logo_fetch_enabled', True)
-        self.logo_url_template = self.global_config.get(
-            'logo_url_template',
-            'https://financialmodelingprep.com/image-stock/{symbol}.png'
-        )
-
-        # Colors
-        self.text_color = tuple(self.feeds_config.get('text_color', [0, 255, 0]))
-        self.symbol_color = tuple(self.feeds_config.get('symbol_color', [255, 255, 0]))
-
-        # Background service config (kept for timeout setting)
-        self.background_config = self.global_config.get('background_service', {
-            'enabled': True,
-            'request_timeout': 30,
-        })
-
-        # State
+        # State — persistent across update cycles
         self.all_news_items: list = []
-        self.current_rotation_index: int = 0
+        self._symbol_data: Dict[str, List] = {}   # per-symbol/feed headline cache
+        self._feed_last_fetch: Dict[str, float] = {}
+        self._fetch_index: int = 0                # rotating symbol index
+        self._last_symbol_fetch: float = 0
         self._rotation_count: int = 0
-        self._items_rotated: int = 0   # tracks full-cycle completions for shuffle
+        self._items_rotated: int = 0
         self._cycle_complete: bool = False
         self._vegas_cache: Optional[list] = None
+        self._was_stale: bool = False
         self.last_update: float = 0
         self.initialized = True
 
@@ -121,33 +83,102 @@ class StockNewsTickerPlugin(BasePlugin):
         self._logo_dir.mkdir(parents=True, exist_ok=True)
         self.logo_helper = LogoHelper(self.display_width, self.display_height, logger=self.logger)
 
-        # Fonts and scroll helper
+        # Fonts and scroll
         self._fonts: dict = self._load_fonts()
         self.scroll_helper = ScrollHelper(self.display_width, self.display_height, logger=self.logger)
         self._configure_scroll_settings()
-
-        # Register fonts with font manager for UI introspection
         self._register_fonts()
 
         stock_symbols = self.feeds_config.get('stock_symbols', [])
-        custom_feeds = list(self.feeds_config.get('custom_feeds', {}).keys())
+        custom_feeds = self.feeds_config.get('custom_feeds', {})
         self.logger.info(
-            "Stock news ticker initialized — symbols=%s, custom_feeds=%s, style=%s",
-            stock_symbols, custom_feeds, self.display_style,
+            "[Stock News] Initialized — symbols=%s, custom=%s, style=%s, font=%dpx, item_gap=%dpx",
+            stock_symbols, list(custom_feeds.keys()), self.display_style,
+            self.font_size, self.item_gap,
         )
+        self._check_budget_adequacy()
 
     # -------------------------------------------------------------------------
-    # Font / scroll configuration
+    # Config helpers
+    # -------------------------------------------------------------------------
+
+    def _apply_config(self) -> None:
+        """Read all config keys into instance vars. Called from __init__ and on_config_change."""
+        gc = self.global_config
+        fc = self.feeds_config
+
+        # Auto font size: 0 or absent → derive from display height
+        raw_fs = gc.get('font_size', 0)
+        self.font_size = int(raw_fs) if raw_fs and int(raw_fs) > 0 else max(6, min(16, self.display_height // 3))
+
+        # Item gap: 0 → use full display width (clean separation between stories)
+        raw_gap = gc.get('item_gap', 0)
+        self.item_gap = int(raw_gap) if raw_gap and int(raw_gap) > 0 else self.display_width
+
+        # Scroll / duration
+        self.display_duration = gc.get('display_duration', 30)
+        self.scroll_speed = gc.get('scroll_speed', 1)
+        self.scroll_delay = gc.get('scroll_delay', 0.01)
+        self.dynamic_duration = gc.get('dynamic_duration', True)
+        self.min_duration = gc.get('min_duration', 30)
+        self.max_duration = gc.get('max_duration', 300)
+
+        # Headlines
+        self.max_headlines_per_symbol = gc.get('max_headlines_per_symbol', 1)  # int or dict
+        self.headlines_per_rotation = gc.get('headlines_per_rotation', 2)
+
+        # Rotation / shuffle
+        self.rotation_enabled = gc.get('rotation_enabled', True)
+        self.rotation_threshold = gc.get('rotation_threshold', 1)
+        self.shuffle_headlines = gc.get('shuffle_headlines', True)
+
+        # Display style
+        self.display_style = gc.get('display_style', 'logo_and_ticker')
+        self.logo_size = gc.get('logo_size', min(self.display_height, 32))
+        self.logo_fetch_enabled = gc.get('logo_fetch_enabled', True)
+        self.logo_url_template = gc.get(
+            'logo_url_template',
+            'https://financialmodelingprep.com/image-stock/{symbol}.png'
+        )
+
+        # What to show
+        self.show_publisher = gc.get('show_publisher', True)
+        self.show_age = gc.get('show_age', True)
+        self.show_price = gc.get('show_price', False)
+
+        # Colours
+        self.text_color: Tuple = tuple(fc.get('text_color', [0, 255, 0]))
+        self.symbol_color: Tuple = tuple(fc.get('symbol_color', [255, 255, 0]))
+        self.publisher_color: Tuple = tuple(fc.get('publisher_color', [110, 110, 110]))
+
+        # Rate limiting
+        self.update_interval = gc.get('update_interval_seconds', 900)
+        self.max_daily_requests = gc.get('max_daily_requests', 200)
+        self.max_requests_per_hour = gc.get('max_requests_per_hour', 50)
+
+        # Market hours
+        self.respect_market_hours = gc.get('respect_market_hours', True)
+        self.off_hours_multiplier = gc.get('off_hours_multiplier', 4)
+
+        # Stale threshold
+        self.stale_threshold_multiplier = gc.get('stale_threshold_multiplier', 2)
+
+        # Background service
+        self.background_config = gc.get('background_service', {
+            'enabled': True, 'request_timeout': 30,
+        })
+
+    # -------------------------------------------------------------------------
+    # Font / scroll
     # -------------------------------------------------------------------------
 
     def _load_fonts(self) -> dict:
-        """Load PIL fonts with three-level fallback: configured path → 4x6 bitmap → PIL default."""
+        """Three-level fallback: configured TTF → 4x6 bitmap → PIL default."""
         configured = self.global_config.get('font_path', 'assets/fonts/PressStart2P-Regular.ttf')
-        fallbacks = [configured, 'assets/fonts/4x6-font.ttf']
-        for path in fallbacks:
+        for path in [configured, 'assets/fonts/4x6-font.ttf']:
             try:
                 font = ImageFont.truetype(path, self.font_size)
-                self.logger.debug("[Stock News] Loaded font: %s @ %dpx", path, self.font_size)
+                self.logger.debug("[Stock News] Font: %s @ %dpx", path, self.font_size)
                 return {'headline': font, 'symbol': font}
             except IOError:
                 continue
@@ -155,23 +186,23 @@ class StockNewsTickerPlugin(BasePlugin):
         return {}
 
     def _configure_scroll_settings(self) -> None:
-        """Configure ScrollHelper with plugin scroll settings (supports legacy keys)."""
+        """Apply scroll speed / FPS to ScrollHelper (supports legacy keys)."""
         if 'scroll_pixels_per_second' in self.global_config:
-            pixels_per_second = float(self.global_config['scroll_pixels_per_second'])
+            pps = float(self.global_config['scroll_pixels_per_second'])
         elif self.scroll_delay and self.scroll_delay > 0:
-            pixels_per_second = self.scroll_speed / self.scroll_delay
+            pps = self.scroll_speed / self.scroll_delay
         else:
-            pixels_per_second = 25.0
-        self.scroll_helper.set_scroll_speed(pixels_per_second)
+            pps = 25.0
+        self.scroll_helper.set_scroll_speed(pps)
 
         if 'scroll_target_fps' in self.global_config:
-            target_fps = float(self.global_config['scroll_target_fps'])
+            fps = float(self.global_config['scroll_target_fps'])
         elif self.scroll_delay and self.scroll_delay > 0:
-            target_fps = 1.0 / self.scroll_delay
+            fps = 1.0 / self.scroll_delay
         else:
-            target_fps = 100.0
+            fps = 100.0
         if hasattr(self.scroll_helper, 'set_target_fps'):
-            self.scroll_helper.set_target_fps(target_fps)
+            self.scroll_helper.set_target_fps(fps)
 
         self.scroll_helper.set_dynamic_duration_settings(
             enabled=self.dynamic_duration,
@@ -180,38 +211,24 @@ class StockNewsTickerPlugin(BasePlugin):
         )
 
     def _register_fonts(self) -> None:
-        """Register fonts with the font manager for UI introspection."""
         try:
             if not hasattr(self.plugin_manager, 'font_manager'):
                 return
             fm = self.plugin_manager.font_manager
-            fm.register_manager_font(
-                manager_id=self.plugin_id,
-                element_key=f"{self.plugin_id}.headline",
-                family="press_start", size_px=self.font_size, color=self.text_color,
-            )
-            fm.register_manager_font(
-                manager_id=self.plugin_id,
-                element_key=f"{self.plugin_id}.symbol",
-                family="press_start", size_px=self.font_size, color=self.symbol_color,
-            )
-            fm.register_manager_font(
-                manager_id=self.plugin_id,
-                element_key=f"{self.plugin_id}.info",
-                family="four_by_six", size_px=6, color=(150, 150, 150),
-            )
+            fm.register_manager_font(self.plugin_id, f"{self.plugin_id}.headline",
+                                     "press_start", self.font_size, self.text_color)
+            fm.register_manager_font(self.plugin_id, f"{self.plugin_id}.symbol",
+                                     "press_start", self.font_size, self.symbol_color)
+            fm.register_manager_font(self.plugin_id, f"{self.plugin_id}.info",
+                                     "four_by_six", 6, self.publisher_color)
         except Exception as e:
-            self.logger.warning(f"Error registering fonts: {e}")
+            self.logger.warning("[Stock News] Font registration error: %s", e)
 
     def _create_session(self) -> requests.Session:
-        """Build a requests Session with automatic retry and exponential backoff."""
         session = requests.Session()
-        retry = Retry(
-            total=4,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET"],
-        )
+        retry = Retry(total=4, backoff_factor=1,
+                      status_forcelist=[429, 500, 502, 503, 504],
+                      allowed_methods=["GET"])
         adapter = HTTPAdapter(max_retries=retry)
         session.mount("https://", adapter)
         session.mount("http://", adapter)
@@ -219,87 +236,120 @@ class StockNewsTickerPlugin(BasePlugin):
         return session
 
     # -------------------------------------------------------------------------
-    # Update / data fetching
+    # Update — spread symbol fetches across time
     # -------------------------------------------------------------------------
 
     def update(self) -> None:
-        """Fetch fresh headlines for all tracked symbols and custom feeds."""
         if not self.initialized:
             return
-        if time.time() - self.last_update < self.update_interval:
-            return
 
-        try:
-            all_items: list = []
-            stock_symbols = self.feeds_config.get('stock_symbols', [])
+        now = time.time()
+        stock_symbols = self.feeds_config.get('stock_symbols', [])
+        custom_feeds = self.feeds_config.get('custom_feeds', {})
+        fetched = False
 
-            for symbol in stock_symbols:
-                items = self._fetch_stock_news(symbol)
-                all_items.extend(items)
+        # Per-symbol interval: spread all symbols evenly within update_interval
+        n = max(len(stock_symbols), 1)
+        per_sym = max(60.0, self.update_interval / n)
+        if not self._is_market_hours():
+            per_sym = per_sym * self.off_hours_multiplier
 
-            custom_feeds = self.feeds_config.get('custom_feeds', {})
-            for feed_name, feed_url in custom_feeds.items():
-                items = self._fetch_rss_feed(
-                    feed_name, feed_url, max_items=self.headlines_per_rotation
-                )
-                all_items.extend(items)
+        # Fetch exactly one symbol per call (rotating)
+        if stock_symbols and (now - self._last_symbol_fetch) >= per_sym:
+            idx = self._fetch_index % len(stock_symbols)
+            symbol = stock_symbols[idx]
+            max_h = self._get_symbol_max_headlines(symbol)
+            items = self._fetch_stock_news(symbol, max_h)
+            self._symbol_data[symbol] = items
+            self._fetch_index = (self._fetch_index + 1) % len(stock_symbols)
+            self._last_symbol_fetch = now
+            fetched = True
 
-            max_items = (
-                len(stock_symbols) * self.max_headlines_per_symbol
-                + len(custom_feeds) * self.headlines_per_rotation
-            )
-            self.all_news_items = all_items[:max_items] if len(all_items) > max_items else all_items
-            if self.shuffle_headlines and self.all_news_items:
-                random.shuffle(self.all_news_items)
-            self.current_rotation_index = 0
-            self._rotation_count = 0
-            self._items_rotated = 0
-            self.last_update = time.time()
-            self.logger.info("[Stock News] Updated: %d items", len(self.all_news_items))
+        # Custom feeds: one at a time, each at full update_interval
+        for feed_name, feed_url in custom_feeds.items():
+            last = self._feed_last_fetch.get(feed_name, 0)
+            if now - last >= self.update_interval:
+                items = self._fetch_rss_feed(feed_name, feed_url,
+                                             max_items=self.headlines_per_rotation)
+                self._symbol_data[f"_feed_{feed_name}"] = items
+                self._feed_last_fetch[feed_name] = now
+                fetched = True
+                break  # one feed per update() call
 
-            if hasattr(self, 'scroll_helper'):
-                self.scroll_helper.clear_cache()
-                self.scroll_helper.reset_scroll()
-            self._vegas_cache = None
+        if fetched:
+            self._rebuild_all_news_items()
 
-        except Exception as e:
-            self.logger.error(f"[Stock News] update() error: {e}")
+    def _rebuild_all_news_items(self) -> None:
+        """Rebuild all_news_items from per-symbol cached data."""
+        stock_symbols = self.feeds_config.get('stock_symbols', [])
+        custom_feeds = self.feeds_config.get('custom_feeds', {})
 
-    def _fetch_stock_news(self, symbol: str) -> List[Dict]:
-        """Fetch live headlines for a symbol — tries YF search API first, falls back to RSS."""
-        items = self._fetch_yf_api(symbol)
+        all_items: list = []
+        for sym in stock_symbols:
+            all_items.extend(self._symbol_data.get(sym, []))
+        for fn in custom_feeds:
+            all_items.extend(self._symbol_data.get(f"_feed_{fn}", []))
+
+        max_total = (
+            sum(self._get_symbol_max_headlines(s) for s in stock_symbols)
+            + len(custom_feeds) * self.headlines_per_rotation
+        )
+        self.all_news_items = all_items[:max_total] if len(all_items) > max_total else all_items
+
+        if self.shuffle_headlines and self.all_news_items:
+            random.shuffle(self.all_news_items)
+
+        self.last_update = time.time()
+        self.scroll_helper.clear_cache()
+        self.scroll_helper.reset_scroll()
+        self._vegas_cache = None
+        self._rotation_count = 0
+        self._items_rotated = 0
+        self.logger.info("[Stock News] Rebuilt: %d items (%d symbols, %d custom feeds)",
+                         len(self.all_news_items), len(stock_symbols), len(custom_feeds))
+
+    # -------------------------------------------------------------------------
+    # Data fetching
+    # -------------------------------------------------------------------------
+
+    def _get_symbol_max_headlines(self, symbol: str) -> int:
+        """Return per-symbol headline limit, supporting int or dict config."""
+        cfg = self.max_headlines_per_symbol
+        if isinstance(cfg, dict):
+            return int(cfg.get(symbol, cfg.get('default', 1)))
+        return int(cfg)
+
+    def _fetch_stock_news(self, symbol: str, max_h: int) -> List[Dict]:
+        """Try YF search API first; fall back to RSS."""
+        items = self._fetch_yf_api(symbol, max_h)
         if items:
             return items
-        # RSS fallback (e.g. if API changes or rate-limits)
         self.logger.debug("[Stock News] RSS fallback for %s", symbol)
         url = _YAHOO_RSS.format(symbol=symbol)
-        items = self._fetch_rss_feed(symbol, url, max_items=self.max_headlines_per_symbol)
+        items = self._fetch_rss_feed(symbol, url, max_items=max_h)
         for item in items:
             item['symbol'] = symbol
         return items
 
-    def _fetch_yf_api(self, symbol: str) -> List[Dict]:
-        """Fetch headlines via Yahoo Finance search API (returns publisher + timestamp)."""
+    def _fetch_yf_api(self, symbol: str, max_h: int) -> List[Dict]:
+        """Yahoo Finance search API — returns publisher, timestamp, optional price."""
         bucket = int(time.time() // self.update_interval)
         cache_key = f"stock_yf_{symbol}_{bucket}"
         cached = self.cache_manager.get(cache_key)
         if cached:
-            self.logger.debug("[Stock News] Cache hit (YF API): %s", symbol)
+            self.logger.debug("[Stock News] Cache hit (YF): %s", symbol)
             return cached
 
         if not self._check_request_budget():
-            self.logger.warning(
-                "[Stock News] Request budget exceeded (%d/day, %d/hr limit) — skipping %s",
-                self._requests_today, self.max_requests_per_hour, symbol,
-            )
+            self.logger.warning("[Stock News] Budget exceeded — skipping %s", symbol)
             return []
 
         params = {
             'q': symbol,
             'lang': 'en-US',
             'region': 'US',
-            'quotesCount': 0,
-            'newsCount': self.max_headlines_per_symbol,
+            'quotesCount': 1 if self.show_price else 0,
+            'newsCount': max_h,
             'enableFuzzyQuery': False,
         }
         try:
@@ -308,31 +358,39 @@ class StockNewsTickerPlugin(BasePlugin):
             resp.raise_for_status()
             self._record_request()
 
-            news_raw = resp.json().get('news', [])
+            data = resp.json()
+
+            # Extract price from quote if requested
+            price: Optional[float] = None
+            if self.show_price:
+                quotes = data.get('quotes', [])
+                if quotes:
+                    price = quotes[0].get('regularMarketPrice') or quotes[0].get('price')
+
             items: List[Dict] = []
-            for raw in news_raw[:self.max_headlines_per_symbol]:
+            for raw in data.get('news', [])[:max_h]:
                 title = raw.get('title', '').strip()
                 if not title:
                     continue
-                pub_ts = raw.get('providerPublishTime', 0)
-                pub_dt = datetime.fromtimestamp(pub_ts) if pub_ts else None
+                pub_ts = float(raw.get('providerPublishTime', 0) or 0)
                 items.append({
                     'symbol': symbol,
                     'feed_name': symbol,
                     'title': self._clean_headline(title),
                     'link': raw.get('link', ''),
                     'publisher': raw.get('publisher', ''),
-                    'published': pub_dt.isoformat() if pub_dt else '',
-                    'published_dt': pub_dt,
-                    'summary': raw.get('summary', ''),
+                    'published_ts': pub_ts,   # unix float — cache-safe
+                    'price': price,
                 })
 
             self.cache_manager.set(cache_key, items, ttl=self.update_interval * 2)
-            self.logger.info("[Stock News] YF API: %d items for %s", len(items), symbol)
+            self.logger.info("[Stock News] YF API: %d items for %s%s",
+                             len(items), symbol,
+                             f" @ ${price:.2f}" if price else "")
             return items
 
         except requests.RequestException as e:
-            self.logger.warning("[Stock News] YF API network error for %s: %s", symbol, e)
+            self.logger.warning("[Stock News] YF API error for %s: %s", symbol, e)
         except (ValueError, KeyError) as e:
             self.logger.warning("[Stock News] YF API parse error for %s: %s", symbol, e)
         except Exception as e:
@@ -340,7 +398,7 @@ class StockNewsTickerPlugin(BasePlugin):
         return []
 
     def _fetch_rss_feed(self, feed_name: str, url: str, max_items: int = 3) -> List[Dict]:
-        """Fetch and parse an RSS feed with caching and request budget enforcement."""
+        """Fetch and parse any RSS feed with caching and budget enforcement."""
         bucket = int(time.time() // self.update_interval)
         cache_key = f"stock_rss_{feed_name}_{bucket}"
         cached = self.cache_manager.get(cache_key)
@@ -349,13 +407,10 @@ class StockNewsTickerPlugin(BasePlugin):
             return cached
 
         if not self._check_request_budget():
-            self.logger.warning(
-                "[Stock News] Request budget exceeded — skipping %s", feed_name,
-            )
+            self.logger.warning("[Stock News] Budget exceeded — skipping RSS %s", feed_name)
             return []
 
         try:
-            self.logger.info("[Stock News] Fetching RSS: %s", feed_name)
             timeout = self.background_config.get('request_timeout', 30)
             resp = self._session.get(url, timeout=timeout)
             resp.raise_for_status()
@@ -369,12 +424,21 @@ class StockNewsTickerPlugin(BasePlugin):
                     continue
                 link_el = rss_item.find('link')
                 pub_el = rss_item.find('pubDate')
+                # Try to parse pubDate to unix timestamp
+                pub_ts = 0.0
+                if pub_el is not None and pub_el.text:
+                    try:
+                        from email.utils import parsedate_to_datetime
+                        pub_ts = parsedate_to_datetime(pub_el.text).timestamp()
+                    except Exception:
+                        pass
                 items.append({
                     'feed_name': feed_name,
                     'title': self._clean_headline(html.unescape(title_el.text.strip())),
                     'link': (link_el.text or '') if link_el is not None else '',
                     'publisher': '',
-                    'published': (pub_el.text or '') if pub_el is not None else '',
+                    'published_ts': pub_ts,
+                    'price': None,
                 })
 
             self.cache_manager.set(cache_key, items, ttl=self.update_interval * 2)
@@ -382,36 +446,75 @@ class StockNewsTickerPlugin(BasePlugin):
             return items
 
         except requests.RequestException as e:
-            self.logger.error("[Stock News] RSS fetch error for %s: %s", feed_name, e)
+            self.logger.error("[Stock News] RSS error for %s: %s", feed_name, e)
         except ET.ParseError as e:
             self.logger.error("[Stock News] RSS parse error for %s: %s", feed_name, e)
         except Exception as e:
-            self.logger.error("[Stock News] Unexpected error for %s: %s", feed_name, e)
+            self.logger.error("[Stock News] RSS unexpected error for %s: %s", feed_name, e)
         return []
 
     def _check_request_budget(self) -> bool:
-        """Return True if within daily and hourly request limits."""
         today = datetime.now().strftime('%Y-%m-%d')
+        if not hasattr(self, '_last_reset_date'):
+            self._last_reset_date = ''
+            self._requests_today = 0
+            self._request_timestamps: list = []
         if self._last_reset_date != today:
             self._requests_today = 0
             self._last_reset_date = today
-
         if self._requests_today >= self.max_daily_requests:
             return False
-
         cutoff = time.time() - 3600
         self._request_timestamps = [t for t in self._request_timestamps if t > cutoff]
-        if len(self._request_timestamps) >= self.max_requests_per_hour:
-            return False
-
-        return True
+        return len(self._request_timestamps) < self.max_requests_per_hour
 
     def _record_request(self) -> None:
         self._requests_today += 1
         self._request_timestamps.append(time.time())
 
+    def _check_budget_adequacy(self) -> None:
+        """Warn at startup if symbol count may exhaust the hourly request budget."""
+        stock_symbols = self.feeds_config.get('stock_symbols', [])
+        custom_feeds = self.feeds_config.get('custom_feeds', {})
+        n = max(len(stock_symbols), 1)
+        per_sym = max(60.0, self.update_interval / n)
+        sym_per_hour = 3600.0 / per_sym
+        custom_per_hour = (3600.0 / self.update_interval) * len(custom_feeds)
+        total_per_hour = sym_per_hour + custom_per_hour
+
+        if total_per_hour > self.max_requests_per_hour:
+            self.logger.warning(
+                "[Stock News] Budget mismatch: ~%.0f req/hr estimated but limit is %d/hr. "
+                "Raise max_requests_per_hour to %d, or reduce symbols from %d.",
+                total_per_hour, self.max_requests_per_hour,
+                int(total_per_hour) + 5, len(stock_symbols),
+            )
+        else:
+            self.logger.info(
+                "[Stock News] Budget OK: ~%.0f req/hr (%d symbols spread %.0fs apart, limit %d/hr)",
+                total_per_hour, len(stock_symbols), per_sym, self.max_requests_per_hour,
+            )
+
+    def _is_market_hours(self) -> bool:
+        """Approximate US equity market hours without external dependencies.
+
+        Covers 9:00–16:30 ET in both EDT (UTC-4) and EST (UTC-5) by using
+        a conservative UTC window of 13:00–22:00, Mon–Fri.
+        """
+        if not self.respect_market_hours:
+            return True
+        now = datetime.utcnow()
+        if now.weekday() >= 5:
+            return False
+        h = now.hour + now.minute / 60.0
+        return 13.0 <= h <= 22.0
+
+    def _is_data_stale(self) -> bool:
+        if self.last_update == 0:
+            return False
+        return (time.time() - self.last_update) > (self.update_interval * self.stale_threshold_multiplier)
+
     def _clean_headline(self, headline: str) -> str:
-        """Normalise whitespace and trim headline to display-safe length."""
         if not headline:
             return ""
         headline = re.sub(r'\s+', ' ', headline.strip())
@@ -420,35 +523,46 @@ class StockNewsTickerPlugin(BasePlugin):
             headline = headline[:77] + "..."
         return headline
 
+    def _format_age(self, pub_ts: float) -> str:
+        """Format a unix timestamp as a human-readable relative age."""
+        if not pub_ts:
+            return ""
+        try:
+            delta = time.time() - pub_ts
+            if delta < 60:
+                return "just now"
+            elif delta < 3600:
+                return f"{int(delta // 60)}m ago"
+            elif delta < 86400:
+                return f"{int(delta // 3600)}h ago"
+            else:
+                return f"{int(delta // 86400)}d ago"
+        except Exception:
+            return ""
+
     # -------------------------------------------------------------------------
     # Logo fetching
     # -------------------------------------------------------------------------
 
     def _get_symbol_logo(self, symbol: str) -> Optional[Image.Image]:
-        """Return a company logo PIL Image for the symbol, downloading if needed."""
         if not self.logo_fetch_enabled:
             return None
-
         logo_path = self._logo_dir / f"{symbol}.png"
         if logo_path.exists():
-            return self.logo_helper.load_logo(
-                symbol, logo_path,
-                max_width=self.logo_size, max_height=self.logo_size,
-            )
-
+            return self.logo_helper.load_logo(symbol, logo_path,
+                                              max_width=self.logo_size,
+                                              max_height=self.logo_size)
         url = self.logo_url_template.replace('{symbol}', symbol)
         try:
             resp = self._session.get(url, timeout=10)
             if resp.status_code == 200 and resp.content:
                 logo_path.write_bytes(resp.content)
                 self.logger.info("[Stock News] Downloaded logo for %s", symbol)
-                return self.logo_helper.load_logo(
-                    symbol, logo_path,
-                    max_width=self.logo_size, max_height=self.logo_size,
-                )
+                return self.logo_helper.load_logo(symbol, logo_path,
+                                                  max_width=self.logo_size,
+                                                  max_height=self.logo_size)
         except Exception as e:
             self.logger.debug("[Stock News] Logo fetch failed for %s: %s", symbol, e)
-
         return None
 
     # -------------------------------------------------------------------------
@@ -456,7 +570,6 @@ class StockNewsTickerPlugin(BasePlugin):
     # -------------------------------------------------------------------------
 
     def display(self, display_mode: str = None, force_clear: bool = False) -> None:
-        """Display the scrolling stock news ticker."""
         if not self.initialized:
             self._display_error("Stock news ticker not initialized")
             return
@@ -464,6 +577,13 @@ class StockNewsTickerPlugin(BasePlugin):
         if not self.all_news_items:
             self._display_no_news()
             return
+
+        # Rebuild if stale state changed (dimmed ↔ normal colours)
+        currently_stale = self._is_data_stale()
+        if currently_stale != self._was_stale:
+            self._was_stale = currently_stale
+            self.scroll_helper.clear_cache()
+            self._vegas_cache = None
 
         if not self.scroll_helper.cached_image or force_clear:
             self._create_scrolling_image()
@@ -490,7 +610,7 @@ class StockNewsTickerPlugin(BasePlugin):
                     self._rotate_headlines()
                     self.scroll_helper.clear_cache()
                     self.scroll_helper.reset_scroll()
-                    return  # next display() call rebuilds with rotated order
+                    return
 
         visible_portion = self.scroll_helper.get_visible_portion()
         if visible_portion:
@@ -500,66 +620,84 @@ class StockNewsTickerPlugin(BasePlugin):
         self.scroll_helper.log_frame_rate()
 
     def _create_scrolling_image(self) -> None:
-        """Build the wide horizontal ticker image from all current news items."""
         try:
-            item_images = [
-                img for img in (self._render_news_item(item) for item in self.all_news_items)
-                if img is not None
-            ]
+            item_images = [img for img in
+                           (self._render_news_item(item) for item in self.all_news_items)
+                           if img is not None]
             if not item_images:
                 self.scroll_helper.clear_cache()
                 return
-            self.scroll_helper.create_scrolling_image(item_images, item_gap=48)
+            self.scroll_helper.create_scrolling_image(item_images, item_gap=self.item_gap)
             self._cycle_complete = False
-            self.logger.info(
-                "[Stock News] Ticker image built: %d items, %dpx wide",
-                len(item_images), self.scroll_helper.total_scroll_width,
-            )
+            self.logger.info("[Stock News] Ticker: %d items, %dpx wide, gap=%dpx",
+                             len(item_images), self.scroll_helper.total_scroll_width, self.item_gap)
         except Exception as e:
-            self.logger.error(f"[Stock News] Failed to build ticker image: {e}")
+            self.logger.error("[Stock News] Failed to build ticker: %s", e)
             self.scroll_helper.clear_cache()
 
     def _render_news_item(self, news_item: dict) -> Optional[Image.Image]:
         """
-        Render one news item as a full-height PIL image strip.
+        Render one news item as a full-height image strip with per-segment colours.
 
-        display_style controls what is shown:
-          logo_and_ticker — logo (if available) + SYMBOL: headline
-          ticker_only     — SYMBOL: headline (no logo lookup)
-          logo_only       — logo (if available) + SYMBOL (no headline text)
+        Segments drawn left-to-right:
+          logo (optional) | symbol: | $price | headline | • publisher | • age
         """
         try:
             symbol = news_item.get('symbol', news_item.get('feed_name', '?'))
             title = news_item.get('title', '')
+            publisher = news_item.get('publisher', '')
+            pub_ts = news_item.get('published_ts', 0)
+            price = news_item.get('price')
+
             font_sym = self._fonts.get('symbol')
             font_hl = self._fonts.get('headline')
 
-            logo = (
-                self._get_symbol_logo(symbol)
-                if self.display_style in ('logo_and_ticker', 'logo_only')
-                else None
-            )
+            logo = (self._get_symbol_logo(symbol)
+                    if self.display_style in ('logo_and_ticker', 'logo_only') else None)
 
-            publisher = news_item.get('publisher', '')
+            # Stale: dim all colours
+            stale = self._is_data_stale()
+            sym_c = (80, 60, 0) if stale else self.symbol_color
+            txt_c = (0, 80, 0) if stale else self.text_color
+            pub_c = (60, 60, 60) if stale else self.publisher_color
+
+            # Build text segments: (text, colour, font)
+            segments: List[Tuple[str, tuple, Any]] = []
+
             if self.display_style == 'logo_only':
-                symbol_text = f" {symbol}"
-                headline_text = ''
+                segments.append((f" {symbol}", sym_c, font_sym))
+                if self.show_price and price is not None:
+                    segments.append((f"  ${price:.2f}", txt_c, font_sym))
             else:
-                symbol_text = f"{symbol}: "
-                headline_text = title
+                segments.append((f"{symbol}: ", sym_c, font_sym))
+                if self.show_price and price is not None:
+                    segments.append((f"${price:.2f}  ", txt_c, font_hl))
+                if title:
+                    segments.append((title, txt_c, font_hl))
+                suffix: List[str] = []
                 if self.show_publisher and publisher:
-                    headline_text = f"{headline_text}  •  {publisher}"
+                    suffix.append(publisher)
+                if self.show_age and pub_ts:
+                    age = self._format_age(pub_ts)
+                    if age:
+                        suffix.append(age)
+                if suffix:
+                    segments.append(("  •  " + "  •  ".join(suffix), pub_c, font_hl))
 
+            # Measure segments
             draw_tmp = ImageDraw.Draw(Image.new('RGB', (1, 1)))
-            sym_bbox = draw_tmp.textbbox((0, 0), symbol_text, font=font_sym) if symbol_text else (0, 0, 0, 0)
-            hl_bbox = draw_tmp.textbbox((0, 0), headline_text, font=font_hl) if headline_text else (0, 0, 0, 0)
+            widths: List[int] = []
+            text_h = 1
+            for text, _, font in segments:
+                if text:
+                    bb = draw_tmp.textbbox((0, 0), text, font=font)
+                    widths.append(bb[2] - bb[0])
+                    text_h = max(text_h, bb[3] - bb[1])
+                else:
+                    widths.append(0)
 
-            sym_w = sym_bbox[2] - sym_bbox[0]
-            hl_w = hl_bbox[2] - hl_bbox[0]
-            text_h = max(sym_bbox[3] - sym_bbox[1], hl_bbox[3] - hl_bbox[1], 1)
-            gap = 4
-            logo_w = (logo.width + gap) if logo else 0
-            total_w = max(logo_w + sym_w + (gap if headline_text else 0) + hl_w, 1)
+            logo_w = (logo.width + 4) if logo else 0
+            total_w = max(logo_w + sum(widths), 1)
 
             img = Image.new('RGB', (total_w, self.display_height), (0, 0, 0))
             draw = ImageDraw.Draw(img)
@@ -570,110 +708,32 @@ class StockNewsTickerPlugin(BasePlugin):
                 logo_y = max(0, (self.display_height - logo.height) // 2)
                 mask = logo if logo.mode == 'RGBA' else None
                 img.paste(logo, (x, logo_y), mask)
-                x += logo.width + gap
+                x += logo.width + 4
 
-            if symbol_text:
-                draw.text((x, text_y), symbol_text, fill=self.symbol_color, font=font_sym)
-                x += sym_w + (gap if headline_text else 0)
-            if headline_text:
-                draw.text((x, text_y), headline_text, fill=self.text_color, font=font_hl)
+            for (text, color, font), w in zip(segments, widths):
+                if text and w > 0:
+                    draw.text((x, text_y), text, fill=color, font=font)
+                    x += w
 
             return img
 
         except Exception as e:
-            self.logger.warning(f"[Stock News] Render error: {e}")
+            self.logger.warning("[Stock News] Render error: %s", e)
             return None
 
     def _rotate_headlines(self) -> None:
-        """Move the front headline to the end, optionally reshuffling after a full cycle."""
         if len(self.all_news_items) <= 1:
             return
         first = self.all_news_items[0]
         self.all_news_items = self.all_news_items[1:] + [first]
         self._items_rotated += 1
-        self.logger.info(
-            "[Stock News] Rotated: '%s...' moved to end — now showing '%s...' first",
-            first.get('title', '')[:40],
-            self.all_news_items[0].get('title', '')[:40],
-        )
+        self.logger.info("[Stock News] Rotated: '%s...' → end | '%s...' now first",
+                         first.get('title', '')[:40],
+                         self.all_news_items[0].get('title', '')[:40])
         if self.shuffle_headlines and self._items_rotated >= len(self.all_news_items):
             random.shuffle(self.all_news_items)
             self._items_rotated = 0
-            self.logger.info("[Stock News] Full rotation complete — reshuffled")
-        self._vegas_cache: Optional[list] = None  # invalidate Vegas cache
-
-    # -------------------------------------------------------------------------
-    # Config hot-reload
-    # -------------------------------------------------------------------------
-
-    def on_config_change(self, new_config: Dict[str, Any]) -> None:
-        """Apply live configuration changes without restarting the plugin."""
-        super().on_config_change(new_config)
-
-        old_symbols = set(self.feeds_config.get('stock_symbols', []))
-        old_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
-        old_font_size = self.font_size
-
-        self.feeds_config = new_config.get('feeds', {})
-        self.global_config = new_config.get('global', {})
-
-        # Scroll / display
-        self.display_duration = self.global_config.get('display_duration', 30)
-        self.scroll_speed = self.global_config.get('scroll_speed', 1)
-        self.scroll_delay = self.global_config.get('scroll_delay', 0.01)
-        self.dynamic_duration = self.global_config.get('dynamic_duration', True)
-        self.min_duration = self.global_config.get('min_duration', 30)
-        self.max_duration = self.global_config.get('max_duration', 300)
-        self.max_headlines_per_symbol = self.global_config.get('max_headlines_per_symbol', 1)
-        self.headlines_per_rotation = self.global_config.get('headlines_per_rotation', 2)
-        self.rotation_enabled = self.global_config.get('rotation_enabled', True)
-        self.rotation_threshold = self.global_config.get('rotation_threshold', 1)
-        self.shuffle_headlines = self.global_config.get('shuffle_headlines', True)
-        self.show_publisher = self.global_config.get('show_publisher', True)
-        self.font_size = self.global_config.get('font_size', 10)
-
-        # Rate limits
-        self.update_interval = self.global_config.get('update_interval_seconds', 900)
-        self.max_daily_requests = self.global_config.get('max_daily_requests', 200)
-        self.max_requests_per_hour = self.global_config.get('max_requests_per_hour', 50)
-
-        # Display style / logo
-        self.display_style = self.global_config.get('display_style', 'logo_and_ticker')
-        self.logo_size = self.global_config.get('logo_size', min(self.display_height, 32))
-        self.logo_fetch_enabled = self.global_config.get('logo_fetch_enabled', True)
-        self.logo_url_template = self.global_config.get(
-            'logo_url_template',
-            'https://financialmodelingprep.com/image-stock/{symbol}.png'
-        )
-
-        # Colors
-        self.text_color = tuple(self.feeds_config.get('text_color', [0, 255, 0]))
-        self.symbol_color = tuple(self.feeds_config.get('symbol_color', [255, 255, 0]))
-
-        # Background service
-        self.background_config = self.global_config.get('background_service', {
-            'enabled': True, 'request_timeout': 30,
-        })
-
-        # Re-apply scroll settings
-        self._configure_scroll_settings()
-
-        # Reload fonts if size changed
-        if self.font_size != old_font_size:
-            self._fonts = self._load_fonts()
-            self._register_fonts()
-            self.logger.info("[Stock News] Fonts reloaded at %dpx", self.font_size)
-
-        # Force refetch if feeds changed
-        new_symbols = set(self.feeds_config.get('stock_symbols', []))
-        new_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
-        if new_symbols != old_symbols or new_custom != old_custom:
-            self.logger.info("[Stock News] Feed config changed — forcing refresh")
-            self.last_update = 0
-
-        # Always invalidate the scroll cache so colours/style take effect immediately
-        self.scroll_helper.clear_cache()
-        self.scroll_helper.reset_scroll()
+            self.logger.info("[Stock News] Full cycle — reshuffled")
         self._vegas_cache = None
 
     # -------------------------------------------------------------------------
@@ -681,18 +741,15 @@ class StockNewsTickerPlugin(BasePlugin):
     # -------------------------------------------------------------------------
 
     def get_vegas_content(self) -> Optional[list]:
-        """Return cached rendered item images for Vegas continuous scroll."""
         if not self.all_news_items:
             return None
         if self._vegas_cache is None:
             rendered = [self._render_news_item(item) for item in self.all_news_items]
             self._vegas_cache = [img for img in rendered if img is not None]
             total_px = sum(img.width for img in self._vegas_cache)
-            self.logger.info(
-                "[Stock News] Vegas cache built: %d items, %dpx total",
-                len(self._vegas_cache), total_px,
-            )
-        return self._vegas_cache if self._vegas_cache else None
+            self.logger.info("[Stock News] Vegas cache: %d items, %dpx total",
+                             len(self._vegas_cache), total_px)
+        return self._vegas_cache or None
 
     def get_vegas_content_type(self) -> str:
         return 'multi'
@@ -704,23 +761,68 @@ class StockNewsTickerPlugin(BasePlugin):
     def _display_no_news(self) -> None:
         img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
         draw = ImageDraw.Draw(img)
-        draw.text((5, 12), "No Stock News", fill=(150, 150, 150))
+        text = "No Stock News"
+        font = self._fonts.get('headline')
+        try:
+            bb = draw.textbbox((0, 0), text, font=font)
+            x = max(0, (self.display_width - (bb[2] - bb[0])) // 2)
+            y = max(0, (self.display_height - (bb[3] - bb[1])) // 2)
+            draw.text((x, y), text, fill=(100, 100, 100), font=font)
+        except Exception:
+            draw.text((4, self.display_height // 2 - 4), text, fill=(100, 100, 100))
         self.display_manager.image = img.copy()
         self.display_manager.update_display()
 
     def _display_error(self, message: str) -> None:
         img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
         draw = ImageDraw.Draw(img)
-        draw.text((5, 12), message, fill=(255, 0, 0))
+        draw.text((4, self.display_height // 2 - 4), message, fill=(255, 0, 0))
         self.display_manager.image = img.copy()
         self.display_manager.update_display()
+
+    # -------------------------------------------------------------------------
+    # Config hot-reload
+    # -------------------------------------------------------------------------
+
+    def on_config_change(self, new_config: Dict[str, Any]) -> None:
+        super().on_config_change(new_config)
+
+        old_symbols = set(self.feeds_config.get('stock_symbols', []))
+        old_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
+        old_font_size = self.font_size
+        old_font_path = self.global_config.get('font_path', '')
+
+        self.feeds_config = new_config.get('feeds', {})
+        self.global_config = new_config.get('global', {})
+        self._apply_config()
+        self._configure_scroll_settings()
+
+        font_changed = (self.font_size != old_font_size or
+                        self.global_config.get('font_path', '') != old_font_path)
+        if font_changed:
+            self._fonts = self._load_fonts()
+            self._register_fonts()
+            self.logger.info("[Stock News] Fonts reloaded at %dpx", self.font_size)
+
+        new_symbols = set(self.feeds_config.get('stock_symbols', []))
+        new_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
+        if new_symbols != old_symbols or new_custom != old_custom:
+            # Drop stale per-symbol data for removed feeds
+            for removed in (old_symbols - new_symbols):
+                self._symbol_data.pop(removed, None)
+            self.logger.info("[Stock News] Feed config changed — will refetch next cycle")
+            self._last_symbol_fetch = 0  # trigger immediate fetch on next update()
+
+        self._check_budget_adequacy()
+        self.scroll_helper.clear_cache()
+        self.scroll_helper.reset_scroll()
+        self._vegas_cache = None
 
     # -------------------------------------------------------------------------
     # Utility
     # -------------------------------------------------------------------------
 
     def get_display_duration(self) -> float:
-        """Return ScrollHelper's dynamically calculated duration when enabled."""
         if self.dynamic_duration:
             d = self.scroll_helper.get_dynamic_duration()
             if d > 0:
@@ -729,37 +831,45 @@ class StockNewsTickerPlugin(BasePlugin):
 
     def get_info(self) -> Dict[str, Any]:
         info = super().get_info()
+        stock_symbols = self.feeds_config.get('stock_symbols', [])
         info.update({
             'total_news_items': len(self.all_news_items),
-            'stock_symbols': self.feeds_config.get('stock_symbols', []),
+            'stock_symbols': stock_symbols,
             'custom_feeds': list(self.feeds_config.get('custom_feeds', {}).keys()),
             'last_update': self.last_update,
+            'data_stale': self._is_data_stale(),
+            'is_market_hours': self._is_market_hours(),
             'display_duration': self.display_duration,
             'dynamic_duration': self.dynamic_duration,
             'display_style': self.display_style,
+            'font_size': self.font_size,
+            'item_gap': self.item_gap,
             'show_publisher': self.show_publisher,
+            'show_age': self.show_age,
+            'show_price': self.show_price,
             'shuffle_headlines': self.shuffle_headlines,
             'rotation_enabled': self.rotation_enabled,
             'rotation_threshold': self.rotation_threshold,
             'logo_fetch_enabled': self.logo_fetch_enabled,
             'logo_size': self.logo_size,
-            'requests_today': self._requests_today,
-            'requests_this_hour': len(self._request_timestamps),
+            'respect_market_hours': self.respect_market_hours,
+            'requests_today': getattr(self, '_requests_today', 0),
+            'requests_this_hour': len(getattr(self, '_request_timestamps', [])),
             'max_daily_requests': self.max_daily_requests,
             'max_requests_per_hour': self.max_requests_per_hour,
             'update_interval_seconds': self.update_interval,
-            'scroll_speed': self.scroll_speed,
-            'font_size': self.font_size,
             'text_color': self.text_color,
             'symbol_color': self.symbol_color,
+            'publisher_color': self.publisher_color,
         })
         return info
 
     def cleanup(self) -> None:
         self.all_news_items = []
+        self._symbol_data.clear()
         self._vegas_cache = None
         if hasattr(self, 'scroll_helper'):
             self.scroll_helper.clear_cache()
         if hasattr(self, '_session'):
             self._session.close()
-        self.logger.info("[Stock News] Plugin cleaned up")
+        self.logger.info("[Stock News] Cleaned up")

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -5,14 +5,13 @@ Displays scrolling stock-specific news headlines and financial updates from RSS 
 Shows market news, company announcements, and financial updates for tracked stocks.
 
 Features:
-- Stock-specific RSS feeds and news aggregation
-- Symbol tracking and filtering
-- Scrolling headline display
+- Real Yahoo Finance RSS headlines per stock symbol
+- Company logo rendering (logo+ticker, ticker only, logo only modes)
+- Configurable per-day / per-hour request budget
+- ScrollHelper-based horizontal scrolling at high FPS
+- Vegas scroll mode integration
 - Custom RSS feed support
-- Configurable scroll speed and colors
-- Background data fetching
-
-API Version: 1.0.0
+- Fully configurable colors, fonts, scroll speed, and display style
 """
 
 import logging
@@ -22,38 +21,43 @@ import xml.etree.ElementTree as ET
 import html
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, Any, List, Optional
 from PIL import Image, ImageDraw, ImageFont
 
 from src.plugin_system.base_plugin import BasePlugin
 from src.common.scroll_helper import ScrollHelper
+from src.common.logo_helper import LogoHelper
 
 logger = logging.getLogger(__name__)
+
+_YAHOO_RSS = "https://feeds.finance.yahoo.com/rss/2.0/headline?s={symbol}&region=US&lang=en-US"
 
 
 class StockNewsTickerPlugin(BasePlugin):
     """
-    Stock news ticker plugin for displaying financial headlines.
+    Stock news ticker plugin for displaying real financial headlines.
 
-    Tracks specific stock symbols and displays relevant news headlines
-    from financial RSS feeds with configurable display options.
+    Fetches live headlines from Yahoo Finance RSS per symbol and renders them
+    as a scrolling horizontal ticker with optional company logos.
 
     Configuration options:
-        feeds: Stock symbols to track and custom RSS feeds
-        display_options: Scroll speed, duration, colors
-        background_service: Data fetching configuration
+        global: Scroll, display, rate-limit, and logo settings
+        feeds: Stock symbols, custom RSS feeds, and text colors
     """
 
     def __init__(self, plugin_id: str, config: Dict[str, Any],
                  display_manager, cache_manager, plugin_manager):
-        """Initialize the stock news ticker plugin."""
         super().__init__(plugin_id, config, display_manager, cache_manager, plugin_manager)
 
-        # Configuration
         self.feeds_config = config.get('feeds', {})
         self.global_config = config.get('global', {})
 
-        # Display settings
+        # Display dimensions
+        self.display_width = self.display_manager.matrix.width
+        self.display_height = self.display_manager.matrix.height
+
+        # Scroll / display settings
         self.display_duration = self.global_config.get('display_duration', 30)
         self.scroll_speed = self.global_config.get('scroll_speed', 1)
         self.scroll_delay = self.global_config.get('scroll_delay', 0.01)
@@ -63,35 +67,50 @@ class StockNewsTickerPlugin(BasePlugin):
         self.max_headlines_per_symbol = self.global_config.get('max_headlines_per_symbol', 1)
         self.headlines_per_rotation = self.global_config.get('headlines_per_rotation', 2)
         self.font_size = self.global_config.get('font_size', 10)
+        self.rotation_enabled = self.global_config.get('rotation_enabled', True)
+        self.rotation_threshold = self.global_config.get('rotation_threshold', 1)
 
-        # Display dimensions
-        self.display_width = self.display_manager.matrix.width
-        self.display_height = self.display_manager.matrix.height
+        # Fetch rate limiting
+        self.update_interval = self.global_config.get('update_interval_seconds', 900)
+        self.max_daily_requests = self.global_config.get('max_daily_requests', 200)
+        self.max_requests_per_hour = self.global_config.get('max_requests_per_hour', 50)
+        self._requests_today: int = 0
+        self._last_reset_date: str = ''
+        self._request_timestamps: list = []
+
+        # Display style
+        self.display_style = self.global_config.get('display_style', 'logo_and_ticker')
+        self.logo_size = self.global_config.get('logo_size', min(self.display_height, 32))
+        self.logo_fetch_enabled = self.global_config.get('logo_fetch_enabled', True)
+        self.logo_url_template = self.global_config.get(
+            'logo_url_template',
+            'https://financialmodelingprep.com/image-stock/{symbol}.png'
+        )
 
         # Colors
         self.text_color = tuple(self.feeds_config.get('text_color', [0, 255, 0]))
         self.symbol_color = tuple(self.feeds_config.get('symbol_color', [255, 255, 0]))
-        self.separator_color = tuple(self.feeds_config.get('separator_color', [255, 0, 0]))
 
-        # Background service configuration
+        # Background service config (kept for timeout setting)
         self.background_config = self.global_config.get('background_service', {
             'enabled': True,
             'request_timeout': 30,
-            'max_retries': 5,
-            'priority': 2
         })
 
         # State
-        self.current_news_items = []
-        self.current_news_group = 0
-        self.scroll_position = 0
-        self.last_update = 0
-        self.all_news_items = []
-        self.current_rotation_index = 0
-        self._cycle_complete = False
+        self.all_news_items: list = []
+        self.current_rotation_index: int = 0
+        self._rotation_count: int = 0
+        self._cycle_complete: bool = False
+        self.last_update: float = 0
         self.initialized = True
 
-        # Fonts and scroll
+        # Logo infrastructure
+        self._logo_dir = Path(__file__).parent / 'assets' / 'logos'
+        self._logo_dir.mkdir(parents=True, exist_ok=True)
+        self.logo_helper = LogoHelper(self.display_width, self.display_height, logger=self.logger)
+
+        # Fonts and scroll helper
         self._fonts: dict = self._load_fonts()
         self.scroll_helper = ScrollHelper(self.display_width, self.display_height, logger=self.logger)
         self._configure_scroll_settings()
@@ -99,13 +118,16 @@ class StockNewsTickerPlugin(BasePlugin):
         # Register fonts with font manager for UI introspection
         self._register_fonts()
 
-        # Log configuration
         stock_symbols = self.feeds_config.get('stock_symbols', [])
         custom_feeds = list(self.feeds_config.get('custom_feeds', {}).keys())
+        self.logger.info(
+            "Stock news ticker initialized — symbols=%s, custom_feeds=%s, style=%s",
+            stock_symbols, custom_feeds, self.display_style,
+        )
 
-        self.logger.info("Stock news ticker plugin initialized")
-        self.logger.info(f"Tracking symbols: {stock_symbols}")
-        self.logger.info(f"Custom feeds: {custom_feeds}")
+    # -------------------------------------------------------------------------
+    # Font / scroll configuration
+    # -------------------------------------------------------------------------
 
     def _load_fonts(self) -> dict:
         """Load PIL fonts for rendering."""
@@ -120,7 +142,7 @@ class StockNewsTickerPlugin(BasePlugin):
             return {}
 
     def _configure_scroll_settings(self) -> None:
-        """Configure ScrollHelper with plugin scroll settings."""
+        """Configure ScrollHelper with plugin scroll settings (supports legacy keys)."""
         if 'scroll_pixels_per_second' in self.global_config:
             pixels_per_second = float(self.global_config['scroll_pixels_per_second'])
         elif self.scroll_delay and self.scroll_delay > 0:
@@ -144,215 +166,201 @@ class StockNewsTickerPlugin(BasePlugin):
             max_duration=self.max_duration,
         )
 
-    def _register_fonts(self):
-        """Register fonts with the font manager."""
+    def _register_fonts(self) -> None:
+        """Register fonts with the font manager for UI introspection."""
         try:
             if not hasattr(self.plugin_manager, 'font_manager'):
                 return
-
-            font_manager = self.plugin_manager.font_manager
-
-            # Headline font
-            font_manager.register_manager_font(
+            fm = self.plugin_manager.font_manager
+            fm.register_manager_font(
                 manager_id=self.plugin_id,
                 element_key=f"{self.plugin_id}.headline",
-                family="press_start",
-                size_px=self.font_size,
-                color=self.text_color
+                family="press_start", size_px=self.font_size, color=self.text_color,
             )
-
-            # Symbol font
-            font_manager.register_manager_font(
+            fm.register_manager_font(
                 manager_id=self.plugin_id,
                 element_key=f"{self.plugin_id}.symbol",
-                family="press_start",
-                size_px=self.font_size,
-                color=self.symbol_color
+                family="press_start", size_px=self.font_size, color=self.symbol_color,
             )
-
-            # Separator font
-            font_manager.register_manager_font(
-                manager_id=self.plugin_id,
-                element_key=f"{self.plugin_id}.separator",
-                family="press_start",
-                size_px=self.font_size,
-                color=self.separator_color
-            )
-
-            # Info font (source, time)
-            font_manager.register_manager_font(
+            fm.register_manager_font(
                 manager_id=self.plugin_id,
                 element_key=f"{self.plugin_id}.info",
-                family="four_by_six",
-                size_px=6,
-                color=(150, 150, 150)
+                family="four_by_six", size_px=6, color=(150, 150, 150),
             )
-
-            self.logger.info("Stock news ticker fonts registered")
         except Exception as e:
             self.logger.warning(f"Error registering fonts: {e}")
 
+    # -------------------------------------------------------------------------
+    # Update / data fetching
+    # -------------------------------------------------------------------------
+
     def update(self) -> None:
-        """Update stock news headlines for all tracked symbols."""
+        """Fetch fresh headlines for all tracked symbols and custom feeds."""
         if not self.initialized:
+            return
+        if time.time() - self.last_update < self.update_interval:
             return
 
         try:
-            self.current_news_items = []
-            self.all_news_items = []
-
-            # Get stock symbols to track
+            all_items: list = []
             stock_symbols = self.feeds_config.get('stock_symbols', [])
 
-            # Fetch news for each symbol
             for symbol in stock_symbols:
-                symbol_news = self._fetch_stock_news(symbol)
-                if symbol_news:
-                    self.all_news_items.extend(symbol_news)
+                items = self._fetch_stock_news(symbol)
+                all_items.extend(items)
 
-            # Fetch from custom feeds
             custom_feeds = self.feeds_config.get('custom_feeds', {})
             for feed_name, feed_url in custom_feeds.items():
-                custom_news = self._fetch_feed_headlines(feed_name, feed_url)
-                if custom_news:
-                    self.all_news_items.extend(custom_news)
+                items = self._fetch_rss_feed(
+                    feed_name, feed_url, max_items=self.headlines_per_rotation
+                )
+                all_items.extend(items)
 
-            # Limit total news items and reset rotation tracking
-            max_items = len(stock_symbols) * self.max_headlines_per_symbol + len(custom_feeds) * self.headlines_per_rotation
-            if len(self.all_news_items) > max_items:
-                self.all_news_items = self.all_news_items[:max_items]
-
-            # Reset rotation tracking for new content
-            if self.all_news_items:
-                self.current_rotation_index = 0
-
+            max_items = (
+                len(stock_symbols) * self.max_headlines_per_symbol
+                + len(custom_feeds) * self.headlines_per_rotation
+            )
+            self.all_news_items = all_items[:max_items] if len(all_items) > max_items else all_items
+            self.current_rotation_index = 0
+            self._rotation_count = 0
             self.last_update = time.time()
-            self.logger.debug(f"Updated stock news: {len(self.all_news_items)} total items")
+            self.logger.info("[Stock News] Updated: %d items", len(self.all_news_items))
+
             if hasattr(self, 'scroll_helper'):
                 self.scroll_helper.clear_cache()
                 self.scroll_helper.reset_scroll()
 
         except Exception as e:
-            self.logger.error(f"Error updating stock news: {e}")
+            self.logger.error(f"[Stock News] update() error: {e}")
 
     def _fetch_stock_news(self, symbol: str) -> List[Dict]:
-        """Fetch news for a specific stock symbol."""
-        cache_key = f"stock_news_{symbol}_{datetime.now().strftime('%Y%m%d%H')}"
-        try:
-            update_interval = int(self.global_config.get('update_interval_seconds', 300))
-        except (ValueError, TypeError):
-            update_interval = 300
+        """Fetch live headlines for a stock symbol from Yahoo Finance RSS."""
+        url = _YAHOO_RSS.format(symbol=symbol)
+        items = self._fetch_rss_feed(symbol, url, max_items=self.max_headlines_per_symbol)
+        for item in items:
+            item['symbol'] = symbol
+        return items
 
-        # Check cache first
-        cached_data = self.cache_manager.get(cache_key)
-        if cached_data and (time.time() - self.last_update) < update_interval:
-            self.logger.debug(f"Using cached news for {symbol}")
-            return cached_data
+    def _fetch_rss_feed(self, feed_name: str, url: str, max_items: int = 3) -> List[Dict]:
+        """Fetch and parse an RSS feed with caching and request budget enforcement."""
+        bucket = int(time.time() // self.update_interval)
+        cache_key = f"stock_rss_{feed_name}_{bucket}"
+        cached = self.cache_manager.get(cache_key)
+        if cached:
+            self.logger.debug("[Stock News] Cache hit: %s", feed_name)
+            return cached
 
-        try:
-            # For now, return placeholder data since actual stock news APIs would require API keys
-            # In a real implementation, this would call financial news APIs
-            placeholder_news = [
-                {
-                    'symbol': symbol,
-                    'title': f"{symbol} Reports Strong Quarterly Earnings",
-                    'summary': f"{symbol} announces better than expected results",
-                    'source': 'Financial News',
-                    'published': datetime.now().isoformat(),
-                    'url': f'https://example.com/news/{symbol}'
-                }
-            ]
-
-            # Cache the results
-            self.cache_manager.set(cache_key, placeholder_news, ttl=update_interval * 2)
-
-            return placeholder_news
-
-        except Exception as e:
-            self.logger.error(f"Error fetching news for {symbol}: {e}")
+        if not self._check_request_budget():
+            self.logger.warning(
+                "[Stock News] Request budget exceeded (%d/day, %d/hr limit) — skipping %s",
+                self._requests_today, self.max_requests_per_hour, feed_name,
+            )
             return []
 
-    def _fetch_feed_headlines(self, feed_name: str, feed_url: str) -> List[Dict]:
-        """Fetch headlines from a custom RSS feed."""
-        cache_key = f"stock_feed_{feed_name}_{datetime.now().strftime('%Y%m%d%H')}"
         try:
-            update_interval = int(self.global_config.get('update_interval_seconds', 300))
-        except (ValueError, TypeError):
-            update_interval = 300
+            self.logger.info("[Stock News] Fetching RSS: %s", feed_name)
+            timeout = self.background_config.get('request_timeout', 30)
+            resp = requests.get(url, timeout=timeout, headers={'User-Agent': 'LEDMatrix/2.0'})
+            resp.raise_for_status()
+            self._record_request()
 
-        # Check cache first
-        cached_data = self.cache_manager.get(cache_key)
-        if cached_data and (time.time() - self.last_update) < update_interval:
-            self.logger.debug(f"Using cached headlines for {feed_name}")
-            return cached_data
+            root = ET.fromstring(resp.content)
+            items: List[Dict] = []
+            for rss_item in root.findall('.//item')[:max_items]:
+                title_el = rss_item.find('title')
+                if title_el is None or not title_el.text:
+                    continue
+                link_el = rss_item.find('link')
+                pub_el = rss_item.find('pubDate')
+                items.append({
+                    'feed_name': feed_name,
+                    'title': self._clean_headline(html.unescape(title_el.text.strip())),
+                    'link': (link_el.text or '') if link_el is not None else '',
+                    'published': (pub_el.text or '') if pub_el is not None else '',
+                })
 
-        try:
-            self.logger.info(f"Fetching stock headlines from {feed_name}...")
-            response = requests.get(feed_url, timeout=self.background_config.get('request_timeout', 30))
-            response.raise_for_status()
-
-            # Parse RSS XML
-            root = ET.fromstring(response.content)
-            headlines = []
-
-            # Extract headlines from RSS items
-            for item in root.findall('.//item')[:self.headlines_per_rotation]:
-                title = item.find('title')
-                description = item.find('description')
-                pub_date = item.find('pubDate')
-                link = item.find('link')
-
-                if title is not None and title.text:
-                    headline = {
-                        'feed_name': feed_name,
-                        'title': html.unescape(title.text).strip(),
-                        'description': html.unescape(description.text).strip() if description is not None else '',
-                        'published': pub_date.text if pub_date is not None else '',
-                        'link': link.text if link is not None else '',
-                        'timestamp': datetime.now().isoformat()
-                    }
-
-                    # Clean up the title
-                    headline['title'] = self._clean_headline(headline['title'])
-                    headlines.append(headline)
-
-            # Cache the results
-            self.cache_manager.set(cache_key, headlines, ttl=update_interval * 2)
-
-            return headlines
+            self.cache_manager.set(cache_key, items, ttl=self.update_interval * 2)
+            self.logger.info("[Stock News] Got %d items for %s", len(items), feed_name)
+            return items
 
         except requests.RequestException as e:
-            self.logger.error(f"Error fetching RSS feed {feed_name}: {e}")
-            return []
+            self.logger.error("[Stock News] RSS fetch error for %s: %s", feed_name, e)
         except ET.ParseError as e:
-            self.logger.error(f"Error parsing RSS feed {feed_name}: {e}")
-            return []
+            self.logger.error("[Stock News] RSS parse error for %s: %s", feed_name, e)
         except Exception as e:
-            self.logger.error(f"Error processing RSS feed {feed_name}: {e}")
-            return []
+            self.logger.error("[Stock News] Unexpected error for %s: %s", feed_name, e)
+        return []
+
+    def _check_request_budget(self) -> bool:
+        """Return True if within daily and hourly request limits."""
+        today = datetime.now().strftime('%Y-%m-%d')
+        if self._last_reset_date != today:
+            self._requests_today = 0
+            self._last_reset_date = today
+
+        if self._requests_today >= self.max_daily_requests:
+            return False
+
+        cutoff = time.time() - 3600
+        self._request_timestamps = [t for t in self._request_timestamps if t > cutoff]
+        if len(self._request_timestamps) >= self.max_requests_per_hour:
+            return False
+
+        return True
+
+    def _record_request(self) -> None:
+        self._requests_today += 1
+        self._request_timestamps.append(time.time())
 
     def _clean_headline(self, headline: str) -> str:
-        """Clean and format headline text."""
+        """Normalise whitespace and trim headline to display-safe length."""
         if not headline:
             return ""
-
-        # Remove extra whitespace
         headline = re.sub(r'\s+', ' ', headline.strip())
-
-        # Remove common artifacts
-        headline = re.sub(r'^\s*-\s*', '', headline)  # Remove leading dashes
-        headline = re.sub(r'\s+', ' ', headline)  # Normalize whitespace
-
-        # Limit length for display
+        headline = re.sub(r'^\s*-\s*', '', headline)
         if len(headline) > 80:
             headline = headline[:77] + "..."
-
         return headline
 
+    # -------------------------------------------------------------------------
+    # Logo fetching
+    # -------------------------------------------------------------------------
+
+    def _get_symbol_logo(self, symbol: str) -> Optional[Image.Image]:
+        """Return a company logo PIL Image for the symbol, downloading if needed."""
+        if not self.logo_fetch_enabled:
+            return None
+
+        logo_path = self._logo_dir / f"{symbol}.png"
+        if logo_path.exists():
+            return self.logo_helper.load_logo(
+                symbol, logo_path,
+                max_width=self.logo_size, max_height=self.logo_size,
+            )
+
+        url = self.logo_url_template.replace('{symbol}', symbol)
+        try:
+            resp = requests.get(url, timeout=10, headers={'User-Agent': 'LEDMatrix/2.0'})
+            if resp.status_code == 200 and resp.content:
+                logo_path.write_bytes(resp.content)
+                self.logger.info("[Stock News] Downloaded logo for %s", symbol)
+                return self.logo_helper.load_logo(
+                    symbol, logo_path,
+                    max_width=self.logo_size, max_height=self.logo_size,
+                )
+        except Exception as e:
+            self.logger.debug("[Stock News] Logo fetch failed for %s: %s", symbol, e)
+
+        return None
+
+    # -------------------------------------------------------------------------
+    # Display
+    # -------------------------------------------------------------------------
+
     def display(self, display_mode: str = None, force_clear: bool = False) -> None:
-        """Display scrolling stock news headlines."""
+        """Display the scrolling stock news ticker."""
         if not self.initialized:
-            self._display_error("Stock news ticker plugin not initialized")
+            self._display_error("Stock news ticker not initialized")
             return
 
         if not self.all_news_items:
@@ -374,8 +382,18 @@ class StockNewsTickerPlugin(BasePlugin):
         self.display_manager.process_deferred_updates()
 
         self.scroll_helper.update_scroll_position()
-        if self.dynamic_duration and self.scroll_helper.is_scroll_complete():
+
+        if self.scroll_helper.is_scroll_complete():
             self._cycle_complete = True
+            if self.rotation_enabled:
+                self._rotation_count += 1
+                if self._rotation_count >= self.rotation_threshold:
+                    self._rotation_count = 0
+                    if len(self.all_news_items) > 1:
+                        self.all_news_items = self.all_news_items[1:] + self.all_news_items[:1]
+                    self.scroll_helper.clear_cache()
+                    self.scroll_helper.reset_scroll()
+                    return  # next display() call rebuilds with rotated order
 
         visible_portion = self.scroll_helper.get_visible_portion()
         if visible_portion:
@@ -385,103 +403,147 @@ class StockNewsTickerPlugin(BasePlugin):
         self.scroll_helper.log_frame_rate()
 
     def _create_scrolling_image(self) -> None:
-        """Build wide horizontal ticker image from all news items."""
+        """Build the wide horizontal ticker image from all current news items."""
         try:
-            item_images = []
-            for news_item in self.all_news_items:
-                img = self._render_news_item(news_item)
-                if img:
-                    item_images.append(img)
+            item_images = [
+                img for img in (self._render_news_item(item) for item in self.all_news_items)
+                if img is not None
+            ]
             if not item_images:
                 self.scroll_helper.clear_cache()
                 return
             self.scroll_helper.create_scrolling_image(item_images, item_gap=48)
             self._cycle_complete = False
             self.logger.info(
-                "Created stock news image: %d items, scroll_width=%dpx",
+                "[Stock News] Ticker image built: %d items, %dpx wide",
                 len(item_images), self.scroll_helper.total_scroll_width,
             )
         except Exception as e:
-            self.logger.error(f"Error creating stock news image: {e}")
+            self.logger.error(f"[Stock News] Failed to build ticker image: {e}")
             self.scroll_helper.clear_cache()
 
     def _render_news_item(self, news_item: dict) -> Optional[Image.Image]:
-        """Render one news item as a PIL image strip (symbol in yellow, headline in green)."""
+        """
+        Render one news item as a full-height PIL image strip.
+
+        display_style controls what is shown:
+          logo_and_ticker — logo (if available) + SYMBOL: headline
+          ticker_only     — SYMBOL: headline (no logo lookup)
+          logo_only       — logo (if available) + SYMBOL (no headline text)
+        """
         try:
             symbol = news_item.get('symbol', news_item.get('feed_name', '?'))
-            title = news_item.get('title', 'No title')
-            symbol_text = f"{symbol}: "
-
+            title = news_item.get('title', '')
             font_sym = self._fonts.get('symbol')
             font_hl = self._fonts.get('headline')
 
+            logo = (
+                self._get_symbol_logo(symbol)
+                if self.display_style in ('logo_and_ticker', 'logo_only')
+                else None
+            )
+
+            if self.display_style == 'logo_only':
+                symbol_text = f" {symbol}"
+                headline_text = ''
+            else:
+                symbol_text = f"{symbol}: "
+                headline_text = title
+
             draw_tmp = ImageDraw.Draw(Image.new('RGB', (1, 1)))
-            sym_bbox = draw_tmp.textbbox((0, 0), symbol_text, font=font_sym)
-            hl_bbox = draw_tmp.textbbox((0, 0), title, font=font_hl)
+            sym_bbox = draw_tmp.textbbox((0, 0), symbol_text, font=font_sym) if symbol_text else (0, 0, 0, 0)
+            hl_bbox = draw_tmp.textbbox((0, 0), headline_text, font=font_hl) if headline_text else (0, 0, 0, 0)
 
             sym_w = sym_bbox[2] - sym_bbox[0]
             hl_w = hl_bbox[2] - hl_bbox[0]
-            text_h = max(sym_bbox[3] - sym_bbox[1], hl_bbox[3] - hl_bbox[1])
+            text_h = max(sym_bbox[3] - sym_bbox[1], hl_bbox[3] - hl_bbox[1], 1)
             gap = 4
-            total_w = sym_w + gap + hl_w
+            logo_w = (logo.width + gap) if logo else 0
+            total_w = max(logo_w + sym_w + (gap if headline_text else 0) + hl_w, 1)
 
             img = Image.new('RGB', (total_w, self.display_height), (0, 0, 0))
             draw = ImageDraw.Draw(img)
-            y = max(0, (self.display_height - text_h) // 2)
-            draw.text((0, y), symbol_text, fill=self.symbol_color, font=font_sym)
-            draw.text((sym_w + gap, y), title, fill=self.text_color, font=font_hl)
+            text_y = max(0, (self.display_height - text_h) // 2)
+
+            x = 0
+            if logo:
+                logo_y = max(0, (self.display_height - logo.height) // 2)
+                mask = logo if logo.mode == 'RGBA' else None
+                img.paste(logo, (x, logo_y), mask)
+                x += logo.width + gap
+
+            if symbol_text:
+                draw.text((x, text_y), symbol_text, fill=self.symbol_color, font=font_sym)
+                x += sym_w + (gap if headline_text else 0)
+            if headline_text:
+                draw.text((x, text_y), headline_text, fill=self.text_color, font=font_hl)
+
             return img
+
         except Exception as e:
-            self.logger.warning(f"Error rendering news item: {e}")
+            self.logger.warning(f"[Stock News] Render error: {e}")
             return None
 
-    def _display_no_news(self):
-        """Display message when no news is available."""
-        img = Image.new('RGB', (self.display_manager.matrix.width,
-                               self.display_manager.matrix.height),
-                       (0, 0, 0))
+    # -------------------------------------------------------------------------
+    # Vegas scroll mode
+    # -------------------------------------------------------------------------
+
+    def get_vegas_content(self) -> Optional[list]:
+        """Return list of item images for Vegas continuous scroll."""
+        if not self.all_news_items:
+            return None
+        images = [self._render_news_item(item) for item in self.all_news_items]
+        result = [img for img in images if img is not None]
+        return result if result else None
+
+    def get_vegas_content_type(self) -> str:
+        return 'multi'
+
+    # -------------------------------------------------------------------------
+    # Fallback displays
+    # -------------------------------------------------------------------------
+
+    def _display_no_news(self) -> None:
+        img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
         draw = ImageDraw.Draw(img)
         draw.text((5, 12), "No Stock News", fill=(150, 150, 150))
-
         self.display_manager.image = img.copy()
         self.display_manager.update_display()
 
-    def _display_error(self, message: str):
-        """Display error message."""
-        img = Image.new('RGB', (self.display_manager.matrix.width,
-                               self.display_manager.matrix.height),
-                       (0, 0, 0))
+    def _display_error(self, message: str) -> None:
+        img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
         draw = ImageDraw.Draw(img)
         draw.text((5, 12), message, fill=(255, 0, 0))
-
         self.display_manager.image = img.copy()
         self.display_manager.update_display()
 
+    # -------------------------------------------------------------------------
+    # Utility
+    # -------------------------------------------------------------------------
+
     def get_display_duration(self) -> float:
-        """Get display duration from config."""
         return self.display_duration
 
     def get_info(self) -> Dict[str, Any]:
-        """Return plugin info for web UI."""
         info = super().get_info()
         info.update({
             'total_news_items': len(self.all_news_items),
             'stock_symbols': self.feeds_config.get('stock_symbols', []),
             'custom_feeds': list(self.feeds_config.get('custom_feeds', {}).keys()),
             'last_update': self.last_update,
-            'display_duration': self.display_duration,
+            'display_style': self.display_style,
+            'requests_today': self._requests_today,
+            'requests_this_hour': len(self._request_timestamps),
+            'max_daily_requests': self.max_daily_requests,
+            'max_requests_per_hour': self.max_requests_per_hour,
+            'update_interval_seconds': self.update_interval,
             'scroll_speed': self.scroll_speed,
-            'max_headlines_per_symbol': self.max_headlines_per_symbol,
-            'headlines_per_rotation': self.headlines_per_rotation,
             'font_size': self.font_size,
             'text_color': self.text_color,
             'symbol_color': self.symbol_color,
-            'separator_color': self.separator_color
         })
         return info
 
     def cleanup(self) -> None:
-        """Cleanup resources."""
         self.all_news_items = []
-        self.current_news_items = []
-        self.logger.info("Stock news ticker plugin cleaned up")
+        self.logger.info("[Stock News] Plugin cleaned up")

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -64,6 +64,7 @@ class StockNewsTickerPlugin(BasePlugin):
         # State — persistent across update cycles
         self.all_news_items: list = []
         self._symbol_data: Dict[str, List] = {}   # per-symbol/feed headline cache
+        self._logo_failed: set = set()            # symbols whose logo download failed this session
         self._feed_last_fetch: Dict[str, float] = {}
         self._fetch_index: int = 0                # rotating symbol index
         self._last_symbol_fetch: float = 0
@@ -134,7 +135,9 @@ class StockNewsTickerPlugin(BasePlugin):
 
         # Display style
         self.display_style = gc.get('display_style', 'logo_and_ticker')
-        self.logo_size = gc.get('logo_size', min(self.display_height, 32))
+        # 0 → auto: fill the full display height so logos use all available vertical space
+        raw_ls = gc.get('logo_size', 0)
+        self.logo_size = int(raw_ls) if raw_ls and int(raw_ls) > 0 else self.display_height
         self.logo_fetch_enabled = gc.get('logo_fetch_enabled', True)
         self.logo_url_template = gc.get(
             'logo_url_template',
@@ -545,13 +548,27 @@ class StockNewsTickerPlugin(BasePlugin):
     # -------------------------------------------------------------------------
 
     def _get_symbol_logo(self, symbol: str) -> Optional[Image.Image]:
+        """Return a logo PIL Image sized to display_height, downloading once if needed.
+
+        Logos are constrained by height only (max_width is generous) so landscape
+        company logos render at full panel height without being squeezed into a square.
+        Failed downloads are remembered for the session to avoid repeated attempts.
+        """
         if not self.logo_fetch_enabled:
             return None
+        if symbol in self._logo_failed:
+            return None
+
+        # Width can be up to 4× height — lets landscape logos breathe
+        max_w = self.logo_size * 4
+
         logo_path = self._logo_dir / f"{symbol}.png"
         if logo_path.exists():
             return self.logo_helper.load_logo(symbol, logo_path,
-                                              max_width=self.logo_size,
+                                              max_width=max_w,
                                               max_height=self.logo_size)
+
+        # Download and cache to disk on first use
         url = self.logo_url_template.replace('{symbol}', symbol)
         try:
             resp = self._session.get(url, timeout=10)
@@ -559,10 +576,14 @@ class StockNewsTickerPlugin(BasePlugin):
                 logo_path.write_bytes(resp.content)
                 self.logger.info("[Stock News] Downloaded logo for %s", symbol)
                 return self.logo_helper.load_logo(symbol, logo_path,
-                                                  max_width=self.logo_size,
+                                                  max_width=max_w,
                                                   max_height=self.logo_size)
+            self.logger.debug("[Stock News] Logo not available for %s (HTTP %d)",
+                              symbol, resp.status_code)
         except Exception as e:
             self.logger.debug("[Stock News] Logo fetch failed for %s: %s", symbol, e)
+
+        self._logo_failed.add(symbol)
         return None
 
     # -------------------------------------------------------------------------

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -26,7 +26,6 @@ import logging
 import random
 import time
 import requests
-import xml.etree.ElementTree as ET
 import html
 import re
 from datetime import datetime
@@ -35,6 +34,7 @@ from typing import Dict, Any, List, Optional, Tuple
 from PIL import Image, ImageDraw, ImageFont
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+import defusedxml.ElementTree as ET
 
 from src.plugin_system.base_plugin import BasePlugin
 from src.common.scroll_helper import ScrollHelper
@@ -149,6 +149,9 @@ class StockNewsTickerPlugin(BasePlugin):
         self.show_age = gc.get('show_age', True)
         self.show_price = gc.get('show_price', False)
 
+        # Cross-plugin sync
+        self.sync_with_stocks_plugin = gc.get('sync_with_stocks_plugin', False)
+
         # Colours
         self.text_color: Tuple = tuple(fc.get('text_color', [0, 255, 0]))
         self.symbol_color: Tuple = tuple(fc.get('symbol_color', [255, 255, 0]))
@@ -247,7 +250,10 @@ class StockNewsTickerPlugin(BasePlugin):
             return
 
         now = time.time()
-        stock_symbols = self.feeds_config.get('stock_symbols', [])
+        configured_symbols = self.feeds_config.get('stock_symbols', [])
+        synced_symbols = self._get_stocks_plugin_symbols()
+        # Merge: configured first, then any extras from stocks plugin (deduped, order preserved)
+        stock_symbols = list(dict.fromkeys(configured_symbols + synced_symbols))
         custom_feeds = self.feeds_config.get('custom_feeds', {})
         fetched = False
 
@@ -282,9 +288,27 @@ class StockNewsTickerPlugin(BasePlugin):
         if fetched:
             self._rebuild_all_news_items()
 
+    def _get_stocks_plugin_symbols(self) -> List[str]:
+        """Return equity symbols from the ledmatrix-stocks plugin when sync is enabled."""
+        if not self.sync_with_stocks_plugin:
+            return []
+        try:
+            stocks_plugin = self.plugin_manager.get_plugin('ledmatrix-stocks')
+            if stocks_plugin is None:
+                return []
+            stocks_cfg = getattr(stocks_plugin, 'config', {})
+            symbols = stocks_cfg.get('stocks', {}).get('symbols', [])
+            # Filter out index/crypto-style symbols that won't have news (^GSPC, BTC-USD)
+            equity = [s for s in symbols if s and not s.startswith('^') and '-' not in s]
+            return equity
+        except Exception as e:
+            self.logger.debug("[Stock News] Could not read ledmatrix-stocks symbols: %s", e)
+            return []
+
     def _rebuild_all_news_items(self) -> None:
         """Rebuild all_news_items from per-symbol cached data."""
-        stock_symbols = self.feeds_config.get('stock_symbols', [])
+        configured = self.feeds_config.get('stock_symbols', [])
+        stock_symbols = list(dict.fromkeys(configured + self._get_stocks_plugin_symbols()))
         custom_feeds = self.feeds_config.get('custom_feeds', {})
 
         all_items: list = []
@@ -590,7 +614,7 @@ class StockNewsTickerPlugin(BasePlugin):
     # Display
     # -------------------------------------------------------------------------
 
-    def display(self, display_mode: str = None, force_clear: bool = False) -> None:
+    def display(self, display_mode: Optional[str] = None, force_clear: bool = False) -> None:
         if not self.initialized:
             self._display_error("Stock news ticker not initialized")
             return

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -15,6 +15,7 @@ Features:
 """
 
 import logging
+import random
 import time
 import requests
 import xml.etree.ElementTree as ET
@@ -24,6 +25,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from PIL import Image, ImageDraw, ImageFont
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from src.plugin_system.base_plugin import BasePlugin
 from src.common.scroll_helper import ScrollHelper
@@ -31,6 +34,7 @@ from src.common.logo_helper import LogoHelper
 
 logger = logging.getLogger(__name__)
 
+_YAHOO_SEARCH = "https://query1.finance.yahoo.com/v1/finance/search"
 _YAHOO_RSS = "https://feeds.finance.yahoo.com/rss/2.0/headline?s={symbol}&region=US&lang=en-US"
 
 
@@ -69,6 +73,8 @@ class StockNewsTickerPlugin(BasePlugin):
         self.font_size = self.global_config.get('font_size', 10)
         self.rotation_enabled = self.global_config.get('rotation_enabled', True)
         self.rotation_threshold = self.global_config.get('rotation_threshold', 1)
+        self.shuffle_headlines = self.global_config.get('shuffle_headlines', True)
+        self.show_publisher = self.global_config.get('show_publisher', True)
 
         # Fetch rate limiting
         self.update_interval = self.global_config.get('update_interval_seconds', 900)
@@ -101,9 +107,13 @@ class StockNewsTickerPlugin(BasePlugin):
         self.all_news_items: list = []
         self.current_rotation_index: int = 0
         self._rotation_count: int = 0
+        self._items_rotated: int = 0   # tracks full-cycle completions for shuffle
         self._cycle_complete: bool = False
         self.last_update: float = 0
         self.initialized = True
+
+        # HTTP session with retry/backoff
+        self._session = self._create_session()
 
         # Logo infrastructure
         self._logo_dir = Path(__file__).parent / 'assets' / 'logos'
@@ -190,6 +200,21 @@ class StockNewsTickerPlugin(BasePlugin):
         except Exception as e:
             self.logger.warning(f"Error registering fonts: {e}")
 
+    def _create_session(self) -> requests.Session:
+        """Build a requests Session with automatic retry and exponential backoff."""
+        session = requests.Session()
+        retry = Retry(
+            total=4,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"],
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        session.headers.update({'User-Agent': 'LEDMatrix/2.0 (stock-news plugin)'})
+        return session
+
     # -------------------------------------------------------------------------
     # Update / data fetching
     # -------------------------------------------------------------------------
@@ -221,8 +246,11 @@ class StockNewsTickerPlugin(BasePlugin):
                 + len(custom_feeds) * self.headlines_per_rotation
             )
             self.all_news_items = all_items[:max_items] if len(all_items) > max_items else all_items
+            if self.shuffle_headlines and self.all_news_items:
+                random.shuffle(self.all_news_items)
             self.current_rotation_index = 0
             self._rotation_count = 0
+            self._items_rotated = 0
             self.last_update = time.time()
             self.logger.info("[Stock News] Updated: %d items", len(self.all_news_items))
 
@@ -234,12 +262,78 @@ class StockNewsTickerPlugin(BasePlugin):
             self.logger.error(f"[Stock News] update() error: {e}")
 
     def _fetch_stock_news(self, symbol: str) -> List[Dict]:
-        """Fetch live headlines for a stock symbol from Yahoo Finance RSS."""
+        """Fetch live headlines for a symbol — tries YF search API first, falls back to RSS."""
+        items = self._fetch_yf_api(symbol)
+        if items:
+            return items
+        # RSS fallback (e.g. if API changes or rate-limits)
+        self.logger.debug("[Stock News] RSS fallback for %s", symbol)
         url = _YAHOO_RSS.format(symbol=symbol)
         items = self._fetch_rss_feed(symbol, url, max_items=self.max_headlines_per_symbol)
         for item in items:
             item['symbol'] = symbol
         return items
+
+    def _fetch_yf_api(self, symbol: str) -> List[Dict]:
+        """Fetch headlines via Yahoo Finance search API (returns publisher + timestamp)."""
+        bucket = int(time.time() // self.update_interval)
+        cache_key = f"stock_yf_{symbol}_{bucket}"
+        cached = self.cache_manager.get(cache_key)
+        if cached:
+            self.logger.debug("[Stock News] Cache hit (YF API): %s", symbol)
+            return cached
+
+        if not self._check_request_budget():
+            self.logger.warning(
+                "[Stock News] Request budget exceeded (%d/day, %d/hr limit) — skipping %s",
+                self._requests_today, self.max_requests_per_hour, symbol,
+            )
+            return []
+
+        params = {
+            'q': symbol,
+            'lang': 'en-US',
+            'region': 'US',
+            'quotesCount': 0,
+            'newsCount': self.max_headlines_per_symbol,
+            'enableFuzzyQuery': False,
+        }
+        try:
+            timeout = self.background_config.get('request_timeout', 30)
+            resp = self._session.get(_YAHOO_SEARCH, params=params, timeout=timeout)
+            resp.raise_for_status()
+            self._record_request()
+
+            news_raw = resp.json().get('news', [])
+            items: List[Dict] = []
+            for raw in news_raw[:self.max_headlines_per_symbol]:
+                title = raw.get('title', '').strip()
+                if not title:
+                    continue
+                pub_ts = raw.get('providerPublishTime', 0)
+                pub_dt = datetime.fromtimestamp(pub_ts) if pub_ts else None
+                items.append({
+                    'symbol': symbol,
+                    'feed_name': symbol,
+                    'title': self._clean_headline(title),
+                    'link': raw.get('link', ''),
+                    'publisher': raw.get('publisher', ''),
+                    'published': pub_dt.isoformat() if pub_dt else '',
+                    'published_dt': pub_dt,
+                    'summary': raw.get('summary', ''),
+                })
+
+            self.cache_manager.set(cache_key, items, ttl=self.update_interval * 2)
+            self.logger.info("[Stock News] YF API: %d items for %s", len(items), symbol)
+            return items
+
+        except requests.RequestException as e:
+            self.logger.warning("[Stock News] YF API network error for %s: %s", symbol, e)
+        except (ValueError, KeyError) as e:
+            self.logger.warning("[Stock News] YF API parse error for %s: %s", symbol, e)
+        except Exception as e:
+            self.logger.warning("[Stock News] YF API unexpected error for %s: %s", symbol, e)
+        return []
 
     def _fetch_rss_feed(self, feed_name: str, url: str, max_items: int = 3) -> List[Dict]:
         """Fetch and parse an RSS feed with caching and request budget enforcement."""
@@ -247,20 +341,19 @@ class StockNewsTickerPlugin(BasePlugin):
         cache_key = f"stock_rss_{feed_name}_{bucket}"
         cached = self.cache_manager.get(cache_key)
         if cached:
-            self.logger.debug("[Stock News] Cache hit: %s", feed_name)
+            self.logger.debug("[Stock News] Cache hit (RSS): %s", feed_name)
             return cached
 
         if not self._check_request_budget():
             self.logger.warning(
-                "[Stock News] Request budget exceeded (%d/day, %d/hr limit) — skipping %s",
-                self._requests_today, self.max_requests_per_hour, feed_name,
+                "[Stock News] Request budget exceeded — skipping %s", feed_name,
             )
             return []
 
         try:
             self.logger.info("[Stock News] Fetching RSS: %s", feed_name)
             timeout = self.background_config.get('request_timeout', 30)
-            resp = requests.get(url, timeout=timeout, headers={'User-Agent': 'LEDMatrix/2.0'})
+            resp = self._session.get(url, timeout=timeout)
             resp.raise_for_status()
             self._record_request()
 
@@ -276,11 +369,12 @@ class StockNewsTickerPlugin(BasePlugin):
                     'feed_name': feed_name,
                     'title': self._clean_headline(html.unescape(title_el.text.strip())),
                     'link': (link_el.text or '') if link_el is not None else '',
+                    'publisher': '',
                     'published': (pub_el.text or '') if pub_el is not None else '',
                 })
 
             self.cache_manager.set(cache_key, items, ttl=self.update_interval * 2)
-            self.logger.info("[Stock News] Got %d items for %s", len(items), feed_name)
+            self.logger.info("[Stock News] RSS: %d items for %s", len(items), feed_name)
             return items
 
         except requests.RequestException as e:
@@ -340,7 +434,7 @@ class StockNewsTickerPlugin(BasePlugin):
 
         url = self.logo_url_template.replace('{symbol}', symbol)
         try:
-            resp = requests.get(url, timeout=10, headers={'User-Agent': 'LEDMatrix/2.0'})
+            resp = self._session.get(url, timeout=10)
             if resp.status_code == 200 and resp.content:
                 logo_path.write_bytes(resp.content)
                 self.logger.info("[Stock News] Downloaded logo for %s", symbol)
@@ -391,6 +485,12 @@ class StockNewsTickerPlugin(BasePlugin):
                     self._rotation_count = 0
                     if len(self.all_news_items) > 1:
                         self.all_news_items = self.all_news_items[1:] + self.all_news_items[:1]
+                        self._items_rotated += 1
+                        # After every item has had a turn at the front, reshuffle
+                        if self.shuffle_headlines and self._items_rotated >= len(self.all_news_items):
+                            random.shuffle(self.all_news_items)
+                            self._items_rotated = 0
+                            self.logger.debug("[Stock News] Reshuffled headlines")
                     self.scroll_helper.clear_cache()
                     self.scroll_helper.reset_scroll()
                     return  # next display() call rebuilds with rotated order
@@ -443,12 +543,15 @@ class StockNewsTickerPlugin(BasePlugin):
                 else None
             )
 
+            publisher = news_item.get('publisher', '')
             if self.display_style == 'logo_only':
                 symbol_text = f" {symbol}"
                 headline_text = ''
             else:
                 symbol_text = f"{symbol}: "
                 headline_text = title
+                if self.show_publisher and publisher:
+                    headline_text = f"{headline_text}  •  {publisher}"
 
             draw_tmp = ImageDraw.Draw(Image.new('RGB', (1, 1)))
             sym_bbox = draw_tmp.textbbox((0, 0), symbol_text, font=font_sym) if symbol_text else (0, 0, 0, 0)

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -298,8 +298,13 @@ class StockNewsTickerPlugin(BasePlugin):
                 return []
             stocks_cfg = getattr(stocks_plugin, 'config', {})
             symbols = stocks_cfg.get('stocks', {}).get('symbols', [])
-            # Filter out index/crypto-style symbols that won't have news (^GSPC, BTC-USD)
-            equity = [s for s in symbols if s and not s.startswith('^') and '-' not in s]
+            # Exclude index symbols (^GSPC) and crypto pairs (-USD, -USDT, -BTC, -ETH, -USDC)
+            # Hyphenated equities like BRK-B and BF-B are preserved intentionally
+            _CRYPTO_SUFFIXES = ('-USD', '-USDT', '-BTC', '-ETH', '-USDC', '-BUSD', '-EUR', '-GBP')
+            equity = [
+                s for s in symbols
+                if s and not s.startswith('^') and not any(s.endswith(sfx) for sfx in _CRYPTO_SUFFIXES)
+            ]
             return equity
         except Exception as e:
             self.logger.debug("[Stock News] Could not read ledmatrix-stocks symbols: %s", e)
@@ -382,8 +387,8 @@ class StockNewsTickerPlugin(BasePlugin):
         try:
             timeout = self.background_config.get('request_timeout', 30)
             resp = self._session.get(_YAHOO_SEARCH, params=params, timeout=timeout)
+            self._record_request()  # count any response, including 4xx/5xx
             resp.raise_for_status()
-            self._record_request()
 
             data = resp.json()
 
@@ -440,8 +445,8 @@ class StockNewsTickerPlugin(BasePlugin):
         try:
             timeout = self.background_config.get('request_timeout', 30)
             resp = self._session.get(url, timeout=timeout)
+            self._record_request()  # count any response, including 4xx/5xx
             resp.raise_for_status()
-            self._record_request()
 
             root = ET.fromstring(resp.content)
             items: List[Dict] = []
@@ -583,23 +588,26 @@ class StockNewsTickerPlugin(BasePlugin):
         if symbol in self._logo_failed:
             return None
 
+        # Sanitize symbol to safe filename characters — prevents path traversal
+        safe_name = re.sub(r'[^A-Za-z0-9.\-]', '_', symbol)[:20]
+
         # Width can be up to 4× height — lets landscape logos breathe
         max_w = self.logo_size * 4
 
-        logo_path = self._logo_dir / f"{symbol}.png"
+        logo_path = self._logo_dir / f"{safe_name}.png"
         if logo_path.exists():
-            return self.logo_helper.load_logo(symbol, logo_path,
+            return self.logo_helper.load_logo(safe_name, logo_path,
                                               max_width=max_w,
                                               max_height=self.logo_size)
 
-        # Download and cache to disk on first use
+        # Download and cache to disk on first use (URL uses original symbol)
         url = self.logo_url_template.replace('{symbol}', symbol)
         try:
             resp = self._session.get(url, timeout=10)
             if resp.status_code == 200 and resp.content:
                 logo_path.write_bytes(resp.content)
                 self.logger.info("[Stock News] Downloaded logo for %s", symbol)
-                return self.logo_helper.load_logo(symbol, logo_path,
+                return self.logo_helper.load_logo(safe_name, logo_path,
                                                   max_width=max_w,
                                                   max_height=self.logo_size)
             self.logger.debug("[Stock News] Logo not available for %s (HTTP %d)",

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -109,6 +109,7 @@ class StockNewsTickerPlugin(BasePlugin):
         self._rotation_count: int = 0
         self._items_rotated: int = 0   # tracks full-cycle completions for shuffle
         self._cycle_complete: bool = False
+        self._vegas_cache: Optional[list] = None
         self.last_update: float = 0
         self.initialized = True
 
@@ -140,16 +141,18 @@ class StockNewsTickerPlugin(BasePlugin):
     # -------------------------------------------------------------------------
 
     def _load_fonts(self) -> dict:
-        """Load PIL fonts for rendering."""
-        try:
-            font_path = 'assets/fonts/PressStart2P-Regular.ttf'
-            return {
-                'headline': ImageFont.truetype(font_path, self.font_size),
-                'symbol': ImageFont.truetype(font_path, self.font_size),
-            }
-        except IOError:
-            self.logger.warning("Press Start 2P font not found, using PIL default")
-            return {}
+        """Load PIL fonts with three-level fallback: configured path → 4x6 bitmap → PIL default."""
+        configured = self.global_config.get('font_path', 'assets/fonts/PressStart2P-Regular.ttf')
+        fallbacks = [configured, 'assets/fonts/4x6-font.ttf']
+        for path in fallbacks:
+            try:
+                font = ImageFont.truetype(path, self.font_size)
+                self.logger.debug("[Stock News] Loaded font: %s @ %dpx", path, self.font_size)
+                return {'headline': font, 'symbol': font}
+            except IOError:
+                continue
+        self.logger.warning("[Stock News] No TTF font found, using PIL default")
+        return {}
 
     def _configure_scroll_settings(self) -> None:
         """Configure ScrollHelper with plugin scroll settings (supports legacy keys)."""
@@ -257,6 +260,7 @@ class StockNewsTickerPlugin(BasePlugin):
             if hasattr(self, 'scroll_helper'):
                 self.scroll_helper.clear_cache()
                 self.scroll_helper.reset_scroll()
+            self._vegas_cache = None
 
         except Exception as e:
             self.logger.error(f"[Stock News] update() error: {e}")
@@ -483,14 +487,7 @@ class StockNewsTickerPlugin(BasePlugin):
                 self._rotation_count += 1
                 if self._rotation_count >= self.rotation_threshold:
                     self._rotation_count = 0
-                    if len(self.all_news_items) > 1:
-                        self.all_news_items = self.all_news_items[1:] + self.all_news_items[:1]
-                        self._items_rotated += 1
-                        # After every item has had a turn at the front, reshuffle
-                        if self.shuffle_headlines and self._items_rotated >= len(self.all_news_items):
-                            random.shuffle(self.all_news_items)
-                            self._items_rotated = 0
-                            self.logger.debug("[Stock News] Reshuffled headlines")
+                    self._rotate_headlines()
                     self.scroll_helper.clear_cache()
                     self.scroll_helper.reset_scroll()
                     return  # next display() call rebuilds with rotated order
@@ -587,17 +584,115 @@ class StockNewsTickerPlugin(BasePlugin):
             self.logger.warning(f"[Stock News] Render error: {e}")
             return None
 
+    def _rotate_headlines(self) -> None:
+        """Move the front headline to the end, optionally reshuffling after a full cycle."""
+        if len(self.all_news_items) <= 1:
+            return
+        first = self.all_news_items[0]
+        self.all_news_items = self.all_news_items[1:] + [first]
+        self._items_rotated += 1
+        self.logger.info(
+            "[Stock News] Rotated: '%s...' moved to end — now showing '%s...' first",
+            first.get('title', '')[:40],
+            self.all_news_items[0].get('title', '')[:40],
+        )
+        if self.shuffle_headlines and self._items_rotated >= len(self.all_news_items):
+            random.shuffle(self.all_news_items)
+            self._items_rotated = 0
+            self.logger.info("[Stock News] Full rotation complete — reshuffled")
+        self._vegas_cache: Optional[list] = None  # invalidate Vegas cache
+
+    # -------------------------------------------------------------------------
+    # Config hot-reload
+    # -------------------------------------------------------------------------
+
+    def on_config_change(self, new_config: Dict[str, Any]) -> None:
+        """Apply live configuration changes without restarting the plugin."""
+        super().on_config_change(new_config)
+
+        old_symbols = set(self.feeds_config.get('stock_symbols', []))
+        old_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
+        old_font_size = self.font_size
+
+        self.feeds_config = new_config.get('feeds', {})
+        self.global_config = new_config.get('global', {})
+
+        # Scroll / display
+        self.display_duration = self.global_config.get('display_duration', 30)
+        self.scroll_speed = self.global_config.get('scroll_speed', 1)
+        self.scroll_delay = self.global_config.get('scroll_delay', 0.01)
+        self.dynamic_duration = self.global_config.get('dynamic_duration', True)
+        self.min_duration = self.global_config.get('min_duration', 30)
+        self.max_duration = self.global_config.get('max_duration', 300)
+        self.max_headlines_per_symbol = self.global_config.get('max_headlines_per_symbol', 1)
+        self.headlines_per_rotation = self.global_config.get('headlines_per_rotation', 2)
+        self.rotation_enabled = self.global_config.get('rotation_enabled', True)
+        self.rotation_threshold = self.global_config.get('rotation_threshold', 1)
+        self.shuffle_headlines = self.global_config.get('shuffle_headlines', True)
+        self.show_publisher = self.global_config.get('show_publisher', True)
+        self.font_size = self.global_config.get('font_size', 10)
+
+        # Rate limits
+        self.update_interval = self.global_config.get('update_interval_seconds', 900)
+        self.max_daily_requests = self.global_config.get('max_daily_requests', 200)
+        self.max_requests_per_hour = self.global_config.get('max_requests_per_hour', 50)
+
+        # Display style / logo
+        self.display_style = self.global_config.get('display_style', 'logo_and_ticker')
+        self.logo_size = self.global_config.get('logo_size', min(self.display_height, 32))
+        self.logo_fetch_enabled = self.global_config.get('logo_fetch_enabled', True)
+        self.logo_url_template = self.global_config.get(
+            'logo_url_template',
+            'https://financialmodelingprep.com/image-stock/{symbol}.png'
+        )
+
+        # Colors
+        self.text_color = tuple(self.feeds_config.get('text_color', [0, 255, 0]))
+        self.symbol_color = tuple(self.feeds_config.get('symbol_color', [255, 255, 0]))
+
+        # Background service
+        self.background_config = self.global_config.get('background_service', {
+            'enabled': True, 'request_timeout': 30,
+        })
+
+        # Re-apply scroll settings
+        self._configure_scroll_settings()
+
+        # Reload fonts if size changed
+        if self.font_size != old_font_size:
+            self._fonts = self._load_fonts()
+            self._register_fonts()
+            self.logger.info("[Stock News] Fonts reloaded at %dpx", self.font_size)
+
+        # Force refetch if feeds changed
+        new_symbols = set(self.feeds_config.get('stock_symbols', []))
+        new_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
+        if new_symbols != old_symbols or new_custom != old_custom:
+            self.logger.info("[Stock News] Feed config changed — forcing refresh")
+            self.last_update = 0
+
+        # Always invalidate the scroll cache so colours/style take effect immediately
+        self.scroll_helper.clear_cache()
+        self.scroll_helper.reset_scroll()
+        self._vegas_cache = None
+
     # -------------------------------------------------------------------------
     # Vegas scroll mode
     # -------------------------------------------------------------------------
 
     def get_vegas_content(self) -> Optional[list]:
-        """Return list of item images for Vegas continuous scroll."""
+        """Return cached rendered item images for Vegas continuous scroll."""
         if not self.all_news_items:
             return None
-        images = [self._render_news_item(item) for item in self.all_news_items]
-        result = [img for img in images if img is not None]
-        return result if result else None
+        if self._vegas_cache is None:
+            rendered = [self._render_news_item(item) for item in self.all_news_items]
+            self._vegas_cache = [img for img in rendered if img is not None]
+            total_px = sum(img.width for img in self._vegas_cache)
+            self.logger.info(
+                "[Stock News] Vegas cache built: %d items, %dpx total",
+                len(self._vegas_cache), total_px,
+            )
+        return self._vegas_cache if self._vegas_cache else None
 
     def get_vegas_content_type(self) -> str:
         return 'multi'
@@ -625,7 +720,12 @@ class StockNewsTickerPlugin(BasePlugin):
     # -------------------------------------------------------------------------
 
     def get_display_duration(self) -> float:
-        return self.display_duration
+        """Return ScrollHelper's dynamically calculated duration when enabled."""
+        if self.dynamic_duration:
+            d = self.scroll_helper.get_dynamic_duration()
+            if d > 0:
+                return float(d)
+        return float(self.display_duration)
 
     def get_info(self) -> Dict[str, Any]:
         info = super().get_info()
@@ -634,7 +734,15 @@ class StockNewsTickerPlugin(BasePlugin):
             'stock_symbols': self.feeds_config.get('stock_symbols', []),
             'custom_feeds': list(self.feeds_config.get('custom_feeds', {}).keys()),
             'last_update': self.last_update,
+            'display_duration': self.display_duration,
+            'dynamic_duration': self.dynamic_duration,
             'display_style': self.display_style,
+            'show_publisher': self.show_publisher,
+            'shuffle_headlines': self.shuffle_headlines,
+            'rotation_enabled': self.rotation_enabled,
+            'rotation_threshold': self.rotation_threshold,
+            'logo_fetch_enabled': self.logo_fetch_enabled,
+            'logo_size': self.logo_size,
             'requests_today': self._requests_today,
             'requests_this_hour': len(self._request_timestamps),
             'max_daily_requests': self.max_daily_requests,
@@ -649,4 +757,9 @@ class StockNewsTickerPlugin(BasePlugin):
 
     def cleanup(self) -> None:
         self.all_news_items = []
+        self._vegas_cache = None
+        if hasattr(self, 'scroll_helper'):
+            self.scroll_helper.clear_cache()
+        if hasattr(self, '_session'):
+            self._session.close()
         self.logger.info("[Stock News] Plugin cleaned up")

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "author": "ChuckBuilds",
   "description": "Live stock headlines via Yahoo Finance search API with RSS fallback, company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.3.3",
+      "notes": "Fix _record_request() to count 4xx/5xx responses not just 200s; fix BRK-B/BF-B excluded by overly broad crypto filter; sanitize symbol to safe filename before filesystem operations",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "2.3.2",

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "ChuckBuilds",
   "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.3.1",
+      "notes": "Fix logo scaling: auto logo_size now equals display_height (not capped at 32); logos constrained by height only so landscape logos render at full panel height; failed downloads remembered per session to avoid repeated attempts",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "2.3.0",

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "ChuckBuilds",
   "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.1.0",
+      "notes": "YF search API (publisher, timestamp) with RSS fallback; retry session with backoff; shuffle_headlines config; show_publisher config",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "2.0.0",

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": "ChuckBuilds",
-  "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
+  "description": "Live stock headlines via Yahoo Finance search API with RSS fallback, company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
   "class_name": "StockNewsTickerPlugin",
   "category": "financial",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.3.2",
+      "notes": "sync_with_stocks_plugin option to mirror ledmatrix-stocks watchlist; defusedxml for RSS parsing; Optional[str] type hint on display(); fix schema descriptions (update_interval → update_interval_seconds); fix manifest/registry descriptions to reflect YF search API + RSS fallback",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "2.3.1",

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "ChuckBuilds",
   "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.3.0",
+      "notes": "Auto font size; configurable item_gap; spread symbol fetches across update_interval; market-hours throttling; budget adequacy warning; show_price; show_age with relative timestamps; publisher_color; per-symbol max_headlines dict; stale-data colour dimming; centered no-news fallback; multi-segment colour rendering",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "2.2.0",

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "ChuckBuilds",
-  "description": "Displays scrolling stock-specific news headlines and financial updates from RSS feeds, focused on market news and company updates",
+  "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
   "class_name": "StockNewsTickerPlugin",
   "category": "financial",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.0.0",
+      "notes": "Real Yahoo Finance RSS fetching per symbol; company logo rendering (logo_and_ticker / ticker_only / logo_only); per-day and per-hour request budgeting; Vegas scroll integration; headline rotation; fully configurable display style, logo size, and scroll settings",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "1.1.0",

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "ChuckBuilds",
   "description": "Live stock headlines from Yahoo Finance RSS with company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-19",
+      "version": "2.2.0",
+      "notes": "on_config_change() live reload; get_display_duration() uses ScrollHelper dynamic duration; Vegas content caching; session.close() in cleanup; font_path config with 3-level fallback; _rotate_headlines() with logging; expanded get_info(); schema section titles and x-widget hints",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "2.1.0",

--- a/plugins/stock-news/requirements.txt
+++ b/plugins/stock-news/requirements.txt
@@ -8,3 +8,6 @@
 # but listed here for reference:
 # requests>=2.25.0
 # Pillow>=8.0.0
+
+# Safe XML parsing (prevents XML entity expansion attacks on untrusted RSS feeds)
+defusedxml>=0.7.1


### PR DESCRIPTION
## Summary

Complete overhaul of the stock-news plugin, taking it from a placeholder stub to a production-quality financial ticker.

### Data fetching
- **Real Yahoo Finance search API** (JSON) replacing the fake hardcoded placeholder — returns publisher, market price, and Unix timestamps per article
- **RSS fallback** if the API changes or rate-limits
- **requests.Session with 4× retry + exponential backoff** on all HTTP calls (news, logos)
- **Spread symbol fetches**: one symbol per `update()` call, rotating through the list — no more budget burst from fetching all symbols at once
- **Market-hours throttling**: fetch interval multiplied by `off_hours_multiplier` (default 4×) nights/weekends to conserve the daily budget
- **Per-day + per-hour request budget** with startup adequacy warning logged at init

### Display
- **Auto font size**: `font_size: 0` derives from `display_height ÷ 3` — ticker fills panel correctly at any height (16px, 32px, 64px)
- **Auto item gap**: `item_gap: 0` defaults to `display_width` — full-width blank between stories at any panel size
- **Multi-segment colour rendering**: symbol (yellow), headline (green), publisher+age (configurable dim grey) drawn as independent segments
- **Three display styles**: `logo_and_ticker`, `ticker_only`, `logo_only`
- **Company logos**: downloaded once, cached to disk; height-constrained only so landscape logos render at full panel height; failed downloads skipped for the session

### Content options (all configurable)
- `show_price` — current market price (e.g. `$189.42`) before headline
- `show_publisher` — news source attribution (e.g. `• Reuters`)
- `show_age` — relative publish time (e.g. `• 2h ago`) from real timestamps
- `shuffle_headlines` — randomise order on fetch + reshuffle after full rotation
- `rotation_enabled` / `rotation_threshold` — control when stories cycle
- `max_headlines_per_symbol` — int for all symbols, or `{AAPL: 2, default: 1}` dict
- `publisher_color` — separate colour for the dim suffix segment

### Plugin system parity
- `on_config_change()` — full live reload: fonts, colours, feeds, scroll speed, all without restart
- `get_display_duration()` — returns ScrollHelper's dynamic duration so the framework waits for the full scroll before switching
- `get_vegas_content()` — cached rendered images for Vegas continuous scroll (`get_vegas_content_type: 'multi'`)
- `cleanup()` — closes HTTP session, clears scroll cache and per-symbol data
- `get_info()` — 24 keys including budget counters, stale flag, market hours status
- Stale data dimming: colours dim automatically when data is overdue (`stale_threshold_multiplier`)
- Centred "No Stock News" fallback using the configured font at any panel height

### Config schema
- Section `title` fields, `x-widget` hints (`radio`, `tag-input`, `key-value`, `color-picker`)
- All new options documented with descriptions and sensible defaults

## Test plan
- [ ] Configure `stock_symbols: [AAPL, TSLA, GOOGL]` — verify real headlines appear (not "Reports Strong Quarterly Earnings")
- [ ] Confirm symbol fetches spread over time in logs (one per interval, not all at once)
- [ ] `display_style: logo_and_ticker` — logo appears before each story, scales to panel height
- [ ] `display_style: ticker_only` — text only, no logo fetch attempted
- [ ] `show_price: true` — price renders before headline
- [ ] `show_age: true` — "• 2h ago" appended in dim colour
- [ ] `font_size: 0` on 32px and 64px panels — auto-sizes correctly
- [ ] `item_gap: 0` — gap equals display width between stories
- [ ] Change a colour in the UI — takes effect immediately without restart
- [ ] Vegas scroll mode — stock news items appear in continuous scroll
- [ ] Budget warning logged at startup when symbols exceed hourly limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Yahoo Finance + RSS fallback for headlines, logo fetching with configurable sizing, Vegas multi-item scroll support, per-day/hour request budgeting, market-hours-aware fetching, hot config reload.

* **Enhancements**
  * Expanded display & scroll controls (styles, fonts, timing, rotation/shuffle, dynamic durations), publisher/age/price segments, stale-data dimming, caching/retry behavior, richer feed/color settings.

* **Chores**
  * Added safe XML parser dependency for RSS feeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/ledmatrix-plugins/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->