### PR TITLE
feat(of-the-day): migrate file manager to json-file-manager widget (v1.1.0)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-22",
+  "last_updated": "2026-05-26",
   "plugins": [
     {
       "id": "hello-world",
@@ -135,10 +135,10 @@
       "plugin_path": "plugins/of-the-day",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-15",
+      "last_updated": "2026-05-26",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.2"
+      "latest_version": "1.1.0"
     },
     {
       "id": "music",

--- a/plugins/of-the-day/config_schema.json
+++ b/plugins/of-the-day/config_schema.json
@@ -76,9 +76,37 @@
     "file_manager": {
       "type": "null",
       "title": "Data Files",
-      "x-widget": "custom-html",
-      "x-html-file": "web_ui/file_manager.html",
-      "description": "Manage your Of The Day JSON data files"
+      "description": "Manage your Of The Day JSON data files",
+      "x-widget": "json-file-manager",
+      "x-widget-config": {
+        "actions": {
+          "list":   "list-files",
+          "get":    "get-file",
+          "save":   "save-file",
+          "upload": "upload-file",
+          "delete": "delete-file",
+          "create": "create-file",
+          "toggle": "toggle-category"
+        },
+        "upload_hint":    "JSON files with day numbers 1–365 as keys",
+        "directory_label": "of_the_day/",
+        "create_fields": [
+          {
+            "key":         "category_name",
+            "label":       "Category Name",
+            "placeholder": "e.g., my_words",
+            "pattern":     "^[a-z0-9_]+$",
+            "hint":        "Lowercase letters, numbers, underscores — used as filename"
+          },
+          {
+            "key":         "display_name",
+            "label":       "Display Name",
+            "placeholder": "e.g., My Words",
+            "hint":        "Shown in plugin configuration (leave blank to auto-generate)"
+          }
+        ],
+        "toggle_key": "category_name"
+      }
     }
   },
   "required": ["enabled"]

--- a/plugins/of-the-day/manifest.json
+++ b/plugins/of-the-day/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "of-the-day",
   "name": "Of The Day Display",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "ChuckBuilds",
   "description": "Display daily featured content like Word of the Day, Bible verses, or custom daily items. Supports multiple categories with rotating display and configurable data sources.",
   "category": "information",
@@ -22,6 +22,11 @@
   ],
   "versions": [
     {
+      "released": "2026-05-26",
+      "version": "1.1.0",
+      "ledmatrix_min": "2.0.0"
+    },
+    {
       "released": "2026-05-15",
       "version": "1.0.2",
       "ledmatrix_min": "2.0.0"
@@ -32,7 +37,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-15",
+  "last_updated": "2026-05-26",
   "stars": 0,
   "downloads": 0,
   "verified": true,


### PR DESCRIPTION
## Summary

- `config_schema.json` — switches `file_manager` from `x-widget: "custom-html"` / `x-html-file: "web_ui/file_manager.html"` to `x-widget: "json-file-manager"` with full action and create-field config
- `manifest.json` — bumped to `1.1.0`, `last_updated` set to 2026-05-26
- `plugins.json` — auto-updated by pre-commit hook

## Why

The old `web_ui/file_manager.html` loaded `jsoneditor@latest` from jsDelivr CDN (1.5 MB), which broke offline and was not reusable. This migrates to the new `json-file-manager` widget built into LEDMatrix core.

## UX improvements

- No CDN dependency — loads instantly, works offline
- Textarea editor with Format / Validate / Ctrl+S / Escape keyboard shortcuts
- Upload zone at the bottom (files are the primary view)
- Enable/disable toggle directly on each file card
- Auto-derives display name from category name when left blank
- `DOMContentLoaded` bug fixed — the old widget registered a listener that never fired after dynamic injection; new widget initializes directly on mount

## Test plan

- [ ] Open of-the-day plugin config in the web UI — file list loads
- [ ] Edit, save, upload, create, delete, toggle all work end-to-end
- [ ] No CDN requests in network tab

> **Companion PR:** LEDMatrix `feature/json-file-manager-widget` — adds the widget itself (must merge together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * of-the-day (v1.1.0): Enhanced file manager widget with improved management interface
  * stock-news (v2.4.1): Updated custom feeds configuration format and color picker with hex string support

* **Bug Fixes**
  * stock-news: Optimized scroll performance with FPS adjustment for low pixel-per-second scenarios and improved cache clearing during config updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/ledmatrix-plugins/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->