### PR TITLE
feat(flights): configurable rotation views + overhead live-priority preempt

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -331,10 +331,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-31",
+      "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.5.5"
+      "latest_version": "1.6.0"
     },
     {
       "id": "march-madness",

--- a/plugins.json
+++ b/plugins.json
@@ -334,7 +334,7 @@
       "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.0"
+      "latest_version": "1.7.0"
     },
     {
       "id": "march-madness",

--- a/plugins/baseball-scoreboard/test_test_mode_live_games.py
+++ b/plugins/baseball-scoreboard/test_test_mode_live_games.py
@@ -13,6 +13,7 @@ set, so the seeded game survives. This test verifies that control flow without
 needing a display/cache manager.
 """
 
+import contextlib
 import os
 import sys
 import logging
@@ -79,10 +80,12 @@ def test_test_mode_short_circuits_fetch():
     live._fetch_data = fake_fetch
     live._test_mode_update = fake_test_update
 
-    try:
+    # Guard update(): without the fix it enters the live-fetch path and trips over
+    # attributes a bare instance doesn't have. Suppress only that expected
+    # AttributeError so an unrelated failure still surfaces; the invariants below
+    # assert the real behavior regardless of how far the buggy path gets.
+    with contextlib.suppress(AttributeError):
         live.update()
-    except _StopAfterTestUpdate:
-        pass
 
     assert called["test_update"], "expected _test_mode_update() to run in test mode"
     assert not called["fetch"], "_fetch_data() must NOT run in test mode (it wipes the seeded game)"

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -51,7 +51,8 @@
     "live_priority": {
       "type": "boolean",
       "default": false,
-      "description": "Enable live priority takeover when plugin has live content"
+      "title": "Overhead Live Priority",
+      "description": "When enabled, an aircraft entering the proximity radius immediately preempts the normal rotation to show the overhead view for the proximity alert window (see proximity_alert.duration_seconds). Adds a 'flight_tracker_live' rotation slot that stays blank/skipped until a plane is overhead. Leave off for legacy behavior."
     },
     "skyaware_url": {
       "type": "string",
@@ -240,7 +241,7 @@
     "display_mode": {
       "type": "string",
       "title": "Display Mode",
-      "description": "Display mode. 'area' shows multi-aircraft list with FlightWall metrics. 'flight_tracking' shows tracked flight details. 'auto' chooses based on context.",
+      "description": "Single-view display mode, used only when 'rotation_views' is not set. 'area' shows multi-aircraft list with FlightWall metrics. 'flight_tracking' shows tracked flight details. 'auto' chooses based on context.",
       "enum": [
         "map",
         "overhead",
@@ -250,6 +251,21 @@
         "auto"
       ],
       "default": "auto"
+    },
+    "rotation_views": {
+      "type": "array",
+      "title": "Rotation Views",
+      "description": "Which views the display rotation cycles through. Each selected view gets its own rotation slot and an empty/no-content slot is skipped. Leave empty ([]) to show nothing in the normal rotation — useful for an overhead-only board (pair with live_priority). When this field is omitted entirely, the single 'Display Mode' setting is used instead (legacy behavior). The overhead view is not listed here; it is driven by live_priority + proximity_alert.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "map",
+          "stats",
+          "area",
+          "flight_tracking"
+        ]
+      },
+      "uniqueItems": true
     },
     "units": {
       "type": "string",

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -270,7 +270,8 @@
     "rotation_views": {
       "type": "array",
       "title": "Rotation Views",
-      "description": "Which views the display rotation cycles through. Each selected view gets its own rotation slot and an empty/no-content slot is skipped. Leave empty ([]) to show nothing in the normal rotation — useful for an overhead-only board (pair with live_priority). When this field is omitted entirely, the single 'Display Mode' setting is used instead (legacy behavior). The overhead view is not listed here; it is driven by live_priority + proximity_alert.",
+      "description": "Which views the display rotation cycles through. Each selected view gets its own rotation slot and an empty/no-content slot is skipped. Leave all unchecked to show nothing in the normal rotation — useful for an overhead-only board (pair with Overhead Live Priority). When this field is omitted entirely, the single 'Display Mode' setting is used instead (legacy behavior). The overhead view is not listed here; it is driven by live_priority + proximity_alert.",
+      "x-widget": "checkbox-group",
       "items": {
         "type": "string",
         "enum": [
@@ -279,6 +280,14 @@
           "area",
           "flight_tracking"
         ]
+      },
+      "x-options": {
+        "labels": {
+          "map": "Map",
+          "stats": "Stats",
+          "area": "Area (multi-aircraft)",
+          "flight_tracking": "Flight Tracking"
+        }
       },
       "uniqueItems": true
     },
@@ -742,8 +751,10 @@
     "enrichment_provider",
     "route_cache_ttl",
     "display_mode",
+    "rotation_views",
     "display_duration",
     "update_interval",
+    "live_update_interval",
     "live_priority",
     "zoom_factor",
     "max_aircraft",

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -48,6 +48,14 @@
       "maximum": 300,
       "default": 5
     },
+    "live_update_interval": {
+      "type": "integer",
+      "title": "Live Fetch Interval",
+      "description": "Faster fetch interval (seconds) used while a flight is locked on for the overhead view, so altitude/distance update smoothly. The ADS-B source is ~1Hz, so a low value is safe. Idle fetches use update_interval.",
+      "minimum": 1,
+      "maximum": 60,
+      "default": 2
+    },
     "live_priority": {
       "type": "boolean",
       "default": false,
@@ -211,9 +219,16 @@
         },
         "duration_seconds": {
           "type": "integer",
-          "description": "Duration to show proximity alert in seconds",
+          "description": "Hard cap (seconds) on how long a single overhead flight holds the screen, measured from when it is locked on. The flight shows for this long even if it leaves the radius sooner, and is released after this even if it lingers.",
           "minimum": 5,
           "maximum": 300,
+          "default": 30
+        },
+        "cooldown_seconds": {
+          "type": "integer",
+          "description": "After a flight's window ends, suppress the overhead preempt for this many seconds so the normal rotation (weather/clock/sports) gets guaranteed screen time, even if planes remain overhead. Set to 0 to disable the cooldown.",
+          "minimum": 0,
+          "maximum": 600,
           "default": 30
         }
       },

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -41,7 +41,23 @@ logger = logging.getLogger(__name__)
 
 class FlightTrackerPlugin(BasePlugin):
     """Flight tracker plugin for LEDMatrix."""
-    
+
+    # Scroll-through views that can be enabled individually via `rotation_views`.
+    # 'overhead' is intentionally excluded — it is the live preempt view, driven
+    # by proximity alerts rather than the normal rotation.
+    _VALID_ROTATION_VIEWS = ('map', 'stats', 'area', 'flight_tracking')
+
+    # Maps the framework's per-slot mode name to the internal view rendered by
+    # display(). The bare 'flight_tracker' slot is legacy and resolves via the
+    # configured `display_mode` instead.
+    _GRANULAR_MODES = {
+        'flight_tracker_map': 'map',
+        'flight_tracker_stats': 'stats',
+        'flight_tracker_area': 'area',
+        'flight_tracker_flight_tracking': 'flight_tracking',
+        'flight_tracker_live': 'overhead',
+    }
+
     def __init__(self, plugin_id: str, config: Dict[str, Any], display_manager, cache_manager, plugin_manager):
         super().__init__(plugin_id, config, display_manager, cache_manager, plugin_manager)
         self.plugin_manager = plugin_manager
@@ -170,6 +186,10 @@ class FlightTrackerPlugin(BasePlugin):
         self.proximity_enabled = self.proximity_config.get('enabled', True)
         self.proximity_distance_miles = self.proximity_config.get('distance_miles', 0.1)
         self.proximity_duration = self.proximity_config.get('duration_seconds', 30)
+        # Opt-in: when True, an aircraft entering the proximity radius preempts
+        # the normal rotation to show the overhead view (the 'flight_tracker_live'
+        # slot). Defaults False so existing installs are unaffected.
+        self.live_priority_enabled = self.config.get('live_priority', False)
         
         # Runtime data
         self.aircraft_data = {}  # ICAO -> aircraft dict (within map_radius_miles)
@@ -244,6 +264,13 @@ class FlightTrackerPlugin(BasePlugin):
 
         # Proximity alert variables (for overhead mode)
         self.proximity_triggered_time = None
+        # Snapshot of the aircraft that last triggered the proximity latch, so the
+        # overhead view keeps showing the same plane for the full alert window even
+        # if it briefly drops out of range.
+        self._proximity_aircraft = None
+        # Set transiently while rendering the live overhead slot so _display_overhead
+        # shows the latched aircraft rather than the current closest.
+        self._active_overhead_aircraft = None
 
         # Fonts
         self.fonts = self._load_fonts()
@@ -284,7 +311,12 @@ class FlightTrackerPlugin(BasePlugin):
             self.logger.info(f"[Flight Tracker] Display: {self.display_width}x{self.display_height}, Data source: FlightRadar24")
         else:
             self.logger.info(f"[Flight Tracker] Display: {self.display_width}x{self.display_height}, Data source: SkyAware ({self.skyaware_url}), FR24 enrichment: {self.fr24_enrichment}")
-    
+
+        # Rotation slots exposed to the framework. The core prefers this over the
+        # manifest's display_modes, giving us per-view rotation + the live slot.
+        self.modes = self._get_available_modes()
+        self.logger.info(f"[Flight Tracker] Rotation modes: {self.modes}")
+
     @property
     def display_width(self) -> int:
         return self._display_manager_ref.matrix.width
@@ -2314,14 +2346,19 @@ class FlightTrackerPlugin(BasePlugin):
             self.logger.warning(f"[Flight Tracker] get_vegas_content() failed: {e}")
             return None
 
-    def display(self, force_clear: bool = False, *, display_mode: Optional[str] = None) -> None:
-        """Display flight tracker content based on display_mode configuration.
+    def display(self, force_clear: bool = False, *, display_mode: Optional[str] = None) -> bool:
+        """Display flight tracker content based on the active slot.
 
         Supports modes: map, overhead, stats, area, flight_tracking, auto.
 
-        The ``display_mode`` parameter is passed by the LEDMatrix framework to
-        indicate which manifest display mode is active.  It maps framework mode
-        names (from manifest ``display_modes``) to our internal mode names.
+        The ``display_mode`` parameter is the framework's active slot name. It is
+        resolved to an internal view via ``_GRANULAR_MODES`` (per-view rotation +
+        the live overhead slot); the bare legacy ``flight_tracker`` slot falls back
+        to the configured ``display_mode``.
+
+        Returns ``True`` when content was rendered and ``False`` when there is
+        nothing to show for the active slot, so the framework skips to the next
+        mode instead of dwelling on a blank screen.
         """
         now = time.time()
         was_hidden = (now - self._last_displayed_time) > self._display_idle_threshold
@@ -2332,49 +2369,70 @@ class FlightTrackerPlugin(BasePlugin):
         aircraft_count = len(self.aircraft_data)
         closest = self.get_closest_aircraft()
 
-        # The framework passes display_mode='flight_tracker' (the single
-        # manifest mode name).  We always use our internal config setting
-        # to decide which view to render (map, overhead, stats, area,
-        # flight_tracking, or auto).
-        mode = self.display_mode
+        # Resolve which internal view to render from the framework's slot name.
+        # Granular slots (flight_tracker_map/_stats/_area/_flight_tracking/_live)
+        # map directly to a view; the bare legacy 'flight_tracker' slot falls back
+        # to the configured display_mode (auto/map/stats/...).
+        granular_view = self._GRANULAR_MODES.get(display_mode)
 
         self.logger.debug(
-            "[Flight Tracker] display() called: configured_mode=%s, framework_mode=%s, resolved=%s, aircraft=%s",
-            self.display_mode, display_mode, mode, aircraft_count,
+            "[Flight Tracker] display() called: configured_mode=%s, framework_mode=%s, granular=%s, aircraft=%s",
+            self.display_mode, display_mode, granular_view, aircraft_count,
         )
-        if mode == 'auto':
-            # Priority interrupts — always show these immediately
-            has_airborne_tracked = any(
-                tf.status == "AIRBORNE" for tf in self.tracked_flight_data.values()
-            )
-            if has_airborne_tracked:
-                mode = 'flight_tracking'
-            elif self.proximity_enabled and closest and closest['distance_miles'] <= self.proximity_distance_miles:
-                mode = 'overhead'
-            else:
-                # Rotate through available modes
-                auto_modes = []
-                if self.aircraft_data:
-                    auto_modes.append('map')
-                    auto_modes.append('area')
-                if self.all_aircraft_data or self.aircraft_data:
-                    auto_modes.append('stats')
-                if not auto_modes:
-                    auto_modes = ['stats']
 
-                now = time.time()
-                if now - self._auto_mode_last_change >= self._auto_rotate_interval:
-                    self._auto_mode_index = (self._auto_mode_index + 1) % len(auto_modes)
-                    self._auto_mode_last_change = now
-
-                mode = auto_modes[self._auto_mode_index % len(auto_modes)]
-
-            self.logger.debug(
-                "[Flight Tracker] Auto mode selection: chosen_mode=%s (aircraft=%s)",
-                mode, aircraft_count,
-            )
+        if granular_view is not None:
+            mode = granular_view
+            if mode == 'overhead':
+                # Live slot: only render while the proximity latch is active, so
+                # the overhead view shows for the full alert window then releases.
+                self._update_proximity_latch()
+                if not self._proximity_active():
+                    return False
+                self._active_overhead_aircraft = self._proximity_aircraft
+            elif not self._view_has_content(mode):
+                # Enabled-but-empty rotation slot — skip so the rotation advances
+                # instead of dwelling on a blank screen.
+                return False
+        elif display_mode and display_mode != 'flight_tracker':
+            # Unknown slot (e.g. the plugin-id fallback when no rotation views are
+            # selected) — nothing to show.
+            return False
         else:
-            self.logger.debug("[Flight Tracker] Manual mode selection: chosen_mode=%s", mode)
+            # Legacy single-slot behavior: choose the view from display_mode.
+            mode = self.display_mode
+            if mode == 'auto':
+                # Priority interrupts — always show these immediately
+                has_airborne_tracked = any(
+                    tf.status == "AIRBORNE" for tf in self.tracked_flight_data.values()
+                )
+                if has_airborne_tracked:
+                    mode = 'flight_tracking'
+                elif self.proximity_enabled and closest and closest['distance_miles'] <= self.proximity_distance_miles:
+                    mode = 'overhead'
+                else:
+                    # Rotate through available modes
+                    auto_modes = []
+                    if self.aircraft_data:
+                        auto_modes.append('map')
+                        auto_modes.append('area')
+                    if self.all_aircraft_data or self.aircraft_data:
+                        auto_modes.append('stats')
+                    if not auto_modes:
+                        auto_modes = ['stats']
+
+                    now = time.time()
+                    if now - self._auto_mode_last_change >= self._auto_rotate_interval:
+                        self._auto_mode_index = (self._auto_mode_index + 1) % len(auto_modes)
+                        self._auto_mode_last_change = now
+
+                    mode = auto_modes[self._auto_mode_index % len(auto_modes)]
+
+                self.logger.debug(
+                    "[Flight Tracker] Auto mode selection: chosen_mode=%s (aircraft=%s)",
+                    mode, aircraft_count,
+                )
+            else:
+                self.logger.debug("[Flight Tracker] Manual mode selection: chosen_mode=%s", mode)
 
         self.logger.info("[Flight Tracker] display(): mode=%s, aircraft=%d", mode, aircraft_count)
 
@@ -2399,7 +2457,13 @@ class FlightTrackerPlugin(BasePlugin):
                 self._renderer.render_error(f"ERR:{mode}")
             except Exception:
                 self.logger.exception("[Flight Tracker] Failed to render error fallback")
-    
+        finally:
+            # Clear the transient overhead override regardless of how rendering went.
+            self._active_overhead_aircraft = None
+
+        return True
+
+
     # -------------------------------------------------------------------------
     # New display modes (delegated to renderer.py)
     # -------------------------------------------------------------------------
@@ -2588,8 +2652,10 @@ class FlightTrackerPlugin(BasePlugin):
         """Display detailed overhead view of closest aircraft."""
         if force_clear:
             self.display_manager.clear()
-        
-        closest = self.get_closest_aircraft()
+
+        # During a live proximity alert, keep showing the latched aircraft (the one
+        # that triggered the alert) even if it has just dropped out of range.
+        closest = self._active_overhead_aircraft or self.get_closest_aircraft()
         if not closest:
             # No aircraft to display
             img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
@@ -2852,17 +2918,82 @@ class FlightTrackerPlugin(BasePlugin):
             record_time=rec_ts if record_data else "",
         )
 
