### PR TITLE
fix(news): remove 100-char headline truncation in news ticker

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -449,10 +449,10 @@
       "plugin_path": "plugins/news",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-06",
+      "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.6"
+      "latest_version": "1.0.7"
     },
     {
       "id": "nfl-draft",

--- a/plugins/news/manager.py
+++ b/plugins/news/manager.py
@@ -724,10 +724,6 @@ class NewsTickerPlugin(BasePlugin):
         headline = re.sub(r'^\s*-\s*', '', headline)  # Remove leading dashes
         headline = re.sub(r'\s+', ' ', headline)  # Normalize whitespace
 
-        # Limit length for display
-        if len(headline) > 100:
-            headline = headline[:97] + "..."
-
         return headline
 
     def display(self, display_mode: str = None, force_clear: bool = False) -> None:

--- a/plugins/news/manifest.json
+++ b/plugins/news/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "news",
   "name": "News Ticker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Displays scrolling news headlines from RSS feeds including sports news from ESPN, NCAA updates, and custom RSS sources",
   "author": "ChuckBuilds",
   "category": "content",
@@ -20,6 +20,11 @@
   "branch": "main",
   "plugin_path": "plugins/news",
   "versions": [
+    {
+      "version": "1.0.7",
+      "released": "2026-06-01",
+      "ledmatrix_min_version": "2.0.0"
+    },
     {
       "version": "1.0.6",
       "released": "2026-05-06",
@@ -43,7 +48,7 @@
   ],
   "stars": 0,
   "downloads": 0,
-  "last_updated": "2026-05-06",
+  "last_updated": "2026-06-01",
   "verified": true,
   "screenshot": "",
   "display_modes": [


### PR DESCRIPTION
## Summary

- `_clean_headline()` in `manager.py` was silently truncating every headline to 97 characters + `"..."` before rendering
- Because the News Ticker displays on a horizontally-scrolling LED matrix there is no fixed width — a headline can be as long as needed and will scroll fully across the display
- Removing the cap lets viewers read complete headlines instead of cut-off fragments

## Changes

- `plugins/news/manager.py`: removed the `if len(headline) > 100` block from `_clean_headline()`
- `plugins/news/manifest.json`: bumped version `1.0.6 → 1.0.7`
- `plugins.json`: auto-updated by pre-commit hook

## Test plan

- [ ] Feed with headlines longer than 100 characters scrolls the full text
- [ ] Short headlines (under 100 chars) are unaffected
- [ ] Whitespace normalisation and leading-dash removal still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced headline sanitization to remove formatting artifacts and normalize whitespace
  * Removed headline length limits so headlines can display at full cleaned length

* **Chores**
  * News plugin bumped to version 1.0.7 (metadata and release date updated)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->