### PR TITLE
fix(ledmatrix-flights): parse adsb.fi 'aircraft' response key

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -331,10 +331,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-19",
+      "last_updated": "2026-05-31",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.5.4"
+      "latest_version": "1.5.5"
     },
     {
       "id": "march-madness",

--- a/plugins/ledmatrix-flights/fetcher.py
+++ b/plugins/ledmatrix-flights/fetcher.py
@@ -494,7 +494,9 @@ class AdsbNetFetcher(AircraftFetcher):
             logger.exception(f"[Flight Tracker] {self.provider} fetch failed")
             return None
 
-        aircraft_list = data.get("ac", [])
+        # adsb.lol returns aircraft under "ac"; adsb.fi's opendata API uses
+        # "aircraft". Accept either so both providers work.
+        aircraft_list = data.get("ac") or data.get("aircraft") or []
         if not aircraft_list:
             logger.info(f"[Flight Tracker] {self.provider}: no aircraft in range ({radius_miles}mi)")
             return {}

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-05-31",
+      "version": "1.5.5",
+      "notes": "Fix adsb.fi data source returning no aircraft: parse the 'aircraft' response key (adsb.fi opendata) in addition to 'ac' (adsb.lol)",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "1.5.4",
@@ -86,5 +92,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-19"
+  "last_updated": "2026-05-31"
 }

--- a/plugins/ledmatrix-flights/test/test_adsbfi_response_key.py
+++ b/plugins/ledmatrix-flights/test/test_adsbfi_response_key.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Regression test for AdsbNetFetcher response-key parsing.
+
+adsb.lol returns aircraft under the "ac" key (ADSBexchange v2 format), but
+adsb.fi's opendata API returns them under "aircraft". The fetcher previously
+read only "ac", so the adsb.fi provider always reported "no aircraft in range".
+
+This test verifies the fetcher accepts BOTH keys.
+"""
+
+import os
+import sys
+from typing import Dict, List
+
+# Make the plugin package importable (fetcher.py imports `from utils import ...`)
+PLUGIN_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+import fetcher  # noqa: E402
+from fetcher import AdsbNetFetcher  # noqa: E402
+
+CENTER_LAT = 47.3223
+CENTER_LON = -122.3126
+ALTITUDE_COLORS: Dict[str, List[int]] = {"0": [255, 100, 0], "40000": [0, 200, 150]}
+
+
+def _fake_aircraft():
+    # Positioned exactly at the center so it is always within radius.
+    return {
+        "hex": "abc123",
+        "flight": "ASA844 ",
+        "t": "A21N",
+        "lat": CENTER_LAT,
+        "lon": CENTER_LON,
+        "alt_baro": 25450,
+        "gs": 410,
+        "track": 180,
+        "r": "N925VA",
+    }
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _run_with_payload(payload) -> int:
+    """Patch requests.get to return `payload`, run a fetch, return aircraft count."""
+    original_get = fetcher.requests.get
+    fetcher.requests.get = lambda *a, **k: _FakeResponse(payload)
+    try:
+        f = AdsbNetFetcher(provider="adsbfi")
+        result = f.fetch(CENTER_LAT, CENTER_LON, 30, ALTITUDE_COLORS)
+        return len(result or {})
+    finally:
+        fetcher.requests.get = original_get
+
+
+def test_adsbfi_aircraft_key():
+    """adsb.fi format: aircraft under 'aircraft' key must be parsed."""
+    count = _run_with_payload({"aircraft": [_fake_aircraft()], "resultCount": 1})
+    assert count == 1, f"expected 1 aircraft from 'aircraft' key, got {count}"
+    print("✓ adsb.fi 'aircraft' key parsed correctly")
+
+
+def test_adsblol_ac_key():
+    """adsb.lol format: aircraft under 'ac' key must still be parsed."""
+    count = _run_with_payload({"ac": [_fake_aircraft()], "total": 1})
+    assert count == 1, f"expected 1 aircraft from 'ac' key, got {count}"
+    print("✓ adsb.lol 'ac' key still parsed correctly")
+
+
+def test_empty_response():
+    """Neither key present → no aircraft (no crash)."""
+    count = _run_with_payload({"now": 0})
+    assert count == 0, f"expected 0 aircraft from empty response, got {count}"
+    print("✓ empty response handled")
+
+
+if __name__ == "__main__":
+    print("AdsbNetFetcher response-key regression test")
+    print("=" * 44)
+    ok = True
+    for t in (test_adsbfi_aircraft_key, test_adsblol_ac_key, test_empty_response):
+        try:
+            t()
+        except AssertionError as e:
+            ok = False
+            print(f"✗ {t.__name__}: {e}")
+    print("=" * 44)
+    print("PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Problem

Selecting `data_source: adsbfi` always shows **"No Aircraft"**, even when there is heavy traffic in range. The adsb.lol source works fine.

## Root cause

adsb.fi's opendata API (`https://opendata.adsb.fi/api/v2/lat/{lat}/lon/{lon}/dist/{nm}`) returns the aircraft list under the **`aircraft`** key, whereas adsb.lol uses **`ac`** (ADSBexchange v2). `AdsbNetFetcher.fetch()` in `fetcher.py` read only `data.get("ac", [])`, so for adsb.fi the list was always empty and the fetcher returned `{}` with `"no aircraft in range"`.

Verified directly against the live API:

```
GET https://opendata.adsb.fi/api/v2/lat/51.47/lon/-0.4543/dist/100
→ {"now":..., "aircraft":[...24 aircraft...], "resultCount":24, "ptime":...}
```

(adsb.lol returns `{"ac":[...], "total":...}` for the same query.)

## Fix

Accept either key:

```python
aircraft_list = data.get("ac") or data.get("aircraft") or []
```

## Testing

- **Unit:** added `test/test_adsbfi_response_key.py` — mocks `requests.get` and asserts the fetcher parses aircraft from **both** the `aircraft` (adsb.fi) and `ac` (adsb.lol) shapes, and handles an empty response. Passes.
- **Live, end-to-end (emulator):** with the fix and `data_source: adsbfi` centered near KSEA, the fetcher logged **`adsbfi: 66–71 aircraft in range`** across update cycles (it logged `no aircraft in range` on every cycle before the fix), and the flight view rendered real traffic (e.g. `VIR20V`, 505 kn, FL380, 70 mi). adsb.lol was also re-confirmed working.

Bumps `version` to `1.5.5` and runs `update_registry.py`.