+    def _get_available_modes(self) -> list:
+        """Build the rotation slot list the framework cycles through.
+
+        Backward compatible: when ``rotation_views`` is not configured the plugin
+        exposes the single legacy ``flight_tracker`` slot and renders according to
+        the ``display_mode`` setting (auto/map/stats/...) exactly as before.
+
+        When ``rotation_views`` is configured, each selected view becomes its own
+        rotation slot (``flight_tracker_<view>``). An empty list means the plugin
+        contributes no scroll-through slots. The overhead live slot
+        (``flight_tracker_live``) is appended when proximity preemption is enabled.
+        """
+        rotation_views = self.config.get('rotation_views', None)
+        modes = []
+        if rotation_views is None:
+            modes.append('flight_tracker')
+        else:
+            for view in rotation_views:
+                if view in self._VALID_ROTATION_VIEWS:
+                    modes.append(f'flight_tracker_{view}')
+        if self.proximity_enabled and self.live_priority_enabled:
+            modes.append('flight_tracker_live')
+        return modes
+
+    def _update_proximity_latch(self) -> None:
+        """Latch the proximity alert when an aircraft enters the alert radius.
+
+        Keeps the overhead view "live" for ``proximity_duration`` seconds after the
+        closest aircraft was last within ``proximity_distance_miles``, so a plane
+        passing overhead stays on screen for the full alert window even after it
+        moves out of the radius.
+        """
+        if not self.proximity_enabled:
+            return
+        closest = self.get_closest_aircraft()
+        if closest and closest['distance_miles'] <= self.proximity_distance_miles:
+            self.proximity_triggered_time = time.time()
+            self._proximity_aircraft = closest
+
+    def _proximity_active(self) -> bool:
+        """True while the proximity latch is within its alert window."""
+        if not self.proximity_enabled or self.proximity_triggered_time is None:
+            return False
+        return (time.time() - self.proximity_triggered_time) < self.proximity_duration
+
+    def _view_has_content(self, view: str) -> bool:
+        """Whether a scroll-through view has anything to render right now.
+
+        Used to skip an enabled-but-empty rotation slot so the rotation moves on
+        instead of dwelling on a blank/"No Aircraft" screen.
+        """
+        if view == 'stats':
+            return True
+        if view == 'flight_tracking':
+            return bool(self.tracked_flight_data)
+        # map, area
+        return bool(self.aircraft_data)
+
+    def has_live_priority(self) -> bool:
+        """Whether this plugin should preempt the rotation for overhead aircraft."""
+        return bool(self.live_priority_enabled and self.proximity_enabled)
+
     def has_live_content(self) -> bool:
