### PR TITLE
feat(stock-news): fix config schema for web UI rendering (v2.4.0)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-21",
+  "last_updated": "2026-05-22",
   "plugins": [
     {
       "id": "hello-world",
@@ -464,10 +464,10 @@
       "plugin_path": "plugins/stock-news",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-20",
+      "last_updated": "2026-05-22",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.4.0"
+      "latest_version": "2.4.1"
     },
     {
       "id": "stocks",

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-20",
+  "last_updated": "2026-05-21",
   "plugins": [
     {
       "id": "hello-world",
@@ -467,7 +467,7 @@
       "last_updated": "2026-05-20",
       "verified": true,
       "screenshot": "",
-      "latest_version": "2.3.4"
+      "latest_version": "2.4.0"
     },
     {
       "id": "stocks",

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -256,6 +256,7 @@
             "properties": {
               "name": {
                 "type": "string",
+                "minLength": 1,
                 "description": "Display label for this feed"
               },
               "url": {

--- a/plugins/stock-news/config_schema.json
+++ b/plugins/stock-news/config_schema.json
@@ -144,21 +144,11 @@
           "description": "Maximum headline length in characters before truncating with '...'. Default 120 shows most headlines in full."
         },
         "max_headlines_per_symbol": {
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 5,
-              "description": "Apply the same limit to every symbol"
-            },
-            {
-              "type": "object",
-              "description": "Per-symbol overrides, e.g. {\"AAPL\": 2, \"default\": 1}",
-              "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 5}
-            }
-          ],
+          "type": "integer",
           "default": 1,
-          "description": "Max headlines per symbol. Use int for all symbols, or object for per-symbol control."
+          "minimum": 1,
+          "maximum": 5,
+          "description": "Max headlines shown per stock symbol (1–5)."
         },
         "headlines_per_rotation": {
           "type": "integer",
@@ -259,40 +249,44 @@
           "description": "Stock symbols — headlines fetched from Yahoo Finance. Fetches are spread across update_interval_seconds."
         },
         "custom_feeds": {
-          "type": "object",
-          "x-widget": "key-value",
-          "patternProperties": {
-            ".*": {"type": "string", "format": "uri"}
+          "type": "array",
+          "x-widget": "array-table",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Display label for this feed"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "RSS feed URL"
+              }
+            },
+            "required": ["name", "url"],
+            "additionalProperties": false
           },
-          "additionalProperties": false,
-          "description": "Extra RSS feeds keyed by display name (any financial news RSS URL)"
+          "default": [],
+          "description": "Extra RSS feeds to include alongside stock symbols"
         },
         "text_color": {
-          "type": "array",
+          "type": "string",
           "x-widget": "color-picker",
-          "items": {"type": "integer", "minimum": 0, "maximum": 255},
-          "minItems": 3,
-          "maxItems": 3,
-          "default": [0, 255, 0],
-          "description": "RGB color for headline text"
+          "default": "#00ff00",
+          "description": "Color for headline text"
         },
         "symbol_color": {
-          "type": "array",
+          "type": "string",
           "x-widget": "color-picker",
-          "items": {"type": "integer", "minimum": 0, "maximum": 255},
-          "minItems": 3,
-          "maxItems": 3,
-          "default": [255, 255, 0],
-          "description": "RGB color for stock symbol labels (e.g. 'AAPL:')"
+          "default": "#ffff00",
+          "description": "Color for stock symbol labels (e.g. 'AAPL:')"
         },
         "publisher_color": {
-          "type": "array",
+          "type": "string",
           "x-widget": "color-picker",
-          "items": {"type": "integer", "minimum": 0, "maximum": 255},
-          "minItems": 3,
-          "maxItems": 3,
-          "default": [110, 110, 110],
-          "description": "RGB color for publisher and age suffix (e.g. '• Reuters • 2h ago')"
+          "default": "#6e6e6e",
+          "description": "Color for publisher and age suffix (e.g. '• Reuters • 2h ago')"
         }
       },
       "additionalProperties": false

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -235,13 +235,20 @@ class StockNewsTickerPlugin(BasePlugin):
         # Convert to per-frame advancement for smooth, consistent scrolling.
         # Frame-based mode advances exactly pixels_per_frame each frame regardless
         # of wall-clock jitter, preventing multi-pixel jumps on slow frames.
