### PR TITLE
feat(weather): migrate to Open-Meteo — no API key required (v2.3.0)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-26",
+  "last_updated": "2026-05-27",
   "plugins": [
     {
       "id": "hello-world",
@@ -47,7 +47,7 @@
     {
       "id": "weather",
       "name": "Weather Display",
-      "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, almanac (sunrise/sunset, moon phase), precipitation radar, weather alerts, UV index, wind direction, and weather icons. Powered by OpenWeatherMap + RainViewer APIs.",
+      "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, almanac (sunrise/sunset, moon phase), precipitation radar, weather alerts, UV index, wind direction, and weather icons. Powered by Open-Meteo (free, no API key) + RainViewer.",
       "author": "ChuckBuilds",
       "category": "weather",
       "tags": [
@@ -55,7 +55,7 @@
         "forecast",
         "temperature",
         "conditions",
-        "openweathermap",
+        "open-meteo",
         "uv-index",
         "wind",
         "icons",
@@ -64,10 +64,10 @@
       "repo": "https://github.com/ChuckBuilds/ledmatrix-plugins",
       "branch": "main",
       "plugin_path": "plugins/ledmatrix-weather",
-      "latest_version": "2.2.4",
+      "latest_version": "2.3.0",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-15",
+      "last_updated": "2026-05-27",
       "verified": true,
       "screenshot": ""
     },

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-22",
+  "last_updated": "2026-05-26",
   "plugins": [
     {
       "id": "hello-world",
@@ -135,10 +135,10 @@
       "plugin_path": "plugins/of-the-day",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-15",
+      "last_updated": "2026-05-26",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.2"
+      "latest_version": "1.1.0"
     },
     {
       "id": "music",

--- a/plugins/ledmatrix-weather/CHANGELOG.md
+++ b/plugins/ledmatrix-weather/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.3.0] - 2026-05-27
+
+### Changed
+- **Migrated weather data source from OpenWeatherMap to Open-Meteo**: No API key
+  required. Open-Meteo is a free, open-source weather API that covers all
+  previously displayed fields: temperature, humidity, wind, UV index, dew point,
+  visibility, pressure, feels-like, hourly/daily forecasts, sunrise/sunset, moon
+  phase, moonrise/moonset.
+- **Weather alerts now use NWS API** (US locations only, free, no key). Alerts
+  are silently skipped for non-US locations.
+- Removed `api_key` from plugin configuration. Existing installs with an
+  `api_key` in `config.json` or `config_secrets.json` can safely leave or remove it.
+
 ## [2.1.0] - 2026-02-13
 
 ### Fixed

--- a/plugins/ledmatrix-weather/README.md
+++ b/plugins/ledmatrix-weather/README.md
@@ -36,32 +36,18 @@ Daily Forecast:
 - **Hourly forecast**: next 24 hours
 - **Daily forecast**: 3–7 day high/low
 - **Almanac**: sunrise/sunset, moon phase, day length
-- **Precipitation radar**: live RainViewer imagery — no API key required for this part
-- **Weather alerts**: when active, takes priority in the rotation
+- **Precipitation radar**: live RainViewer imagery
+- **Weather alerts**: when active (US only), takes priority in the rotation
 
 ## Requirements
 
-- A **One Call API 3.0** subscription from OpenWeatherMap (free tier
-  available) — see API Key below
-- Internet connection for OpenWeatherMap and RainViewer
+- Internet connection
+- No API key required — weather data comes from [Open-Meteo](https://open-meteo.com/),
+  a free and open-source weather API
 - Display size: 64x32 minimum; 64x48 or larger to see the extra current-
   conditions metrics
 
 ## Configuration
-
-### API Key
-
-This plugin requires the **One Call API 3.0** product from OpenWeatherMap.
-A standard OpenWeatherMap API key on its own will **not** work — One Call 3.0
-is a separate subscription you must enable on your account.
-
-1. Sign up at https://openweathermap.org
-2. Generate an API key under **API Keys**
-3. Go to https://openweathermap.org/api, find **One Call API 3.0**, click
-   **Subscribe**. The free tier requires entering payment info but does not
-   charge you below 1,000 calls/day.
-4. Open the **Weather** tab in the LEDMatrix web UI (or edit
-   `config/config_secrets.json`) and paste the key into `api_key`.
 
 ### Configuration options
 
@@ -72,20 +58,19 @@ generated from it. The keys you'll touch most often:
 | Key | Default | Notes |
 |---|---|---|
 | `enabled` | `false` | Master switch |
-| `api_key` | _required_ | One Call 3.0 key (store in `config_secrets.json`) |
 | `location_city` | `"Dallas"` | City name |
 | `location_state` | `"Texas"` | State/province (optional, helps US disambiguation) |
 | `location_country` | `"US"` | ISO 3166-1 alpha-2 code |
 | `units` | `"imperial"` | `"imperial"` (°F) or `"metric"` (°C) |
 | `display_duration` | `30` | Seconds per mode (5–300) |
-| `update_interval` | `1800` | Seconds between OpenWeatherMap fetches (min 300) |
+| `update_interval` | `1800` | Seconds between weather fetches (min 300) |
 | `display_format` | `"{temp}°F\n{condition}"` | Placeholders: `{temp}`, `{condition}`, `{humidity}`, `{wind}` |
 | `show_current_weather` | `true` | Toggle current conditions mode |
 | `show_hourly_forecast` | `true` | Toggle hourly mode |
 | `show_daily_forecast` | `true` | Toggle daily mode |
 | `show_almanac` | `true` | Toggle almanac mode (sun/moon) |
 | `show_radar` | `true` | Toggle precipitation radar mode |
-| `show_alerts` | `true` | Show active weather alerts (preempts rotation) |
+| `show_alerts` | `true` | Show active weather alerts (preempts rotation, US only) |
 | `show_feels_like` / `show_dew_point` / `show_visibility` / `show_pressure` | `true` | Extra current-conditions metrics (need height ≥ 48px) |
 | `radar_zoom` | `6` | 4 (regional) to 8 (very close) |
 | `radar_line_color` | `[0, 130, 70]` | RGB for state outlines |
@@ -106,7 +91,9 @@ controller rotates through them in order:
 | `radar` | Live precipitation radar from RainViewer |
 
 When an active weather alert is available and `show_alerts` is true, the
-alert takes priority over the normal rotation.
+alert takes priority over the normal rotation. Alerts are sourced from the
+[NWS API](https://www.weather.gov/documentation/services-web-api) and are
+only available for US locations.
 
 ## Usage
 
@@ -114,34 +101,30 @@ The plugin auto-rotates through enabled display modes based on
 `display_duration`. Toggle individual modes on or off with the
 `show_*` keys above (or the matching toggles in the web UI).
 
+## Data sources
+
+| Data | Source | Key required |
+|---|---|---|
+| Current conditions, forecast, almanac | [Open-Meteo](https://open-meteo.com/) | None |
+| Weather alerts | [NWS API](https://www.weather.gov/documentation/services-web-api) (US only) | None |
+| Precipitation radar | [RainViewer](https://www.rainviewer.com/api.html) | None |
+
 ## Troubleshooting
 
 **No weather data displayed / "No Data" on screen:**
-- **Most common cause**: Your API key is not subscribed to One Call API 3.0
-  - Check logs for "401 Unauthorized" errors
-  - Subscribe at https://openweathermap.org/api -> One Call API 3.0 -> Subscribe
-- Verify your API key is correct
 - Verify internet connection
-- Ensure location is spelled correctly (city name must match OpenWeatherMap's geocoding)
+- Ensure location is spelled correctly (`location_city` must be a city
+  name that Open-Meteo's geocoding can resolve)
+- Check plugin logs for specific error messages
 
 **Slow updates:**
-- API has rate limits, respect the minimum update interval
-- Free tier allows 1000 calls/day
+- Lower `update_interval` for fresher data (minimum 300 s); the default
+  1800 s (30 min) is recommended since weather rarely changes faster
 
-## API rate limits
-
-OpenWeatherMap One Call 3.0 free tier:
-- 1,000 calls per day
-- 60 calls per minute
-
-With the default `update_interval` of 1800s (30 minutes), this plugin
-makes about 48 calls per day. Lower the interval if you want fresher
-data — just keep it ≥ 300s and watch your daily total.
-
-The radar mode uses RainViewer separately and has no API key, but obeys
-`radar_update_interval` (default 600s) to avoid hammering their CDN.
+**Radar not showing:**
+- Radar uses RainViewer and updates on a separate `radar_update_interval`
+  (default 600 s); allow a minute for the first tiles to load
 
 ## License
 
 GPL-3.0 License - see main LEDMatrix repository for details.
-

--- a/plugins/ledmatrix-weather/config_schema.json
+++ b/plugins/ledmatrix-weather/config_schema.json
@@ -20,14 +20,7 @@
       "type": "integer",
       "default": 1800,
       "minimum": 300,
-      "description": "How often to fetch new weather data in seconds (minimum 300 = 5 minutes to respect API rate limits)"
-    },
-    "api_key": {
-      "type": "string",
-      "default": "YOUR_OPENWEATHERMAP_API_KEY",
-      "description": "OpenWeatherMap API key (required). Must be subscribed to One Call API 3.0 at https://openweathermap.org/api (free tier available, requires payment info). Store in config_secrets.json for security.",
-      "title": "API Key",
-      "x-secret": true
+      "description": "How often to fetch new weather data in seconds (minimum 300 = 5 minutes)"
     },
     "location_city": {
       "type": "string",
@@ -160,7 +153,6 @@
   },
   "required": [
     "enabled",
-    "api_key",
     "location_city",
     "location_country"
   ],

--- a/plugins/ledmatrix-weather/config_schema.json
+++ b/plugins/ledmatrix-weather/config_schema.json
@@ -22,6 +22,11 @@
       "minimum": 300,
       "description": "How often to fetch new weather data in seconds (minimum 300 = 5 minutes)"
     },
+    "api_key": {
+      "type": "string",
+      "description": "Deprecated — no longer used. Kept for backward compatibility with existing configs.",
+      "title": "API Key (deprecated)"
+    },
     "location_city": {
       "type": "string",
       "default": "Dallas",

--- a/plugins/ledmatrix-weather/manager.py
+++ b/plugins/ledmatrix-weather/manager.py
@@ -482,7 +482,6 @@ class WeatherPlugin(BasePlugin):
 
         om_data = response.json()
         current = om_data['current']
-        daily_raw = om_data['daily']
 
         wmo_code = current.get('weather_code', 0)
         is_day = bool(current.get('is_day', 1))
@@ -570,7 +569,8 @@ class WeatherPlugin(BasePlugin):
         for i, t in enumerate(times):
             try:
                 ts = int(datetime.fromisoformat(t).replace(tzinfo=tz).timestamp())
-            except Exception:
+            except (ValueError, OverflowError, OSError) as exc:
+                self.logger.debug("Skipping hourly entry with unparseable time %r: %s", t, exc)
                 continue
             code = codes[i] if i < len(codes) else 0
             is_day = bool(is_days[i]) if i < len(is_days) else True
@@ -616,7 +616,8 @@ class WeatherPlugin(BasePlugin):
                 dt = datetime.fromisoformat(t).replace(tzinfo=tz)
                 ts = int(dt.timestamp())
                 d = dt.date()
-            except Exception:
+            except (ValueError, OverflowError, OSError) as exc:
+                self.logger.debug("Skipping daily entry with unparseable time %r: %s", t, exc)
                 continue
             code = daily['weather_code'][i] if i < len(daily.get('weather_code', [])) else 0
 

--- a/plugins/ledmatrix-weather/manager.py
+++ b/plugins/ledmatrix-weather/manager.py
@@ -276,6 +276,8 @@ class WeatherPlugin(BasePlugin):
         self.show_current = new_config.get('show_current_weather', self.show_current)
         self.show_hourly = new_config.get('show_hourly_forecast', self.show_hourly)
         self.show_daily = new_config.get('show_daily_forecast', self.show_daily)
+        self.show_almanac = new_config.get('show_almanac', self.show_almanac)
+        self.show_radar = new_config.get('show_radar', self.show_radar)
 
         # Rebuild mode list and reset index so IndexError can't occur
         self.modes = []
@@ -285,6 +287,10 @@ class WeatherPlugin(BasePlugin):
             self.modes.append('hourly_forecast')
         if self.show_daily:
             self.modes.append('daily_forecast')
+        if self.show_almanac:
+            self.modes.append('almanac')
+        if self.show_radar:
+            self.modes.append('radar')
         if not self.modes:
             self.modes = ['weather']
         self.current_mode_index = 0
@@ -423,7 +429,8 @@ class WeatherPlugin(BasePlugin):
                 return
 
         # Step A: Geocoding via Open-Meteo geocoding API
-        geo_url = f"https://geocoding-api.open-meteo.com/v1/search?name={city}&count=5&language=en&format=json"
+        from urllib.parse import quote_plus
+        geo_url = f"https://geocoding-api.open-meteo.com/v1/search?name={quote_plus(city)}&count=5&language=en&format=json"
         try:
             response = requests.get(geo_url, timeout=10)
             response.raise_for_status()
@@ -548,15 +555,21 @@ class WeatherPlugin(BasePlugin):
 
     def _map_om_hourly(self, om_data: Dict) -> List[Dict]:
         """Convert Open-Meteo hourly arrays to OWM-compatible hourly list."""
+        import zoneinfo
         hourly = om_data.get('hourly', {})
         times = hourly.get('time', [])
         temps = hourly.get('temperature_2m', [])
         codes = hourly.get('weather_code', [])
         is_days = hourly.get('is_day', [])
+        tz_name = om_data.get('timezone', 'UTC')
+        try:
+            tz = zoneinfo.ZoneInfo(tz_name)
+        except Exception:
+            tz = zoneinfo.ZoneInfo('UTC')
         result = []
         for i, t in enumerate(times):
             try:
-                ts = int(datetime.fromisoformat(t).timestamp())
+                ts = int(datetime.fromisoformat(t).replace(tzinfo=tz).timestamp())
             except Exception:
                 continue
             code = codes[i] if i < len(codes) else 0
@@ -593,14 +606,14 @@ class WeatherPlugin(BasePlugin):
             if not s:
                 return None
             try:
-                return int(datetime.fromisoformat(s).timestamp())
+                return int(datetime.fromisoformat(s).replace(tzinfo=tz).timestamp())
             except Exception:
                 return None
 
         result = []
         for i, t in enumerate(times):
             try:
-                dt = datetime.fromisoformat(t)
+                dt = datetime.fromisoformat(t).replace(tzinfo=tz)
                 ts = int(dt.timestamp())
                 d = dt.date()
             except Exception:

--- a/plugins/ledmatrix-weather/manager.py
+++ b/plugins/ledmatrix-weather/manager.py
@@ -2,7 +2,7 @@
 Weather Plugin for LEDMatrix
 
 Comprehensive weather display with current conditions, hourly forecast, and daily forecast.
-Uses OpenWeatherMap API to provide accurate weather information with beautiful icons.
+Uses Open-Meteo API (free, no API key required) with RainViewer for precipitation radar.
 
 Features:
 - Current weather conditions with temperature, humidity, wind speed
@@ -11,8 +11,6 @@ Features:
 - Weather icons matching conditions
 - UV index display
 - Automatic error handling and retry logic
-
-API Version: 1.0.0
 """
 
 import requests
@@ -47,14 +45,10 @@ except ImportError:
 class WeatherPlugin(BasePlugin):
     """
     Weather plugin that displays current conditions and forecasts.
-    
-    Supports three display modes:
-    - weather: Current conditions
-    - hourly_forecast: Hourly forecast for next 48 hours
-    - daily_forecast: Daily forecast for next 7 days
-    
+
+    Supports display modes: weather, hourly_forecast, daily_forecast, almanac, radar.
+
     Configuration options:
-        api_key (str): OpenWeatherMap API key
         location (dict): City, state, country for weather data
         units (str): 'imperial' (F) or 'metric' (C)
         update_interval (int): Seconds between API updates
@@ -65,9 +59,6 @@ class WeatherPlugin(BasePlugin):
                  display_manager, cache_manager, plugin_manager):
         """Initialize the weather plugin."""
         super().__init__(plugin_id, config, display_manager, cache_manager, plugin_manager)
-        
-        # Weather configuration
-        self.api_key = config.get('api_key', 'YOUR_OPENWEATHERMAP_API_KEY')
         
         # Location - read from flat format (location_city, location_state, location_country)
         # These are the fields defined in config_schema.json for the web interface
@@ -276,7 +267,6 @@ class WeatherPlugin(BasePlugin):
     def on_config_change(self, new_config: Dict[str, Any]) -> None:
         """Handle live configuration updates."""
         self.config = new_config
-        self.api_key = new_config.get('api_key', self.api_key)
         self.location = {
             'city': new_config.get('location_city', self.location.get('city', 'Dallas')),
             'state': new_config.get('location_state', self.location.get('state', 'Texas')),
@@ -305,12 +295,12 @@ class WeatherPlugin(BasePlugin):
 
     def update(self) -> None:
         """
-        Update weather data from OpenWeatherMap API.
+        Update weather data from Open-Meteo API.
 
         Fetches current conditions and forecast data, respecting
         update intervals and error backoff periods.
         """
-        # Refresh radar tiles unconditionally (uses RainViewer, not OpenWeatherMap)
+        # Refresh radar tiles unconditionally (uses RainViewer, separate from weather data)
         self._update_radar()
 
         current_time = time.time()
@@ -331,11 +321,6 @@ class WeatherPlugin(BasePlugin):
                 # Reset error count after backoff
                 self.consecutive_errors = 0
                 self.error_backoff_time = 60
-
-        # Validate API key
-        if not self.api_key or self.api_key == "YOUR_OPENWEATHERMAP_API_KEY":
-            self.logger.warning("No valid OpenWeatherMap API key configured")
-            return
 
         # Try to fetch weather data
         try:
@@ -405,8 +390,7 @@ class WeatherPlugin(BasePlugin):
         )
 
     def _fetch_weather(self) -> None:
-        """Fetch weather data from OpenWeatherMap API."""
-        # Check cache first - use update_interval as max_age to respect configured refresh rate
+        """Fetch weather data from Open-Meteo API (free, no API key required)."""
         city = self.location.get('city', 'Dallas')
         state = self.location.get('state', 'Texas')
         country = self.location.get('country', 'US')
@@ -423,7 +407,7 @@ class WeatherPlugin(BasePlugin):
                         'sunrise': fc.get('sunrise'),
                         'sunset': fc.get('sunset'),
                     }
-                if 'moon' not in self.weather_data and 'daily' in self.forecast_data:
+                if 'moon' not in self.weather_data and self.forecast_data.get('daily'):
                     d0 = self.forecast_data['daily'][0]
                     self.weather_data['moon'] = {
                         'phase': d0.get('moon_phase'),
@@ -437,114 +421,239 @@ class WeatherPlugin(BasePlugin):
                 self._process_forecast_data(self.forecast_data)
                 self.logger.info("Using cached weather data")
                 return
-        
-        # Get coordinates using geocoding API
-        geo_url = f"https://api.openweathermap.org/geo/1.0/direct?q={city},{state},{country}&limit=1&appid={self.api_key}"
 
+        # Step A: Geocoding via Open-Meteo geocoding API
+        geo_url = f"https://geocoding-api.open-meteo.com/v1/search?name={city}&count=5&language=en&format=json"
         try:
             response = requests.get(geo_url, timeout=10)
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             status = e.response.status_code if e.response is not None else None
-            if status == 401:
-                self._last_error_hint = "Invalid API key"
-                self.logger.error(
-                    "Geocoding API returned 401 Unauthorized. "
-                    "Verify your API key is correct at https://openweathermap.org/api"
-                )
-            elif status == 429:
-                self._last_error_hint = "Rate limit exceeded"
-                self.logger.error("Geocoding API rate limit exceeded (429). Increase update_interval.")
-            else:
-                self._last_error_hint = f"Geo API error {status}"
-                self.logger.error(f"Geocoding API HTTP error {status}: {e}")
+            self._last_error_hint = f"Geo API error {status}"
+            self.logger.error(f"Open-Meteo geocoding HTTP error {status}: {e}")
             raise
-        geo_data = response.json()
-        
-        
-        if not geo_data:
-            self._last_error_hint = f"Unknown: {city}, {state}"
-            self.logger.error(f"Could not find coordinates for {city}, {state}, {country}")
-            self.last_update = time.time()  # Prevent immediate retry
-            return
-        
-        lat = geo_data[0]['lat']
-        lon = geo_data[0]['lon']
-        
-        # Get weather data using One Call API
-        one_call_url = f"https://api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lon}&exclude=minutely&appid={self.api_key}&units={self.units}"
 
+        results = response.json().get('results', [])
+        if not results:
+            self._last_error_hint = f"Unknown: {city}"
+            self.logger.error(f"Could not find coordinates for {city}, {state}, {country}")
+            self.last_update = time.time()
+            return
+
+        # Pick the best result by matching country code
+        country_upper = country.upper() if country else ''
+        lat, lon = results[0]['latitude'], results[0]['longitude']
+        for r in results:
+            if r.get('country_code', '').upper() == country_upper:
+                lat, lon = r['latitude'], r['longitude']
+                break
+
+        # Step B: Fetch forecast from Open-Meteo
+        temp_unit = "fahrenheit" if self.units == "imperial" else "celsius"
+        wind_unit = "mph" if self.units == "imperial" else "kmh"
+        forecast_url = (
+            f"https://api.open-meteo.com/v1/forecast"
+            f"?latitude={lat}&longitude={lon}"
+            f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+            f"dew_point_2m,surface_pressure,cloud_cover,visibility,"
+            f"wind_speed_10m,wind_direction_10m,wind_gusts_10m,uv_index,weather_code,is_day"
+            f"&hourly=temperature_2m,weather_code,is_day"
+            f"&daily=temperature_2m_max,temperature_2m_min,weather_code,sunrise,sunset,uv_index_max"
+            f"&temperature_unit={temp_unit}"
+            f"&wind_speed_unit={wind_unit}"
+            f"&timezone=auto"
+            f"&forecast_days=7"
+        )
         try:
-            response = requests.get(one_call_url, timeout=10)
+            response = requests.get(forecast_url, timeout=10)
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             status = e.response.status_code if e.response is not None else None
-            if status == 401:
-                self._last_error_hint = "Subscribe to One Call 3.0"
-                self.logger.error(
-                    "One Call API 3.0 returned 401 Unauthorized. "
-                    "Your API key is NOT subscribed to One Call API 3.0. "
-                    "Subscribe (free tier available) at https://openweathermap.org/api "
-                    "-> One Call API 3.0 -> Subscribe."
-                )
-            elif status == 429:
-                self._last_error_hint = "Rate limit exceeded"
-                self.logger.error("One Call API rate limit exceeded (429). Increase update_interval.")
-            else:
-                self._last_error_hint = f"Weather API error {status}"
-                self.logger.error(f"One Call API HTTP error {status}: {e}")
+            self._last_error_hint = f"Weather API error {status}"
+            self.logger.error(f"Open-Meteo forecast HTTP error {status}: {e}")
             raise
-        one_call_data = response.json()
-        
-        
-        # Store current weather data (including previously-unused fields)
-        current = one_call_data['current']
-        daily_today = one_call_data['daily'][0]
+
+        om_data = response.json()
+        current = om_data['current']
+        daily_raw = om_data['daily']
+
+        wmo_code = current.get('weather_code', 0)
+        is_day = bool(current.get('is_day', 1))
+        icon_code = WeatherIcons.wmo_to_icon_code(wmo_code, is_day)
+        condition = WeatherIcons.wmo_to_condition(wmo_code)
+
+        daily_list = self._map_om_daily(om_data)
+        daily_today = daily_list[0] if daily_list else {}
+
+        tz_offset = om_data.get('utc_offset_seconds', 0)
+
         self.weather_data = {
             'main': {
-                'temp': current['temp'],
-                'temp_max': daily_today['temp']['max'],
-                'temp_min': daily_today['temp']['min'],
-                'humidity': current['humidity'],
-                'pressure': current['pressure'],
-                'uvi': current.get('uvi', 0),
-                'feels_like': current.get('feels_like'),
-                'dew_point': current.get('dew_point'),
-                'visibility': current.get('visibility'),  # meters
-                'clouds': current.get('clouds'),
+                'temp': current.get('temperature_2m'),
+                'temp_max': daily_today.get('temp', {}).get('max'),
+                'temp_min': daily_today.get('temp', {}).get('min'),
+                'humidity': current.get('relative_humidity_2m'),
+                'pressure': current.get('surface_pressure'),
+                'uvi': current.get('uv_index', 0),
+                'feels_like': current.get('apparent_temperature'),
+                'dew_point': current.get('dew_point_2m'),
+                'visibility': current.get('visibility'),
+                'clouds': current.get('cloud_cover'),
             },
-            'weather': current['weather'],
+            'weather': [{'main': condition, 'icon': icon_code, 'description': condition.lower()}],
             'wind': {
-                'speed': current['wind_speed'],
-                'deg': current.get('wind_deg', 0),
-                'gust': current.get('wind_gust'),
+                'speed': current.get('wind_speed_10m', 0),
+                'deg': current.get('wind_direction_10m', 0),
+                'gust': current.get('wind_gusts_10m'),
             },
             'sun': {
-                'sunrise': current.get('sunrise'),
-                'sunset': current.get('sunset'),
+                'sunrise': daily_today.get('sunrise'),
+                'sunset': daily_today.get('sunset'),
             },
             'moon': {
                 'phase': daily_today.get('moon_phase'),
                 'moonrise': daily_today.get('moonrise'),
                 'moonset': daily_today.get('moonset'),
             },
-            'alerts': one_call_data.get('alerts', []),
-            'timezone_offset': one_call_data.get('timezone_offset', 0),
+            'alerts': [],
+            'timezone_offset': tz_offset,
         }
-        
-        # Store forecast data
-        self.forecast_data = one_call_data
-        
-        # Process forecast data
+
+        self.forecast_data = {
+            'lat': lat,
+            'lon': lon,
+            'timezone_offset': tz_offset,
+            'current': {
+                'sunrise': daily_today.get('sunrise'),
+                'sunset': daily_today.get('sunset'),
+            },
+            'daily': daily_list,
+            'hourly': self._map_om_hourly(om_data),
+            'alerts': [],
+        }
+
+        # Step C: NWS alerts (US-only, silent skip for non-US / failures)
+        alerts = self._fetch_nws_alerts(lat, lon)
+        self.weather_data['alerts'] = alerts
+        self.forecast_data['alerts'] = alerts
+
         self._process_forecast_data(self.forecast_data)
-        
-        # Cache the data
+
         self.cache_manager.set(cache_key, {
             'current': self.weather_data,
-            'forecast': self.forecast_data
+            'forecast': self.forecast_data,
         })
-        
+
         self.logger.info(f"Weather data updated for {city}: {self.weather_data['main']['temp']}°")
+
+    def _map_om_hourly(self, om_data: Dict) -> List[Dict]:
+        """Convert Open-Meteo hourly arrays to OWM-compatible hourly list."""
+        hourly = om_data.get('hourly', {})
+        times = hourly.get('time', [])
+        temps = hourly.get('temperature_2m', [])
+        codes = hourly.get('weather_code', [])
+        is_days = hourly.get('is_day', [])
+        result = []
+        for i, t in enumerate(times):
+            try:
+                ts = int(datetime.fromisoformat(t).timestamp())
+            except Exception:
+                continue
+            code = codes[i] if i < len(codes) else 0
+            is_day = bool(is_days[i]) if i < len(is_days) else True
+            result.append({
+                'dt': ts,
+                'temp': temps[i] if i < len(temps) else 0,
+                'weather': [{'main': WeatherIcons.wmo_to_condition(code),
+                              'icon': WeatherIcons.wmo_to_icon_code(code, is_day)}],
+            })
+        return result
+
+    def _map_om_daily(self, om_data: Dict) -> List[Dict]:
+        """Convert Open-Meteo daily arrays to OWM-compatible daily list.
+
+        Moon phase / moonrise / moonset are computed via astral since
+        Open-Meteo does not provide those variables.
+        """
+        from astral import moon as astral_moon, Observer
+        import zoneinfo
+
+        daily = om_data.get('daily', {})
+        times = daily.get('time', [])
+        lat = om_data.get('latitude', 0)
+        lon = om_data.get('longitude', 0)
+        tz_name = om_data.get('timezone', 'UTC')
+        try:
+            tz = zoneinfo.ZoneInfo(tz_name)
+        except Exception:
+            tz = zoneinfo.ZoneInfo('UTC')
+        observer = Observer(latitude=lat, longitude=lon)
+
+        def parse_ts(s):
+            if not s:
+                return None
+            try:
+                return int(datetime.fromisoformat(s).timestamp())
+            except Exception:
+                return None
+
+        result = []
+        for i, t in enumerate(times):
+            try:
+                dt = datetime.fromisoformat(t)
+                ts = int(dt.timestamp())
+                d = dt.date()
+            except Exception:
+                continue
+            code = daily['weather_code'][i] if i < len(daily.get('weather_code', [])) else 0
+
+            # Moon phase: astral returns 0-28; normalize to 0-1 to match OWM convention
+            moon_phase = astral_moon.phase(d) / 28.0
+            try:
+                moonrise_dt = astral_moon.moonrise(observer, d, tzinfo=tz)
+                moonrise_ts = int(moonrise_dt.timestamp()) if moonrise_dt else None
+            except Exception:
+                moonrise_ts = None
+            try:
+                moonset_dt = astral_moon.moonset(observer, d, tzinfo=tz)
+                moonset_ts = int(moonset_dt.timestamp()) if moonset_dt else None
+            except Exception:
+                moonset_ts = None
+
+            result.append({
+                'dt': ts,
+                'temp': {
+                    'max': daily['temperature_2m_max'][i] if i < len(daily.get('temperature_2m_max', [])) else 0,
+                    'min': daily['temperature_2m_min'][i] if i < len(daily.get('temperature_2m_min', [])) else 0,
+                },
+                'weather': [{'main': WeatherIcons.wmo_to_condition(code),
+                              'icon': WeatherIcons.wmo_to_icon_code(code, True)}],
+                'sunrise': parse_ts(daily['sunrise'][i] if i < len(daily.get('sunrise', [])) else None),
+                'sunset': parse_ts(daily['sunset'][i] if i < len(daily.get('sunset', [])) else None),
+                'moonrise': moonrise_ts,
+                'moonset': moonset_ts,
+                'moon_phase': moon_phase,
+            })
+        return result
+
+    def _fetch_nws_alerts(self, lat: float, lon: float) -> List[Dict]:
+        """Fetch active weather alerts from NWS API (US-only, free, no API key)."""
+        try:
+            url = f"https://api.weather.gov/alerts/active?point={lat:.4f},{lon:.4f}"
+            headers = {'User-Agent': 'LEDMatrix-Weather/2.3.0 (github.com/ChuckBuilds/ledmatrix-plugins)'}
+            response = requests.get(url, headers=headers, timeout=8)
+            if response.status_code == 200:
+                return [
+                    {
+                        'event': f.get('properties', {}).get('event', ''),
+                        'sender_name': f.get('properties', {}).get('senderName', ''),
+                        'description': f.get('properties', {}).get('description', ''),
+                    }
+                    for f in response.json().get('features', [])
+                ]
+        except Exception:
+            pass
+        return []
     
     def _process_forecast_data(self, forecast_data: Dict) -> None:
         """Process forecast data into hourly and daily lists."""
@@ -699,10 +808,7 @@ class WeatherPlugin(BasePlugin):
         except Exception:
             font = ImageFont.load_default()
 
-        if not self.api_key or self.api_key == "YOUR_OPENWEATHERMAP_API_KEY":
-            draw.text((2, 8), "Weather:", font=font, fill=(200, 200, 200))
-            draw.text((2, 18), "No API Key", font=font, fill=(255, 100, 100))
-        elif self._last_error_hint:
+        if self._last_error_hint:
             draw.text((2, 4), "Weather Err", font=font, fill=(200, 200, 200))
             hint = self._last_error_hint[:22]
             draw.text((2, 14), hint, font=font, fill=(255, 100, 100))
@@ -1299,7 +1405,6 @@ class WeatherPlugin(BasePlugin):
         info.update({
             'location': self.location,
             'units': self.units,
-            'api_key_configured': bool(self.api_key),
             'last_update': self.last_update,
             'current_temp': self.weather_data.get('main', {}).get('temp') if self.weather_data else None,
             'current_humidity': self.weather_data.get('main', {}).get('humidity') if self.weather_data else None,

--- a/plugins/ledmatrix-weather/manifest.json
+++ b/plugins/ledmatrix-weather/manifest.json
@@ -1,17 +1,17 @@
 {
   "id": "ledmatrix-weather",
   "name": "Weather Display",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "author": "ChuckBuilds",
   "class_name": "WeatherPlugin",
-  "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, almanac (sunrise/sunset, moon phase), precipitation radar, weather alerts, UV index, wind direction, and weather icons. Powered by OpenWeatherMap + RainViewer APIs.",
+  "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, almanac (sunrise/sunset, moon phase), precipitation radar, weather alerts, UV index, wind direction, and weather icons. Powered by Open-Meteo (free, no API key) + RainViewer.",
   "category": "weather",
   "tags": [
     "weather",
     "forecast",
     "temperature",
     "conditions",
-    "openweathermap",
+    "open-meteo",
     "uv-index",
     "wind",
     "icons",
@@ -25,6 +25,12 @@
     "radar"
   ],
   "versions": [
+    {
+      "released": "2026-05-27",
+      "version": "2.3.0",
+      "note": "Migrate data source from OpenWeatherMap to Open-Meteo (free, no API key required). Alerts via NWS API for US locations.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-15",
       "version": "2.2.4",
@@ -78,7 +84,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-15",
+  "last_updated": "2026-05-27",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/ledmatrix-weather/requirements.txt
+++ b/plugins/ledmatrix-weather/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.33.0
 Pillow>=12.2.0
 pytz>=2024.1
+astral>=3.2
 

--- a/plugins/ledmatrix-weather/weather_icons.py
+++ b/plugins/ledmatrix-weather/weather_icons.py
@@ -2,7 +2,7 @@
 Weather Icons Module for Weather Plugin
 
 Handles loading and drawing weather icons from PNG files in assets/weather/.
-Maps OpenWeatherMap icon codes to appropriate icon files.
+Maps OWM-style icon codes (e.g. '01d', '10n') and WMO weather codes to icon files.
 """
 
 import math
@@ -62,6 +62,48 @@ class WeatherIcons:
         "moon-last-quarter": "moon-last-quarter.png",
         "moon-waning-crescent": "moon-waning-crescent.png",
     }
+
+    # WMO weather interpretation codes → OWM-style icon keys
+    # https://open-meteo.com/en/docs#weathervariables
+    _WMO_DAY_MAP = {
+        0: "01d", 1: "02d", 2: "03d", 3: "04d",
+        45: "50d", 48: "50d",
+        51: "09d", 53: "09d", 55: "09d", 56: "09d", 57: "09d",
+        61: "10d", 63: "10d", 65: "10d", 66: "13d", 67: "13d",
+        71: "13d", 73: "13d", 75: "13d", 77: "13d",
+        80: "10d", 81: "10d", 82: "10d", 85: "13d", 86: "13d",
+        95: "11d", 96: "11d", 99: "11d",
+    }
+    _WMO_NIGHT_MAP = {
+        0: "01n", 1: "02n", 2: "03n", 3: "04n",
+        45: "50n", 48: "50n",
+        51: "09n", 53: "09n", 55: "09n", 56: "09n", 57: "09n",
+        61: "10n", 63: "10n", 65: "10n", 66: "13n", 67: "13n",
+        71: "13n", 73: "13n", 75: "13n", 77: "13n",
+        80: "10n", 81: "10n", 82: "10n", 85: "13n", 86: "13n",
+        95: "11n", 96: "11n", 99: "11n",
+    }
+    _WMO_CONDITION_MAP = {
+        0: "Clear", 1: "Clear", 2: "Partly Cloudy", 3: "Overcast",
+        45: "Fog", 48: "Fog",
+        51: "Drizzle", 53: "Drizzle", 55: "Drizzle", 56: "Drizzle", 57: "Drizzle",
+        61: "Rain", 63: "Rain", 65: "Rain", 66: "Rain", 67: "Rain",
+        71: "Snow", 73: "Snow", 75: "Snow", 77: "Snow",
+        80: "Showers", 81: "Showers", 82: "Showers",
+        85: "Snow Showers", 86: "Snow Showers",
+        95: "Thunderstorm", 96: "Thunderstorm", 99: "Thunderstorm",
+    }
+
+    @classmethod
+    def wmo_to_icon_code(cls, wmo_code: int, is_day: bool = True) -> str:
+        """Convert a WMO weather code to an OWM-style icon code."""
+        mapping = cls._WMO_DAY_MAP if is_day else cls._WMO_NIGHT_MAP
+        return mapping.get(wmo_code, "01d" if is_day else "01n")
+
+    @classmethod
+    def wmo_to_condition(cls, wmo_code: int) -> str:
+        """Convert a WMO weather code to a human-readable condition string."""
+        return cls._WMO_CONDITION_MAP.get(wmo_code, "Unknown")
 
     @classmethod
     def _resolve_icon_path(cls, filename: str) -> Union[Path, None]:

--- a/plugins/of-the-day/config_schema.json
+++ b/plugins/of-the-day/config_schema.json
@@ -76,9 +76,37 @@
     "file_manager": {
       "type": "null",
       "title": "Data Files",
-      "x-widget": "custom-html",
-      "x-html-file": "web_ui/file_manager.html",
-      "description": "Manage your Of The Day JSON data files"
+      "description": "Manage your Of The Day JSON data files",
+      "x-widget": "json-file-manager",
+      "x-widget-config": {
+        "actions": {
+          "list":   "list-files",
+          "get":    "get-file",
+          "save":   "save-file",
+          "upload": "upload-file",
+          "delete": "delete-file",
+          "create": "create-file",
+          "toggle": "toggle-category"
+        },
+        "upload_hint":    "JSON files with day numbers 1–365 as keys",
+        "directory_label": "of_the_day/",
+        "create_fields": [
+          {
+            "key":         "category_name",
+            "label":       "Category Name",
+            "placeholder": "e.g., my_words",
+            "pattern":     "^[a-z0-9_]+$",
+            "hint":        "Lowercase letters, numbers, underscores — used as filename"
+          },
+          {
+            "key":         "display_name",
+            "label":       "Display Name",
+            "placeholder": "e.g., My Words",
+            "hint":        "Shown in plugin configuration (leave blank to auto-generate)"
+          }
+        ],
+        "toggle_key": "category_name"
+      }
     }
   },
   "required": ["enabled"]

--- a/plugins/of-the-day/manifest.json
+++ b/plugins/of-the-day/manifest.json
@@ -34,7 +34,7 @@
     {
       "released": "2025-10-19",
       "version": "1.0.1",
-      "ledmatrix_min_version": "2.0.0"
+      "ledmatrix_min": "2.0.0"
     }
   ],
   "last_updated": "2026-05-26",

--- a/plugins/of-the-day/manifest.json
+++ b/plugins/of-the-day/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "of-the-day",
   "name": "Of The Day Display",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "ChuckBuilds",
   "description": "Display daily featured content like Word of the Day, Bible verses, or custom daily items. Supports multiple categories with rotating display and configurable data sources.",
   "category": "information",
@@ -22,6 +22,11 @@
   ],
   "versions": [
     {
+      "released": "2026-05-26",
+      "version": "1.1.0",
+      "ledmatrix_min": "2.0.0"
+    },
+    {
       "released": "2026-05-15",
       "version": "1.0.2",
       "ledmatrix_min": "2.0.0"
@@ -32,7 +37,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-15",
+  "last_updated": "2026-05-26",
   "stars": 0,
   "downloads": 0,
   "verified": true,


### PR DESCRIPTION
## Summary

- **Removes OpenWeatherMap dependency** — the One Call API 3.0 subscription (requires payment info) is replaced with [Open-Meteo](https://open-meteo.com/), a free open-source weather API that requires no API key
- **`api_key` removed from config** — existing installs can safely leave or remove any `api_key` entry from their config; it's silently ignored
- **All display modes preserved** — current conditions, hourly, daily, almanac, radar, and alerts all continue to work; the fetch layer maps directly into the same internal `weather_data` structure
- **Weather alerts now via NWS API** — US-only, free, no key; silently skipped for non-US locations
- **Moon data via `astral` library** — Open-Meteo doesn't provide moon phase/rise/set, so these are computed locally using `astral>=3.2` (already installed on the base system); added to `requirements.txt`

## Data sources after this change

| Data | Source | Key required |
|---|---|---|
| Current conditions, forecasts, almanac | Open-Meteo | None |
| Weather alerts | NWS API (US only) | None |
| Precipitation radar | RainViewer | None |

## Test plan

- [ ] Install/update plugin, remove `api_key` from config
- [ ] Confirm weather data fetches from `api.open-meteo.com` in plugin logs
- [ ] Cycle through all display modes: current, hourly, daily, almanac, radar
- [ ] Confirm WMO weather icons render (not "not-available.png") for current conditions
- [ ] Confirm almanac shows correct moon phase, moonrise, moonset, sunrise, sunset
- [ ] For US location: verify NWS alert fetch (0 alerts if none active is fine)
- [ ] For non-US location: confirm no errors related to alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather Plugin v2.3.0: switched to Open‑Meteo (no API key), added moon phase data, expanded display modes (almanac, radar).
* **Updates**
  * Weather alerts now use NWS for US locations; radar integration refreshed.
  * Of‑the‑Day Plugin v1.1.0: improved JSON-based file manager UI for easier content edits.
* **Documentation**
  * Docs and setup guidance updated to reflect new data sources and defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/ledmatrix-plugins/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->