-        """Check if plugin has live/urgent content (proximity alerts)."""
+        """Live content = an aircraft is (or was recently) within the proximity radius."""
         if not self.proximity_enabled:
             return False
-        
-        closest = self.get_closest_aircraft()
-        if not closest:
-            return False
-        
-        return closest['distance_miles'] <= self.proximity_distance_miles
-    
+        self._update_proximity_latch()
+        return self._proximity_active()
+
+    def get_live_modes(self) -> list:
+        """Return the live slot name when there is overhead content to preempt with."""
+        if self.has_live_priority() and self.has_live_content():
+            return ['flight_tracker_live']
+        return []
+
+
     def validate_config(self) -> bool:
         """Validate plugin configuration."""
         if not super().validate_config():

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -185,11 +185,20 @@ class FlightTrackerPlugin(BasePlugin):
         self.proximity_config = self.config.get('proximity_alert', {})
         self.proximity_enabled = self.proximity_config.get('enabled', True)
         self.proximity_distance_miles = self.proximity_config.get('distance_miles', 0.1)
+        # Hard cap on how long a single overhead flight holds the screen, measured
+        # from when it was locked on (not refreshed while it dwells in the radius).
         self.proximity_duration = self.proximity_config.get('duration_seconds', 30)
+        # After a flight's window ends, suppress the preempt for this long so the
+        # normal rotation (weather/clock/sports) is guaranteed screen time.
+        self.proximity_cooldown = self.proximity_config.get('cooldown_seconds', 30)
         # Opt-in: when True, an aircraft entering the proximity radius preempts
         # the normal rotation to show the overhead view (the 'flight_tracker_live'
         # slot). Defaults False so existing installs are unaffected.
         self.live_priority_enabled = self.config.get('live_priority', False)