+        _MIN_PPF = 0.1  # minimum pixels-per-frame the scroll helper accepts
         pixels_per_frame = pps / fps if fps > 0 else pps / 100.0
-        pixels_per_frame = max(0.1, min(5.0, pixels_per_frame))
+        if pixels_per_frame < _MIN_PPF:
+            # Lower effective FPS to preserve requested px/s rather than bumping px/frame
+            effective_fps = min(fps, max(1.0, int(pps / _MIN_PPF)))
+            pixels_per_frame = pps / effective_fps
+        else:
+            effective_fps = fps
+        pixels_per_frame = min(5.0, pixels_per_frame)  # retain upper clamp
 
         if hasattr(self.scroll_helper, 'set_frame_based_scrolling'):
             self.scroll_helper.set_frame_based_scrolling(True)
         if hasattr(self.scroll_helper, 'set_scroll_delay'):
-            self.scroll_helper.set_scroll_delay(1.0 / fps)
+            self.scroll_helper.set_scroll_delay(1.0 / effective_fps)
         self.scroll_helper.set_scroll_speed(pixels_per_frame)
 
         if hasattr(self.scroll_helper, 'set_target_fps'):
@@ -884,7 +891,7 @@ class StockNewsTickerPlugin(BasePlugin):
         super().on_config_change(new_config)
 
         old_symbols = set(self.feeds_config.get('stock_symbols', []))
-        old_custom = set(self._get_custom_feeds().keys())
+        old_custom_map = self._get_custom_feeds().copy()
         old_font_size = self.font_size
         old_font_path = self.global_config.get('font_path', '')
 
@@ -901,8 +908,18 @@ class StockNewsTickerPlugin(BasePlugin):
             self.logger.info("[Stock News] Fonts reloaded at %dpx", self.font_size)
 
         new_symbols = set(self.feeds_config.get('stock_symbols', []))
-        new_custom = set(self._get_custom_feeds().keys())
-        if new_symbols != old_symbols or new_custom != old_custom:
+        new_custom_map = self._get_custom_feeds()
+        old_custom_keys = set(old_custom_map.keys())
+        new_custom_keys = set(new_custom_map.keys())
+
+        # Clear state for any feed whose URL changed (same name, different URL)
+        for name in new_custom_keys & old_custom_keys:
+            if new_custom_map[name] != old_custom_map.get(name):
+                self._symbol_data.pop(f"_feed_{name}", None)
+                self._feed_last_fetch.pop(name, None)
+                self.logger.info("[Stock News] Feed URL changed for '%s' — will refetch", name)
+
+        if new_symbols != old_symbols or new_custom_keys != old_custom_keys:
             # Drop stale per-symbol data for removed feeds
             for removed in (old_symbols - new_symbols):
                 self._symbol_data.pop(removed, None)

--- a/plugins/stock-news/manager.py
+++ b/plugins/stock-news/manager.py
@@ -91,7 +91,7 @@ class StockNewsTickerPlugin(BasePlugin):
         self._register_fonts()
 
         stock_symbols = self.feeds_config.get('stock_symbols', [])
