### PR TITLE
fix(baseball-scoreboard): make test_mode show a simulated live game

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -46,10 +46,10 @@
       "plugin_path": "plugins/baseball-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-15",
+      "last_updated": "2026-05-31",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.1"
+      "latest_version": "1.6.2"
     },
     {
       "id": "basketball-scoreboard",

--- a/plugins/baseball-scoreboard/manager.py
+++ b/plugins/baseball-scoreboard/manager.py
@@ -597,6 +597,7 @@ class BaseballScoreboardPlugin(BasePlugin if BasePlugin else object):
                     15  # Default per-game duration for upcoming games
                 ),
                 "live_priority": league_config.get("live_priority", False),
+                "test_mode": league_config.get("test_mode", False),
                 "show_favorite_teams_only": show_favorites_only,
                 "show_all_live": show_all_live,
                 "filtering": filtering,

--- a/plugins/baseball-scoreboard/manifest.json
+++ b/plugins/baseball-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "baseball-scoreboard",
   "name": "Baseball Scoreboard",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming baseball games across MLB, MiLB, and NCAA Baseball with real-time scores and schedules",
   "category": "sports",
@@ -30,6 +30,12 @@
   "branch": "main",
   "plugin_path": "plugins/baseball-scoreboard",
   "versions": [
+    {
+      "released": "2026-05-31",
+      "version": "1.6.2",
+      "notes": "Fix test_mode: pass the flag through to the live manager and short-circuit update() so the simulated live game is not overwritten by an empty live fetch",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-15",
       "version": "1.6.1",
@@ -121,7 +127,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-15",
+  "last_updated": "2026-05-31",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/baseball-scoreboard/sports.py
+++ b/plugins/baseball-scoreboard/sports.py
@@ -2188,6 +2188,12 @@ class SportsLive(SportsCore):
         if current_time - self.last_update >= interval:
             self.last_update = current_time
 
+            # Test mode: advance the simulated game instead of fetching real API
+            # data (which would overwrite the seeded live game with an empty list).
+            if _test_mode_attr:
+                self._test_mode_update()
+                return
+
             # Fetch rankings if enabled
             if self.show_ranking:
                 self._fetch_team_rankings()

--- a/plugins/baseball-scoreboard/test_test_mode_live_games.py
+++ b/plugins/baseball-scoreboard/test_test_mode_live_games.py
@@ -61,6 +61,9 @@ def test_test_mode_short_circuits_fetch():
     live = _make_live(test_mode=True)
     called = {"fetch": False, "test_update": False}
 
+    class _StopAfterTestUpdate(Exception):
+        pass
+
     def fake_fetch():
         called["fetch"] = True
         live.live_games = []  # reproduce the original overwrite
@@ -68,16 +71,17 @@ def test_test_mode_short_circuits_fetch():
 
     def fake_test_update():
         called["test_update"] = True
+        # Stop update() right after the short-circuit branch is taken, so we
+        # don't run downstream code that touches attributes a bare instance
+        # lacks. Catching only this sentinel lets any *unexpected* error surface.
+        raise _StopAfterTestUpdate()
 
     live._fetch_data = fake_fetch
     live._test_mode_update = fake_test_update
 
-    # Guard update(): without the fix it enters the live-fetch path and may raise
-    # on attributes a bare instance doesn't have. We assert on the invariants below
-    # so the failure is clear regardless of how far the buggy path gets.
     try:
         live.update()
-    except Exception:  # noqa: BLE001 - downstream attrs irrelevant to this test
+    except _StopAfterTestUpdate:
         pass
 
     assert called["test_update"], "expected _test_mode_update() to run in test mode"

--- a/plugins/baseball-scoreboard/test_test_mode_live_games.py
+++ b/plugins/baseball-scoreboard/test_test_mode_live_games.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Regression test for SportsLive.update() test-mode handling.
+
+In test mode the live manager seeds a simulated live game (self.live_games).
+The bug: update() ignored test_mode and always called _fetch_data(), which
+rebuilds live_games from the real (empty) API response — wiping the seeded
+game on the first tick, so has_live_content() returned False and the live
+view / live-priority never engaged.
+
+The fix short-circuits to _test_mode_update() (and returns) when test_mode is
+set, so the seeded game survives. This test verifies that control flow without
+needing a display/cache manager.
+"""
+
+import os
+import sys
+import logging
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+from sports import SportsLive  # noqa: E402
+
+
+class _ConcreteLive(SportsLive):
+    """Minimal concrete SportsLive so we can instantiate without the full
+    manager stack. The methods update() calls are replaced per-test."""
+
+    def _extract_game_details(self, game):  # abstract in SportsCore
+        return None
+
+    def _fetch_data(self):  # abstract in SportsCore
+        return None
+
+    def _test_mode_update(self):  # abstract in SportsLive
+        return None
+
+
+def _make_live(test_mode: bool):
+    """Build a bare SportsLive with only the attributes update() touches."""
+    live = object.__new__(_ConcreteLive)
+    live.is_enabled = True
+    live.test_mode = test_mode
+    live.live_games = [
+        {"id": "t1", "home_abbr": "SEA", "away_abbr": "HOU",
+         "is_live": True, "is_final": False}
+    ]
+    live.no_data_interval = 300
+    live.update_interval = 30
+    live.last_update = 0  # 0 → force an update on this call
+    live.show_ranking = False
+    live.sport_key = "mlb"
+    live.logger = logging.getLogger("test_test_mode")
+    return live
+
+
+def test_test_mode_short_circuits_fetch():
+    """test_mode=True must call _test_mode_update(), NOT _fetch_data(), and keep the game."""
+    live = _make_live(test_mode=True)
+    called = {"fetch": False, "test_update": False}
+
+    def fake_fetch():
+        called["fetch"] = True
+        live.live_games = []  # reproduce the original overwrite
+        return {"events": []}
+
+    def fake_test_update():
+        called["test_update"] = True
+
+    live._fetch_data = fake_fetch
+    live._test_mode_update = fake_test_update
+
+    # Guard update(): without the fix it enters the live-fetch path and may raise
+    # on attributes a bare instance doesn't have. We assert on the invariants below
+    # so the failure is clear regardless of how far the buggy path gets.
+    try:
+        live.update()
+    except Exception:  # noqa: BLE001 - downstream attrs irrelevant to this test
+        pass
+
+    assert called["test_update"], "expected _test_mode_update() to run in test mode"
+    assert not called["fetch"], "_fetch_data() must NOT run in test mode (it wipes the seeded game)"
+    assert len(live.live_games) == 1, f"seeded live game must survive, got {len(live.live_games)}"
+    print("✓ test_mode short-circuits to _test_mode_update and preserves live_games")
+
+
+def test_live_mode_still_fetches():
+    """test_mode=False must reach _fetch_data() (real data path is unchanged)."""
+    live = _make_live(test_mode=False)
+    live.live_games = []
+    called = {"fetch": False}
+
+    class _StopAfterFetch(Exception):
+        pass
+
+    def fake_fetch():
+        called["fetch"] = True
+        raise _StopAfterFetch()  # we only care that the fetch path is reached
+
+    live._fetch_data = fake_fetch
+    try:
+        live.update()
+    except _StopAfterFetch:
+        pass
+
+    assert called["fetch"], "live mode (test_mode=False) must call _fetch_data()"
+    print("✓ live mode still calls _fetch_data()")
+
+
+if __name__ == "__main__":
+    print("SportsLive test_mode regression test")
+    print("=" * 44)
+    ok = True
+    for t in (test_test_mode_short_circuits_fetch, test_live_mode_still_fetches):
+        try:
+            t()
+        except AssertionError as e:
+            ok = False
+            print(f"✗ {t.__name__}: {e}")
+    print("=" * 44)
+    print("PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Problem

Setting `mlb.test_mode: true` (the documented way to preview the live scorebug without a real game in progress) does nothing — the plugin never shows the simulated live game, and live-priority never engages.

## Root cause

Two issues compound:

1. **The flag is dropped.** `BaseballScoreboardPlugin` builds each league's manager config (`manager.py`, the `manager_config` dict) from a fixed key allowlist that doesn't include `test_mode`, so `MLBLiveManager` always saw `test_mode = False` (it logs `Initialized MLBLiveManager in live mode`).

2. **The seeded game is overwritten.** Even with the flag set, `SportsLive.update()` (`sports.py`) used `test_mode` only to pick the poll interval, then **unconditionally** called `_fetch_data()` and rebuilt `live_games` from the real (empty) API response — wiping the seeded game on the first tick. `has_live_content()` then returns `False`. (The base `_test_mode_update()` hook exists but was never reached — the core `base_classes/sports.py` has the `if self.test_mode: ... else: fetch` branch; this bundled copy lost it.)

## Fix

- `manager.py`: pass `test_mode` through to the manager config.
- `sports.py`: short-circuit `update()` to `_test_mode_update()` (and return) when `test_mode` is set, so the seeded game is preserved.

```python
if current_time - self.last_update >= interval:
    self.last_update = current_time
    if _test_mode_attr:
        self._test_mode_update()
        return
    ...
```

## Testing

- Added `test_test_mode_live_games.py` — verifies `update()` short-circuits to `_test_mode_update()` (and does **not** call `_fetch_data()`, which would wipe `live_games`) when `test_mode` is set, and that normal (`test_mode=False`) operation still reaches `_fetch_data()`. **Passes with the fix; fails without it.**
- Verified end-to-end in the emulator: with `mlb.test_mode: true` + `mlb.live_priority: true`, the seeded MLB game renders, live-priority preempts the rotation, and the scorebug (bases/balls/strikes/outs/inning) animates via `_test_mode_update()`.

Bumps `version` to `1.6.2` and runs `update_registry.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test mode to properly handle simulated live games without interference from live updates.

* **Tests**
  * Added test coverage for test mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->