+        # Faster fetch cadence while a flight is locked on, so altitude/distance
+        # update smoothly during the overhead window. The ADS-B source is ~1Hz, so
+        # this is safe; idle fetches stay at update_interval.
+        self.live_update_interval = self.config.get('live_update_interval', 2)
         
         # Runtime data
         self.aircraft_data = {}  # ICAO -> aircraft dict (within map_radius_miles)
@@ -262,14 +271,16 @@ class FlightTrackerPlugin(BasePlugin):
         self.last_stat_change = 0
         self.stat_duration = 10  # Show each stat for 10 seconds
 
-        # Proximity alert variables (for overhead mode)
-        self.proximity_triggered_time = None
-        # Snapshot of the aircraft that last triggered the proximity latch, so the
-        # overhead view keeps showing the same plane for the full alert window even
-        # if it briefly drops out of range.
-        self._proximity_aircraft = None
+        # Proximity alert / overhead live-priority state machine (IDLE -> LOCKED ->
+        # COOLDOWN). When a plane enters the radius we lock onto that specific ICAO
+        # and show it for proximity_duration, then enter a cooldown before any other
+        # flight can preempt again.
+        self._lock_icao = None          # ICAO of the flight currently locked on
+        self._lock_start = 0.0          # time the lock was acquired
+        self._lock_aircraft = None      # last-known data for the locked flight
+        self._cooldown_until = 0.0      # preempt suppressed until this time
         # Set transiently while rendering the live overhead slot so _display_overhead
-        # shows the latched aircraft rather than the current closest.
+        # shows the locked aircraft rather than the current closest.
         self._active_overhead_aircraft = None
 
         # Fonts
@@ -2019,7 +2030,11 @@ class FlightTrackerPlugin(BasePlugin):
         current_time = time.time()
         is_visible = (current_time - self._last_displayed_time) < self._display_idle_threshold
 
-        if current_time - self.last_fetch >= self.update_interval:
+        # Fetch faster while a flight is locked on so the overhead view's
+        # altitude/distance stay current; fall back to update_interval when idle.
+        fetch_interval = self.live_update_interval if self._lock_icao is not None else self.update_interval
+
+        if current_time - self.last_fetch >= fetch_interval:
             self.last_fetch = current_time
 
             if self.data_source == 'flightradar24':
@@ -2383,12 +2398,11 @@ class FlightTrackerPlugin(BasePlugin):
         if granular_view is not None:
             mode = granular_view
             if mode == 'overhead':
-                # Live slot: only render while the proximity latch is active, so
-                # the overhead view shows for the full alert window then releases.
-                self._update_proximity_latch()
-                if not self._proximity_active():
+                # Live slot: only render while a flight is locked on. Show that
+                # specific flight (not whatever is currently closest) for its window.
+                if not self._evaluate_proximity():
                     return False
-                self._active_overhead_aircraft = self._proximity_aircraft
+                self._active_overhead_aircraft = self._lock_aircraft
             elif not self._view_has_content(mode):
                 # Enabled-but-empty rotation slot — skip so the rotation advances
                 # instead of dwelling on a blank screen.
@@ -2942,26 +2956,58 @@ class FlightTrackerPlugin(BasePlugin):
             modes.append('flight_tracker_live')
         return modes
 
-    def _update_proximity_latch(self) -> None:
-        """Latch the proximity alert when an aircraft enters the alert radius.
+    def _closest_in_radius(self):
+        """Return (icao, aircraft) for the closest aircraft within the alert radius,
+        or (None, None) if nothing is within ``proximity_distance_miles``."""
+        if not self.aircraft_data:
+            return None, None
+        icao, ac = min(self.aircraft_data.items(), key=lambda kv: kv[1]['distance_miles'])
+        if ac['distance_miles'] <= self.proximity_distance_miles:
+            return icao, ac
+        return None, None
 
-        Keeps the overhead view "live" for ``proximity_duration`` seconds after the
-        closest aircraft was last within ``proximity_distance_miles``, so a plane
-        passing overhead stays on screen for the full alert window even after it
-        moves out of the radius.
+    def _evaluate_proximity(self) -> bool:
+        """Advance the overhead state machine and report whether a flight is live.
+
+        IDLE -> LOCKED: when a plane enters the radius, lock onto that ICAO and show
+            it for ``proximity_duration`` (the hard cap), refreshing its data each
+            cycle so altitude/distance stay current — but never switching to a
+            different (closer) plane mid-window.
+        LOCKED -> COOLDOWN: once the cap elapses, release and suppress the preempt
+            for ``proximity_cooldown`` so the normal rotation gets screen time.
+        COOLDOWN -> IDLE: after the cooldown, the next plane in range can lock on.
+
+        This is the single source of truth for the live state; it has side effects
+        (acquiring/releasing the lock) and is safe to call repeatedly within a cycle.
         """
-        if not self.proximity_enabled:
-            return
-        closest = self.get_closest_aircraft()
-        if closest and closest['distance_miles'] <= self.proximity_distance_miles:
-            self.proximity_triggered_time = time.time()
-            self._proximity_aircraft = closest
-
-    def _proximity_active(self) -> bool:
-        """True while the proximity latch is within its alert window."""
-        if not self.proximity_enabled or self.proximity_triggered_time is None:
+        if not (self.proximity_enabled and self.live_priority_enabled):
             return False
-        return (time.time() - self.proximity_triggered_time) < self.proximity_duration
+        now = time.time()
+
+        if self._lock_icao is not None:
+            # Keep the locked flight's data fresh while it is still tracked.
+            ac = self.aircraft_data.get(self._lock_icao)
+            if ac is not None:
+                self._lock_aircraft = ac
+            # Hold for the full window even if the plane has left the radius, so a
+            # plane that flew over still shows for the configured duration.
+            if now - self._lock_start < self.proximity_duration:
+                return True
+            # Cap reached — release and start the cooldown.
+            self._lock_icao = None
+            self._cooldown_until = now + self.proximity_cooldown
+            return False
+
+        if now < self._cooldown_until:
+            return False
+
+        icao, ac = self._closest_in_radius()
+        if icao is not None:
+            self._lock_icao = icao
+            self._lock_start = now
+            self._lock_aircraft = ac
+            return True
+        return False
 
     def _view_has_content(self, view: str) -> bool:
         """Whether a scroll-through view has anything to render right now.