-        custom_feeds = self.feeds_config.get('custom_feeds', {})
+        custom_feeds = self._get_custom_feeds()
         self.logger.info(
             "[Stock News] Initialized — symbols=%s, custom=%s, style=%s, font=%dpx, item_gap=%dpx",
             stock_symbols, list(custom_feeds.keys()), self.display_style,
@@ -102,6 +102,30 @@ class StockNewsTickerPlugin(BasePlugin):
     # -------------------------------------------------------------------------
     # Config helpers
     # -------------------------------------------------------------------------
+
+    def _get_custom_feeds(self) -> Dict[str, str]:
+        """Return custom_feeds as {name: url}. Accepts new list format or legacy dict format."""
+        raw = self.feeds_config.get('custom_feeds', [])
+        if isinstance(raw, list):
+            return {item['name']: item['url'] for item in raw
+                    if isinstance(item, dict) and 'name' in item and 'url' in item}
+        return raw if isinstance(raw, dict) else {}
+
+    @staticmethod
+    def _parse_color(value: Any, default: List[int]) -> Tuple[int, int, int]:
+        """Accept '#rrggbb' hex string (new) or [R, G, B] list (legacy) and return an (R, G, B) tuple."""
+        if isinstance(value, str):
+            v = value.lstrip('#')
+            if len(v) == 3:
+                v = v[0] * 2 + v[1] * 2 + v[2] * 2
+            if len(v) == 6:
+                try:
+                    return (int(v[0:2], 16), int(v[2:4], 16), int(v[4:6], 16))
+                except ValueError:
+                    pass
+        if isinstance(value, (list, tuple)) and len(value) == 3:
+            return tuple(value)  # type: ignore[return-value]
+        return tuple(default)  # type: ignore[return-value]
 
     def _apply_config(self) -> None:
         """Read all config keys into instance vars. Called from __init__ and on_config_change."""
@@ -154,9 +178,9 @@ class StockNewsTickerPlugin(BasePlugin):
         self.sync_with_stocks_plugin = gc.get('sync_with_stocks_plugin', False)
 
         # Colours
-        self.text_color: Tuple = tuple(fc.get('text_color', [0, 255, 0]))
-        self.symbol_color: Tuple = tuple(fc.get('symbol_color', [255, 255, 0]))
-        self.publisher_color: Tuple = tuple(fc.get('publisher_color', [110, 110, 110]))
+        self.text_color: Tuple = self._parse_color(fc.get('text_color'), [0, 255, 0])
+        self.symbol_color: Tuple = self._parse_color(fc.get('symbol_color'), [255, 255, 0])
+        self.publisher_color: Tuple = self._parse_color(fc.get('publisher_color'), [110, 110, 110])
 
         # Rate limiting
         self.update_interval = gc.get('update_interval_seconds', 900)
@@ -272,7 +296,7 @@ class StockNewsTickerPlugin(BasePlugin):
         synced_symbols = self._get_stocks_plugin_symbols()
         # Merge: configured first, then any extras from stocks plugin (deduped, order preserved)
         stock_symbols = list(dict.fromkeys(configured_symbols + synced_symbols))
-        custom_feeds = self.feeds_config.get('custom_feeds', {})
+        custom_feeds = self._get_custom_feeds()
         fetched = False
 
         # Per-symbol interval: spread all symbols evenly within update_interval
@@ -332,7 +356,7 @@ class StockNewsTickerPlugin(BasePlugin):
         """Rebuild all_news_items from per-symbol cached data."""
         configured = self.feeds_config.get('stock_symbols', [])
         stock_symbols = list(dict.fromkeys(configured + self._get_stocks_plugin_symbols()))
-        custom_feeds = self.feeds_config.get('custom_feeds', {})
+        custom_feeds = self._get_custom_feeds()
 
         all_items: list = []
         for sym in stock_symbols:
@@ -525,7 +549,7 @@ class StockNewsTickerPlugin(BasePlugin):
     def _check_budget_adequacy(self) -> None:
         """Warn at startup if symbol count may exhaust the hourly request budget."""
         stock_symbols = self.feeds_config.get('stock_symbols', [])
-        custom_feeds = self.feeds_config.get('custom_feeds', {})
+        custom_feeds = self._get_custom_feeds()
         n = max(len(stock_symbols), 1)
         per_sym = max(60.0, self.update_interval / n)
         sym_per_hour = 3600.0 / per_sym
@@ -860,7 +884,7 @@ class StockNewsTickerPlugin(BasePlugin):
         super().on_config_change(new_config)
 
         old_symbols = set(self.feeds_config.get('stock_symbols', []))
-        old_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
+        old_custom = set(self._get_custom_feeds().keys())
         old_font_size = self.font_size
         old_font_path = self.global_config.get('font_path', '')
 
@@ -877,7 +901,7 @@ class StockNewsTickerPlugin(BasePlugin):
             self.logger.info("[Stock News] Fonts reloaded at %dpx", self.font_size)
 
         new_symbols = set(self.feeds_config.get('stock_symbols', []))
-        new_custom = set(self.feeds_config.get('custom_feeds', {}).keys())
+        new_custom = set(self._get_custom_feeds().keys())
         if new_symbols != old_symbols or new_custom != old_custom:
             # Drop stale per-symbol data for removed feeds
             for removed in (old_symbols - new_symbols):
@@ -907,7 +931,7 @@ class StockNewsTickerPlugin(BasePlugin):
         info.update({
             'total_news_items': len(self.all_news_items),
             'stock_symbols': stock_symbols,
-            'custom_feeds': list(self.feeds_config.get('custom_feeds', {}).keys()),
+            'custom_feeds': list(self._get_custom_feeds().keys()),
             'last_update': self.last_update,
             'data_stale': self._is_data_stale(),
             'is_market_hours': self._is_market_hours(),

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "ChuckBuilds",
   "description": "Live stock headlines via Yahoo Finance search API with RSS fallback, company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-22",
+      "version": "2.4.1",
+      "notes": "custom_feeds name minLength:1 to prevent blank keys; scroll FPS reduced instead of px/frame bumped when pps is low, preserving requested speed; on_config_change detects URL edits under same feed name and clears stale cached data",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-21",
       "version": "2.4.0",
@@ -105,7 +111,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-20",
+  "last_updated": "2026-05-22",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/stock-news/manifest.json
+++ b/plugins/stock-news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-news",
   "name": "Stock News Ticker",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "author": "ChuckBuilds",
   "description": "Live stock headlines via Yahoo Finance search API with RSS fallback, company logos, configurable display styles (logo+ticker, ticker only, logo only), Vegas scroll integration, and per-day/hour request budgeting",
   "entry_point": "manager.py",
@@ -24,6 +24,12 @@
   "branch": "main",
   "plugin_path": "plugins/stock-news",
   "versions": [
+    {
+      "released": "2026-05-21",
+      "version": "2.4.0",
+      "notes": "config_schema: fix web UI rendering — max_headlines_per_symbol now type:integer; custom_feeds changed to array-table (name+url rows); color fields changed to hex string for color-picker widget. Manager accepts both new and legacy config formats.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-20",
       "version": "2.3.4",


### PR DESCRIPTION
## Summary

Fixes the stock-news plugin config tab in the LEDMatrix web UI — the tab was blank because three schema fields couldn't be rendered by the template.

- **`max_headlines_per_symbol`**: replaced `oneOf: [integer, object]` (no top-level `type` key) with `type: integer`. The missing `type` triggered a Jinja2 `UndefinedError` that crashed the entire config tab render, returning HTTP 500 and leaving the tab blank. The per-symbol dict override is a power-user feature that can't be meaningfully represented in a form field anyway.

- **`custom_feeds`**: changed from `type: object` + `patternProperties` + `x-widget: key-value` to `type: array` + `x-widget: array-table` with `name` / `url` item columns. The `key-value` widget has no handler in the LEDMatrix template; `array-table` already works. The manager normalises both formats via the new `_get_custom_feeds()` helper so existing dict-format configs continue to work.

- **Color fields** (`text_color`, `symbol_color`, `publisher_color`): changed from `type: array` of `[R, G, B]` integers to `type: string` hex (e.g. `"#00ff00"`). The color-picker widget expects hex strings; the old array type fell through to a plain comma-separated text input. The manager parses both formats via the new `_parse_color()` helper so existing `[R, G, B]` configs are migrated transparently on next load.

Also includes the soccer-scoreboard live cache TTL fix, teams documentation, and stock-news smooth scroll / headline length improvements from a prior commit on this branch.

## Test plan

- [ ] Install or update the `stock-news` plugin via the Plugin Store
- [ ] Open the web UI → Plugins → Stock News Ticker config tab — it should load without being blank
- [ ] Verify `max_headlines_per_symbol` renders as a number input (1–5)
- [ ] Verify `custom_feeds` renders as an add/remove table with Name and URL columns
- [ ] Verify the three color fields render as color pickers
- [ ] Save config and confirm the plugin reads values correctly (headlines fetch, colors display)
- [ ] Confirm existing installs with old `[R, G, B]` color arrays or `{name: url}` custom feed dicts continue working after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Soccer Scoreboard: Live game updates now refresh every 30 seconds for faster data availability.
  * Stock News: Added configurable headline length and improved color selection via color picker.

* **Documentation**
  * Soccer Scoreboard: Added comprehensive team abbreviations guide for ESPN teams.

* **Chores**
  * Soccer Scoreboard updated to version 1.6.3.
  * Stock News updated to version 2.4.0 with simplified configuration format and backward compatibility for legacy settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/ledmatrix-plugins/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->