@@ -2981,11 +3027,8 @@ class FlightTrackerPlugin(BasePlugin):
         return bool(self.live_priority_enabled and self.proximity_enabled)
 
     def has_live_content(self) -> bool:
-        """Live content = an aircraft is (or was recently) within the proximity radius."""
-        if not self.proximity_enabled:
-            return False
-        self._update_proximity_latch()
-        return self._proximity_active()
+        """Live content = a flight is currently locked on (overhead) and not in cooldown."""
+        return self._evaluate_proximity()
 
     def get_live_modes(self) -> list:
         """Return the live slot name when there is overhead content to preempt with."""

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -2030,7 +2030,17 @@ class FlightTrackerPlugin(BasePlugin):
         current_time = time.time()
         is_visible = (current_time - self._last_displayed_time) < self._display_idle_threshold
 
-        # Fetch faster while a flight is locked on so the overhead view's
+        # Expire a timed-out live lock here too, mirroring _evaluate_proximity()'s
+        # release. The render path normally advances the state machine, but if the
+        # plugin stops rendering while a flight is locked, _evaluate_proximity()
+        # never runs and the lock would otherwise pin fetching at the live cadence
+        # forever.
+        if (self._lock_icao is not None
+                and current_time - self._lock_start >= self.proximity_duration):
+            self._lock_icao = None
+            self._cooldown_until = current_time + self.proximity_cooldown
+
+        # Fetch faster while a flight is actively locked on so the overhead view's
         # altitude/distance stay current; fall back to update_interval when idle.
         fetch_interval = self.live_update_interval if self._lock_icao is not None else self.update_interval
 
@@ -3016,7 +3026,13 @@ class FlightTrackerPlugin(BasePlugin):
         instead of dwelling on a blank/"No Aircraft" screen.
         """
         if view == 'stats':
-            return True
+            # Mirror _display_stats()'s "No Aircraft" guard: content exists when
+            # there is live data in range or a saved record to show.
+            stats_pool = self.all_aircraft_data or self.aircraft_data
+            has_records = self.flight_records_enabled and (
+                self._closest_record or self._farthest_record
+            )
+            return bool(stats_pool or has_records)
         if view == 'flight_tracking':
             return bool(self.tracked_flight_data)
         # map, area

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-01",
+      "version": "1.7.0",
+      "notes": "Overhead live-priority behavior: lock onto the specific flight that enters the radius (no longer hops to whatever is momentarily closest); duration_seconds is now a hard cap measured from lock-on (a lingering plane no longer overstays); add proximity_alert.cooldown_seconds to guarantee the normal rotation screen time after each flight; add live_update_interval for a faster fetch (default 2s) while a flight is locked on so altitude/distance update smoothly.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-01",
       "version": "1.6.0",

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-01",
+      "version": "1.6.0",
+      "notes": "Add configurable rotation views (rotation_views: pick which of map/stats/area/flight_tracking cycle, or none) and overhead live-priority preempt (live_priority: a plane entering the proximity radius cuts in to the overhead view for the proximity_alert window, then releases). Empty rotation_views + live_priority gives a blank-until-overhead board. Fully backward compatible: unset rotation_views keeps the legacy single display_mode behavior.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-31",
       "version": "1.5.5",
@@ -92,5 +98,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-31"
+  "last_updated": "2026-06-01"
 }

--- a/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+++ b/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
@@ -59,11 +59,17 @@ def make_plugin(config):
     p.proximity_enabled = pc.get("enabled", True)
     p.proximity_distance_miles = pc.get("distance_miles", 0.1)
     p.proximity_duration = pc.get("duration_seconds", 30)
+    p.proximity_cooldown = pc.get("cooldown_seconds", 30)
     p.live_priority_enabled = config.get("live_priority", False)
+    p.update_interval = config.get("update_interval", 5)
+    p.live_update_interval = config.get("live_update_interval", 2)
 
     p.display_mode = config.get("display_mode", "auto")
-    p.proximity_triggered_time = None
-    p._proximity_aircraft = None
+    # Overhead state machine
+    p._lock_icao = None
+    p._lock_start = 0.0
+    p._lock_aircraft = None
+    p._cooldown_until = 0.0
     p._active_overhead_aircraft = None
 
     p.aircraft_data = {}
@@ -80,8 +86,13 @@ def make_plugin(config):
     return p
 
 
-def _aircraft(distance_miles):
-    return {"icao": "abc123", "callsign": "TEST123", "distance_miles": distance_miles}
+def _aircraft(distance_miles, icao="abc123", callsign="TEST123"):
+    return {"icao": icao, "callsign": callsign, "distance_miles": distance_miles}
+
+
+def _set(p, *aircraft):
+    """Replace aircraft_data with the given aircraft (keyed by icao)."""
+    p.aircraft_data = {a["icao"]: a for a in aircraft}
 
 
 # ---------------------------------------------------------------------------
@@ -129,43 +140,120 @@ def test_rotation_views_plus_overhead():
 
 
 # ---------------------------------------------------------------------------
-# Proximity latch / live content
+# Overhead state machine: lock-on, hard cap, cooldown
 # ---------------------------------------------------------------------------
 
-def test_proximity_latch_holds_for_window():
-    p = make_plugin({"live_priority": True,
-                     "proximity_alert": {"distance_miles": 0.1, "duration_seconds": 20}})
-    # Aircraft enters the radius.
-    p.aircraft_data = {"abc123": _aircraft(0.05)}
+def _cfg(**proximity):
+    base = {"distance_miles": 0.5, "duration_seconds": 20, "cooldown_seconds": 30}
+    base.update(proximity)
+    return {"live_priority": True, "proximity_alert": base}
+
+
+def test_lock_on_acquires_and_reports_live():
+    p = make_plugin(_cfg())
+    _set(p, _aircraft(0.3, icao="AAA", callsign="AAL1"))
     assert p.has_live_priority() is True
     assert p.has_live_content() is True
     assert p.get_live_modes() == ["flight_tracker_live"]
-    assert p._proximity_aircraft is not None
+    assert p._lock_icao == "AAA"
+    assert p._lock_aircraft["callsign"] == "AAL1"
 
-    # Aircraft leaves the radius but we are still inside the alert window:
-    # the latch keeps the plugin "live".
-    p.aircraft_data = {"abc123": _aircraft(5.0)}
+
+def test_lock_on_does_not_switch_to_closer_plane():
+    # Once locked, a newly-closer plane must NOT steal the screen mid-window.
+    p = make_plugin(_cfg())
+    _set(p, _aircraft(0.3, icao="AAA", callsign="AAL1"))
     assert p.has_live_content() is True
+    assert p._lock_icao == "AAA"
+    # A closer plane appears; the lock stays on AAA.
+    _set(p, _aircraft(0.3, icao="AAA", callsign="AAL1"),
+            _aircraft(0.05, icao="BBB", callsign="BAW2"))
+    assert p.has_live_content() is True
+    assert p._lock_icao == "AAA"
+    assert p._lock_aircraft["callsign"] == "AAL1"
 
-    # Once the window elapses, live content clears.
-    p.proximity_triggered_time = time.time() - 999
+
+def test_hard_cap_releases_even_if_plane_lingers():
+    # The flight is held only for duration_seconds, even if it stays in the radius.
+    p = make_plugin(_cfg(duration_seconds=20))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    # Simulate the cap elapsing while the plane is still overhead.
+    p._lock_start = time.time() - 21
+    assert p.has_live_content() is False          # released
+    assert p._lock_icao is None
+    assert p._cooldown_until > time.time()        # cooldown started
+
+
+def test_window_holds_after_plane_leaves_radius():
+    # A plane that flew over still shows for the full window after leaving the radius.
+    p = make_plugin(_cfg(duration_seconds=20))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    # Plane leaves the radius but we are still inside the window.
+    _set(p, _aircraft(5.0, icao="AAA"))
+    assert p.has_live_content() is True
+    assert p._lock_icao == "AAA"
+
+
+def test_cooldown_blocks_repreempt():
+    p = make_plugin(_cfg(duration_seconds=20, cooldown_seconds=30))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    p._lock_start = time.time() - 21
+    assert p.has_live_content() is False          # released into cooldown
+    # Another plane is overhead, but cooldown suppresses the preempt.
+    _set(p, _aircraft(0.05, icao="BBB"))
     assert p.has_live_content() is False
     assert p.get_live_modes() == []
+    # After cooldown, the next plane can lock on.
+    p._cooldown_until = time.time() - 1
+    assert p.has_live_content() is True
+    assert p._lock_icao == "BBB"
+
+
+def test_cooldown_zero_allows_immediate_relock():
+    p = make_plugin(_cfg(duration_seconds=20, cooldown_seconds=0))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    p._lock_start = time.time() - 21
+    assert p.has_live_content() is False          # released, no cooldown
+    _set(p, _aircraft(0.1, icao="BBB"))
+    assert p.has_live_content() is True
+    assert p._lock_icao == "BBB"
 
 
 def test_live_priority_requires_optin():
     # Without live_priority, a close aircraft never preempts the rotation.
-    p = make_plugin({"proximity_alert": {"distance_miles": 0.1}})
-    p.aircraft_data = {"abc123": _aircraft(0.05)}
+    p = make_plugin({"proximity_alert": {"distance_miles": 0.5}})
+    _set(p, _aircraft(0.05))
     assert p.has_live_priority() is False
+    assert p.has_live_content() is False
     assert p.get_live_modes() == []
+    assert p._lock_icao is None
 
 
 def test_proximity_disabled_has_no_live_content():
     p = make_plugin({"live_priority": True, "proximity_alert": {"enabled": False}})
-    p.aircraft_data = {"abc123": _aircraft(0.01)}
+    _set(p, _aircraft(0.01))
     assert p.has_live_content() is False
     assert p.has_live_priority() is False
+
+
+# ---------------------------------------------------------------------------
+# Dynamic fetch interval
+# ---------------------------------------------------------------------------
+
+def test_fetch_interval_speeds_up_when_locked():
+    p = make_plugin(_cfg(distance_miles=0.5))
+    p.update_interval = 5
+    p.live_update_interval = 2
+    # Idle: the effective interval is the normal one.
+    assert (p.live_update_interval if p._lock_icao is not None else p.update_interval) == 5
+    _set(p, _aircraft(0.1, icao="AAA"))
+    p.has_live_content()  # acquire lock
+    assert p._lock_icao == "AAA"
+    assert (p.live_update_interval if p._lock_icao is not None else p.update_interval) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+++ b/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
@@ -15,7 +15,6 @@ Run with the core venv:
 """
 
 import logging
-import os
 import sys
 import time
 import types
@@ -75,6 +74,11 @@ def make_plugin(config):
     p.aircraft_data = {}
     p.all_aircraft_data = {}
     p.tracked_flight_data = {}
+
+    # Flight-records state (consulted by stats content checks)
+    p.flight_records_enabled = config.get("flight_records", {}).get("enabled", True)
+    p._closest_record = None
+    p._farthest_record = None
 
     # display() preamble attrs
     p._last_displayed_time = 0.0
@@ -256,6 +260,31 @@ def test_fetch_interval_speeds_up_when_locked():
     assert (p.live_update_interval if p._lock_icao is not None else p.update_interval) == 2
 
 
+def test_update_expires_stale_lock():
+    # Regression: if rendering stops while a flight is locked, _evaluate_proximity()
+    # never runs, so update() itself must expire a timed-out lock — otherwise the
+    # stale lock pins fetching at the live cadence forever.
+    p = make_plugin(_cfg(duration_seconds=20, cooldown_seconds=30))
+    # Minimal attrs for update()'s no-op path (fetch branch skipped via last_fetch).
+    p.data_source = "adsbfi"
+    p.last_fetch = time.time()
+    p.pending_fr24_details = {}
+    p.tracked_flights_cfg = []
+
+    _set(p, _aircraft(0.1, icao="AAA"))
+    p.has_live_content()  # acquire lock
+    assert p._lock_icao == "AAA"
+
+    # Simulate the lock outliving its hard cap with no render path advancing it.
+    p._lock_start = time.time() - 21
+    p.update()
+
+    assert p._lock_icao is None, "update() should expire a timed-out lock"
+    assert p._cooldown_until > time.time(), "expiry should start the cooldown"
+    # Polling falls back to the normal interval once the lock is gone.
+    assert (p.live_update_interval if p._lock_icao is not None else p.update_interval) == p.update_interval
+
+
 # ---------------------------------------------------------------------------
 # display() skip behavior (returns False -> framework rotates on)
 # ---------------------------------------------------------------------------
@@ -284,12 +313,26 @@ def test_display_unknown_slot_skips():
 
 def test_view_has_content():
     p = make_plugin({})
-    assert p._view_has_content("stats") is True  # stats always has something
+    # With no live aircraft and no saved records, the stats slot is empty so the
+    # rotation can skip it instead of dwelling on "No Aircraft".
+    assert p._view_has_content("stats") is False
     assert p._view_has_content("map") is False
     assert p._view_has_content("flight_tracking") is False
+
+    # Live aircraft make stats (and map/area) renderable.
     p.aircraft_data = {"abc123": _aircraft(2.0)}
+    assert p._view_has_content("stats") is True
     assert p._view_has_content("map") is True
     assert p._view_has_content("area") is True
+
+    # A saved record alone is enough for stats, even with no live aircraft.
+    p.aircraft_data = {}
+    p._closest_record = {"callsign": "REC1", "distance_miles": 0.2}
+    assert p._view_has_content("stats") is True
+
+    # ...unless flight records are disabled.
+    p.flight_records_enabled = False
+    assert p._view_has_content("stats") is False
 
 
 def run():

--- a/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+++ b/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Regression tests for configurable rotation views + overhead live-priority preempt.
+
+Covers:
+  - `_get_available_modes`: legacy single slot, per-view rotation slots, the
+    "none" (empty) case, invalid-view filtering, and the overhead live slot.
+  - The proximity latch: an aircraft entering the radius makes the plugin "live"
+    for the full proximity window, even after it leaves the radius.
+  - `display()` returning False (skip) for an inactive live slot, an empty
+    rotation slot, and an unknown slot name.
+
+Run with the core venv:
+    .venv/bin/python plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+"""
+
+import logging
+import os
+import sys
+import time
+import types
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN_DIR))
+
+# Stub the core's BasePlugin so `manager` imports without the full LEDMatrix core
+# tree on the path. We bypass __init__ in these tests, so a no-op base is enough.
+if "src.plugin_system.base_plugin" not in sys.modules:
+    src_mod = types.ModuleType("src")
+    plugin_system_mod = types.ModuleType("src.plugin_system")
+    base_plugin_mod = types.ModuleType("src.plugin_system.base_plugin")
+
+    class _StubBasePlugin:  # pragma: no cover - trivial stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    base_plugin_mod.BasePlugin = _StubBasePlugin
+    src_mod.plugin_system = plugin_system_mod
+    plugin_system_mod.base_plugin = base_plugin_mod
+    sys.modules["src"] = src_mod
+    sys.modules["src.plugin_system"] = plugin_system_mod
+    sys.modules["src.plugin_system.base_plugin"] = base_plugin_mod
+
+logging.basicConfig(level=logging.CRITICAL)
+
+from manager import FlightTrackerPlugin  # noqa: E402
+
+
+def make_plugin(config):
+    """Build a FlightTrackerPlugin with only the attributes the units-under-test
+    need, bypassing the heavy real __init__ (which requires display/cache managers).
+    """
+    p = FlightTrackerPlugin.__new__(FlightTrackerPlugin)
+    p.config = config
+    p.logger = logging.getLogger("flight-test")
+
+    pc = config.get("proximity_alert", {})
+    p.proximity_enabled = pc.get("enabled", True)
+    p.proximity_distance_miles = pc.get("distance_miles", 0.1)
+    p.proximity_duration = pc.get("duration_seconds", 30)
+    p.live_priority_enabled = config.get("live_priority", False)
+
+    p.display_mode = config.get("display_mode", "auto")
+    p.proximity_triggered_time = None
+    p._proximity_aircraft = None
+    p._active_overhead_aircraft = None
+
+    p.aircraft_data = {}
+    p.all_aircraft_data = {}
+    p.tracked_flight_data = {}
+
+    # display() preamble attrs
+    p._last_displayed_time = 0.0
+    p._display_idle_threshold = 30.0
+    p.fr24_enrichment = False
+    p.last_fr24_enrichment = 0.0
+
+    p.modes = p._get_available_modes()
+    return p
+
+
+def _aircraft(distance_miles):
+    return {"icao": "abc123", "callsign": "TEST123", "distance_miles": distance_miles}
+
+
+# ---------------------------------------------------------------------------
+# _get_available_modes
+# ---------------------------------------------------------------------------
+
+def test_legacy_single_slot():
+    p = make_plugin({})  # no rotation_views, live_priority off
+    assert p.modes == ["flight_tracker"], p.modes
+
+
+def test_legacy_with_overhead_priority():
+    p = make_plugin({"live_priority": True})
+    assert p.modes == ["flight_tracker", "flight_tracker_live"], p.modes
+
+
+def test_rotation_views_subset_preserves_order():
+    p = make_plugin({"rotation_views": ["stats", "map"]})
+    assert p.modes == ["flight_tracker_stats", "flight_tracker_map"], p.modes
+
+
+def test_rotation_views_filters_invalid_and_overhead():
+    # 'overhead' and unknown views are not valid rotation views.
+    p = make_plugin({"rotation_views": ["map", "overhead", "bogus", "area"]})
+    assert p.modes == ["flight_tracker_map", "flight_tracker_area"], p.modes
+
+
+def test_none_rotation_with_overhead_only():
+    p = make_plugin({"rotation_views": [], "live_priority": True})
+    assert p.modes == ["flight_tracker_live"], p.modes
+
+
+def test_none_rotation_without_priority_is_empty():
+    p = make_plugin({"rotation_views": []})
+    assert p.modes == [], p.modes
+
+
+def test_rotation_views_plus_overhead():
+    p = make_plugin({"rotation_views": ["map", "stats"], "live_priority": True})
+    assert p.modes == [
+        "flight_tracker_map",
+        "flight_tracker_stats",
+        "flight_tracker_live",
+    ], p.modes
+
+
+# ---------------------------------------------------------------------------
+# Proximity latch / live content
+# ---------------------------------------------------------------------------
+
+def test_proximity_latch_holds_for_window():
+    p = make_plugin({"live_priority": True,
+                     "proximity_alert": {"distance_miles": 0.1, "duration_seconds": 20}})
+    # Aircraft enters the radius.
+    p.aircraft_data = {"abc123": _aircraft(0.05)}
+    assert p.has_live_priority() is True
+    assert p.has_live_content() is True
+    assert p.get_live_modes() == ["flight_tracker_live"]
+    assert p._proximity_aircraft is not None
+
+    # Aircraft leaves the radius but we are still inside the alert window:
+    # the latch keeps the plugin "live".
+    p.aircraft_data = {"abc123": _aircraft(5.0)}
+    assert p.has_live_content() is True
+
+    # Once the window elapses, live content clears.
+    p.proximity_triggered_time = time.time() - 999
+    assert p.has_live_content() is False
+    assert p.get_live_modes() == []
+
+
+def test_live_priority_requires_optin():
+    # Without live_priority, a close aircraft never preempts the rotation.
+    p = make_plugin({"proximity_alert": {"distance_miles": 0.1}})
+    p.aircraft_data = {"abc123": _aircraft(0.05)}
+    assert p.has_live_priority() is False
+    assert p.get_live_modes() == []
+
+
+def test_proximity_disabled_has_no_live_content():
+    p = make_plugin({"live_priority": True, "proximity_alert": {"enabled": False}})
+    p.aircraft_data = {"abc123": _aircraft(0.01)}
+    assert p.has_live_content() is False
+    assert p.has_live_priority() is False
+
+
+# ---------------------------------------------------------------------------
+# display() skip behavior (returns False -> framework rotates on)
+# ---------------------------------------------------------------------------
+
+def test_display_live_slot_skips_when_inactive():
+    p = make_plugin({"live_priority": True})
+    p.aircraft_data = {"abc123": _aircraft(5.0)}  # nothing overhead
+    assert p.display(display_mode="flight_tracker_live") is False
+
+
+def test_display_empty_rotation_view_skips():
+    p = make_plugin({"rotation_views": ["map"]})
+    p.aircraft_data = {}  # empty map -> skip
+    assert p.display(display_mode="flight_tracker_map") is False
+
+
+def test_display_unknown_slot_skips():
+    p = make_plugin({"rotation_views": []})
+    # The plugin-id fallback slot the core injects when modes is empty.
+    assert p.display(display_mode="ledmatrix-flights") is False
+
+
+# ---------------------------------------------------------------------------
+# _view_has_content
+# ---------------------------------------------------------------------------
+
+def test_view_has_content():
+    p = make_plugin({})
+    assert p._view_has_content("stats") is True  # stats always has something
+    assert p._view_has_content("map") is False
+    assert p._view_has_content("flight_tracking") is False
+    p.aircraft_data = {"abc123": _aircraft(2.0)}
+    assert p._view_has_content("map") is True
+    assert p._view_has_content("area") is True
+
+
+def run():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # pragma: no cover
+            failures += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return failures == 0
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)


### PR DESCRIPTION
## Summary

Adds two opt-in capabilities to the Flight Tracker plugin, plus the web-UI wiring for them. Fully backward compatible — with no new config, behavior is unchanged.

### 1. Configurable rotation views (`rotation_views`)
Choose which of `map` / `stats` / `area` / `flight_tracking` cycle in the normal rotation. Each selected view becomes its own rotation slot (via a dynamic `.modes` list, the same mechanism the sports plugins use), and an empty/no-content slot returns `False` from `display()` so the framework skips it instead of dwelling on a blank screen. Selecting none contributes no scroll-through slots.

### 2. Overhead live-priority preempt (`live_priority` + `proximity_alert`)
When a plane enters the proximity radius it preempts the rotation to show the overhead view, then yields. Implemented as a small state machine (IDLE → LOCKED → COOLDOWN):
- **Lock-on** — latches the specific ICAO that entered the radius; won't hop to whatever is momentarily closest.
- **Hard cap** — `duration_seconds` is measured from lock-on, so a plane lingering in the radius no longer overstays.
- **Cooldown** — new `proximity_alert.cooldown_seconds` guarantees the normal rotation screen time after each flight, even when planes remain overhead.
- **Dynamic fetch** — new `live_update_interval` (default 2s) fetches faster while a flight is locked on so altitude/distance update smoothly; idle stays at `update_interval`. The ADS-B source is ~1Hz, so this is safe.

Empty `rotation_views` + `live_priority` yields a blank-until-overhead board.

### 3. Web UI
The dashboard renders the config form from `config_schema.json`. New fields are added to `x-propertyOrder` so they appear, and `rotation_views` is tagged `x-widget: checkbox-group` (matching f1-scoreboard / news / odds-ticker) to render as a multi-select.

## Backward compatibility
- When `rotation_views` is unset, the plugin exposes the single legacy `flight_tracker` slot and renders per the existing `display_mode` (auto/map/stats/...) — unchanged.
- `live_priority` defaults off, so nothing preempts unless opted in.
- Schema changes are additive; the `display_mode` enum is untouched.

## Testing
- Unit/regression tests in `test/test_rotation_views_and_overhead.py` (20 cases): mode building (legacy/subset/none/invalid-filtering), lock acquisition, not-switching-to-a-closer-plane, hard-cap release of a lingering plane, holding the window after the plane leaves the radius, cooldown blocking re-preempt (and cooldown=0), the dynamic fetch interval, and `display()` skip behavior.
- Verified end-to-end on the RGBMatrixEmulator. At a 2mi radius (heavy SeaTac approach traffic): flight holds measured 18–20s (the cap), with ≥30s normal-content gaps between — flights down to ~40% of screen time, versus near-total takeover without the cap/cooldown.
- Web UI form verified by rendering `/v3/partials/plugin-config/ledmatrix-flights`: all new fields present; `rotation_views` shows checkboxes for map/stats/area/flight_tracking.

Version bumped to **1.7.0**; `plugins.json` synced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable rotation views to select which displays participate in normal rotation.
  * Added live update interval setting for smoother overhead aircraft updates.
  * Added proximity alert cooldown to suppress repeated alerts after the alert window.
  * Enhanced overhead preemption behavior when live priority is enabled.

* **Tests**
  * Added comprehensive test coverage for rotation views and overhead priority functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->