### PR TITLE
refactor(flights): move overhead view into renderer + redesign as a card

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -331,10 +331,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-19",
+      "last_updated": "2026-05-31",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.5.4"
+      "latest_version": "1.5.5"
     },
     {
       "id": "march-madness",

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-01",
+  "last_updated": "2026-06-02",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -334,7 +334,7 @@
       "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.7.0"
+      "latest_version": "1.8.0"
     },
     {
       "id": "march-madness",

--- a/plugins.json
+++ b/plugins.json
@@ -46,10 +46,10 @@
       "plugin_path": "plugins/baseball-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-15",
+      "last_updated": "2026-05-31",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.1"
+      "latest_version": "1.6.2"
     },
     {
       "id": "basketball-scoreboard",

--- a/plugins.json
+++ b/plugins.json
@@ -334,7 +334,7 @@
       "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.0"
+      "latest_version": "1.7.0"
     },
     {
       "id": "march-madness",

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-05-31",
+  "last_updated": "2026-06-01",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -331,10 +331,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-31",
+      "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.5.5"
+      "latest_version": "1.6.0"
     },
     {
       "id": "march-madness",

--- a/plugins/baseball-scoreboard/manager.py
+++ b/plugins/baseball-scoreboard/manager.py
@@ -597,6 +597,7 @@ class BaseballScoreboardPlugin(BasePlugin if BasePlugin else object):
                     15  # Default per-game duration for upcoming games
                 ),
                 "live_priority": league_config.get("live_priority", False),
+                "test_mode": league_config.get("test_mode", False),
                 "show_favorite_teams_only": show_favorites_only,
                 "show_all_live": show_all_live,
                 "filtering": filtering,

--- a/plugins/baseball-scoreboard/manifest.json
+++ b/plugins/baseball-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "baseball-scoreboard",
   "name": "Baseball Scoreboard",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming baseball games across MLB, MiLB, and NCAA Baseball with real-time scores and schedules",
   "category": "sports",
@@ -30,6 +30,12 @@
   "branch": "main",
   "plugin_path": "plugins/baseball-scoreboard",
   "versions": [
+    {
+      "released": "2026-05-31",
+      "version": "1.6.2",
+      "notes": "Fix test_mode: pass the flag through to the live manager and short-circuit update() so the simulated live game is not overwritten by an empty live fetch",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-15",
       "version": "1.6.1",
@@ -121,7 +127,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-15",
+  "last_updated": "2026-05-31",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/baseball-scoreboard/sports.py
+++ b/plugins/baseball-scoreboard/sports.py
@@ -2188,6 +2188,12 @@ class SportsLive(SportsCore):
         if current_time - self.last_update >= interval:
             self.last_update = current_time
 
+            # Test mode: advance the simulated game instead of fetching real API
+            # data (which would overwrite the seeded live game with an empty list).
+            if _test_mode_attr:
+                self._test_mode_update()
+                return
+
             # Fetch rankings if enabled
             if self.show_ranking:
                 self._fetch_team_rankings()

--- a/plugins/baseball-scoreboard/test_test_mode_live_games.py
+++ b/plugins/baseball-scoreboard/test_test_mode_live_games.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Regression test for SportsLive.update() test-mode handling.
+
+In test mode the live manager seeds a simulated live game (self.live_games).
+The bug: update() ignored test_mode and always called _fetch_data(), which
+rebuilds live_games from the real (empty) API response — wiping the seeded
+game on the first tick, so has_live_content() returned False and the live
+view / live-priority never engaged.
+
+The fix short-circuits to _test_mode_update() (and returns) when test_mode is
+set, so the seeded game survives. This test verifies that control flow without
+needing a display/cache manager.
+"""
+
+import os
+import sys
+import logging
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+from sports import SportsLive  # noqa: E402
+
+
+class _ConcreteLive(SportsLive):
+    """Minimal concrete SportsLive so we can instantiate without the full
+    manager stack. The methods update() calls are replaced per-test."""
+
+    def _extract_game_details(self, game):  # abstract in SportsCore
+        return None
+
+    def _fetch_data(self):  # abstract in SportsCore
+        return None
+
+    def _test_mode_update(self):  # abstract in SportsLive
+        return None
+
+
+def _make_live(test_mode: bool):
+    """Build a bare SportsLive with only the attributes update() touches."""
+    live = object.__new__(_ConcreteLive)
+    live.is_enabled = True
+    live.test_mode = test_mode
+    live.live_games = [
+        {"id": "t1", "home_abbr": "SEA", "away_abbr": "HOU",
+         "is_live": True, "is_final": False}
+    ]
+    live.no_data_interval = 300
+    live.update_interval = 30
+    live.last_update = 0  # 0 → force an update on this call
+    live.show_ranking = False
+    live.sport_key = "mlb"
+    live.logger = logging.getLogger("test_test_mode")
+    return live
+
+
+def test_test_mode_short_circuits_fetch():
+    """test_mode=True must call _test_mode_update(), NOT _fetch_data(), and keep the game."""
+    live = _make_live(test_mode=True)
+    called = {"fetch": False, "test_update": False}
+
+    def fake_fetch():
+        called["fetch"] = True
+        live.live_games = []  # reproduce the original overwrite
+        return {"events": []}
+
+    def fake_test_update():
+        called["test_update"] = True
+
+    live._fetch_data = fake_fetch
+    live._test_mode_update = fake_test_update
+
+    # Guard update(): without the fix it enters the live-fetch path and may raise
+    # on attributes a bare instance doesn't have. We assert on the invariants below
+    # so the failure is clear regardless of how far the buggy path gets.
+    try:
+        live.update()
+    except Exception:  # noqa: BLE001 - downstream attrs irrelevant to this test
+        pass
+
+    assert called["test_update"], "expected _test_mode_update() to run in test mode"
+    assert not called["fetch"], "_fetch_data() must NOT run in test mode (it wipes the seeded game)"
+    assert len(live.live_games) == 1, f"seeded live game must survive, got {len(live.live_games)}"
+    print("✓ test_mode short-circuits to _test_mode_update and preserves live_games")
+
+
+def test_live_mode_still_fetches():
+    """test_mode=False must reach _fetch_data() (real data path is unchanged)."""
+    live = _make_live(test_mode=False)
+    live.live_games = []
+    called = {"fetch": False}
+
+    class _StopAfterFetch(Exception):
+        pass
+
+    def fake_fetch():
+        called["fetch"] = True
+        raise _StopAfterFetch()  # we only care that the fetch path is reached
+
+    live._fetch_data = fake_fetch
+    try:
+        live.update()
+    except _StopAfterFetch:
+        pass
+
+    assert called["fetch"], "live mode (test_mode=False) must call _fetch_data()"
+    print("✓ live mode still calls _fetch_data()")
+
+
+if __name__ == "__main__":
+    print("SportsLive test_mode regression test")
+    print("=" * 44)
+    ok = True
+    for t in (test_test_mode_short_circuits_fetch, test_live_mode_still_fetches):
+        try:
+            t()
+        except AssertionError as e:
+            ok = False
+            print(f"✗ {t.__name__}: {e}")
+    print("=" * 44)
+    print("PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -51,7 +51,8 @@
     "live_priority": {
       "type": "boolean",
       "default": false,
-      "description": "Enable live priority takeover when plugin has live content"
+      "title": "Overhead Live Priority",
+      "description": "When enabled, an aircraft entering the proximity radius immediately preempts the normal rotation to show the overhead view for the proximity alert window (see proximity_alert.duration_seconds). Adds a 'flight_tracker_live' rotation slot that stays blank/skipped until a plane is overhead. Leave off for legacy behavior."
     },
     "skyaware_url": {
       "type": "string",
@@ -240,7 +241,7 @@
     "display_mode": {
       "type": "string",
       "title": "Display Mode",
-      "description": "Display mode. 'area' shows multi-aircraft list with FlightWall metrics. 'flight_tracking' shows tracked flight details. 'auto' chooses based on context.",
+      "description": "Single-view display mode, used only when 'rotation_views' is not set. 'area' shows multi-aircraft list with FlightWall metrics. 'flight_tracking' shows tracked flight details. 'auto' chooses based on context.",
       "enum": [
         "map",
         "overhead",
@@ -250,6 +251,21 @@
         "auto"
       ],
       "default": "auto"
+    },
+    "rotation_views": {
+      "type": "array",
+      "title": "Rotation Views",
+      "description": "Which views the display rotation cycles through. Each selected view gets its own rotation slot and an empty/no-content slot is skipped. Leave empty ([]) to show nothing in the normal rotation — useful for an overhead-only board (pair with live_priority). When this field is omitted entirely, the single 'Display Mode' setting is used instead (legacy behavior). The overhead view is not listed here; it is driven by live_priority + proximity_alert.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "map",
+          "stats",
+          "area",
+          "flight_tracking"
+        ]
+      },
+      "uniqueItems": true
     },
     "units": {
       "type": "string",

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -270,7 +270,8 @@
     "rotation_views": {
       "type": "array",
       "title": "Rotation Views",
-      "description": "Which views the display rotation cycles through. Each selected view gets its own rotation slot and an empty/no-content slot is skipped. Leave empty ([]) to show nothing in the normal rotation — useful for an overhead-only board (pair with live_priority). When this field is omitted entirely, the single 'Display Mode' setting is used instead (legacy behavior). The overhead view is not listed here; it is driven by live_priority + proximity_alert.",
+      "description": "Which views the display rotation cycles through. Each selected view gets its own rotation slot and an empty/no-content slot is skipped. Leave all unchecked to show nothing in the normal rotation — useful for an overhead-only board (pair with Overhead Live Priority). When this field is omitted entirely, the single 'Display Mode' setting is used instead (legacy behavior). The overhead view is not listed here; it is driven by live_priority + proximity_alert.",
+      "x-widget": "checkbox-group",
       "items": {
         "type": "string",
         "enum": [
@@ -279,6 +280,14 @@
           "area",
           "flight_tracking"
         ]
+      },
+      "x-options": {
+        "labels": {
+          "map": "Map",
+          "stats": "Stats",
+          "area": "Area (multi-aircraft)",
+          "flight_tracking": "Flight Tracking"
+        }
       },
       "uniqueItems": true
     },
@@ -742,8 +751,10 @@
     "enrichment_provider",
     "route_cache_ttl",
     "display_mode",
+    "rotation_views",
     "display_duration",
     "update_interval",
+    "live_update_interval",
     "live_priority",
     "zoom_factor",
     "max_aircraft",

--- a/plugins/ledmatrix-flights/config_schema.json
+++ b/plugins/ledmatrix-flights/config_schema.json
@@ -48,6 +48,14 @@
       "maximum": 300,
       "default": 5
     },
+    "live_update_interval": {
+      "type": "integer",
+      "title": "Live Fetch Interval",
+      "description": "Faster fetch interval (seconds) used while a flight is locked on for the overhead view, so altitude/distance update smoothly. The ADS-B source is ~1Hz, so a low value is safe. Idle fetches use update_interval.",
+      "minimum": 1,
+      "maximum": 60,
+      "default": 2
+    },
     "live_priority": {
       "type": "boolean",
       "default": false,
@@ -211,9 +219,16 @@
         },
         "duration_seconds": {
           "type": "integer",
-          "description": "Duration to show proximity alert in seconds",
+          "description": "Hard cap (seconds) on how long a single overhead flight holds the screen, measured from when it is locked on. The flight shows for this long even if it leaves the radius sooner, and is released after this even if it lingers.",
           "minimum": 5,
           "maximum": 300,
+          "default": 30
+        },
+        "cooldown_seconds": {
+          "type": "integer",
+          "description": "After a flight's window ends, suppress the overhead preempt for this many seconds so the normal rotation (weather/clock/sports) gets guaranteed screen time, even if planes remain overhead. Set to 0 to disable the cooldown.",
+          "minimum": 0,
+          "maximum": 600,
           "default": 30
         }
       },

--- a/plugins/ledmatrix-flights/fetcher.py
+++ b/plugins/ledmatrix-flights/fetcher.py
@@ -494,7 +494,9 @@ class AdsbNetFetcher(AircraftFetcher):
             logger.exception(f"[Flight Tracker] {self.provider} fetch failed")
             return None
 
-        aircraft_list = data.get("ac", [])
+        # adsb.lol returns aircraft under "ac"; adsb.fi's opendata API uses
+        # "aircraft". Accept either so both providers work.
+        aircraft_list = data.get("ac") or data.get("aircraft") or []
         if not aircraft_list:
             logger.info(f"[Flight Tracker] {self.provider}: no aircraft in range ({radius_miles}mi)")
             return {}

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -41,7 +41,23 @@ logger = logging.getLogger(__name__)
 
 class FlightTrackerPlugin(BasePlugin):
     """Flight tracker plugin for LEDMatrix."""
-    
+
+    # Scroll-through views that can be enabled individually via `rotation_views`.
+    # 'overhead' is intentionally excluded — it is the live preempt view, driven
+    # by proximity alerts rather than the normal rotation.
+    _VALID_ROTATION_VIEWS = ('map', 'stats', 'area', 'flight_tracking')
+
+    # Maps the framework's per-slot mode name to the internal view rendered by
+    # display(). The bare 'flight_tracker' slot is legacy and resolves via the
+    # configured `display_mode` instead.
+    _GRANULAR_MODES = {
+        'flight_tracker_map': 'map',
+        'flight_tracker_stats': 'stats',
+        'flight_tracker_area': 'area',
+        'flight_tracker_flight_tracking': 'flight_tracking',
+        'flight_tracker_live': 'overhead',
+    }
+
     def __init__(self, plugin_id: str, config: Dict[str, Any], display_manager, cache_manager, plugin_manager):
         super().__init__(plugin_id, config, display_manager, cache_manager, plugin_manager)
         self.plugin_manager = plugin_manager
@@ -170,6 +186,10 @@ class FlightTrackerPlugin(BasePlugin):
         self.proximity_enabled = self.proximity_config.get('enabled', True)
         self.proximity_distance_miles = self.proximity_config.get('distance_miles', 0.1)
         self.proximity_duration = self.proximity_config.get('duration_seconds', 30)
+        # Opt-in: when True, an aircraft entering the proximity radius preempts
+        # the normal rotation to show the overhead view (the 'flight_tracker_live'
+        # slot). Defaults False so existing installs are unaffected.
+        self.live_priority_enabled = self.config.get('live_priority', False)
         
         # Runtime data
         self.aircraft_data = {}  # ICAO -> aircraft dict (within map_radius_miles)
@@ -244,6 +264,13 @@ class FlightTrackerPlugin(BasePlugin):
 
         # Proximity alert variables (for overhead mode)
         self.proximity_triggered_time = None
+        # Snapshot of the aircraft that last triggered the proximity latch, so the
+        # overhead view keeps showing the same plane for the full alert window even
+        # if it briefly drops out of range.
+        self._proximity_aircraft = None
+        # Set transiently while rendering the live overhead slot so _display_overhead
+        # shows the latched aircraft rather than the current closest.
+        self._active_overhead_aircraft = None
 
         # Fonts
         self.fonts = self._load_fonts()
@@ -284,7 +311,12 @@ class FlightTrackerPlugin(BasePlugin):
             self.logger.info(f"[Flight Tracker] Display: {self.display_width}x{self.display_height}, Data source: FlightRadar24")
         else:
             self.logger.info(f"[Flight Tracker] Display: {self.display_width}x{self.display_height}, Data source: SkyAware ({self.skyaware_url}), FR24 enrichment: {self.fr24_enrichment}")
-    
+
+        # Rotation slots exposed to the framework. The core prefers this over the
+        # manifest's display_modes, giving us per-view rotation + the live slot.
+        self.modes = self._get_available_modes()
+        self.logger.info(f"[Flight Tracker] Rotation modes: {self.modes}")
+
     @property
     def display_width(self) -> int:
         return self._display_manager_ref.matrix.width
@@ -2314,14 +2346,19 @@ class FlightTrackerPlugin(BasePlugin):
             self.logger.warning(f"[Flight Tracker] get_vegas_content() failed: {e}")
             return None
 
-    def display(self, force_clear: bool = False, *, display_mode: Optional[str] = None) -> None:
-        """Display flight tracker content based on display_mode configuration.
+    def display(self, force_clear: bool = False, *, display_mode: Optional[str] = None) -> bool:
+        """Display flight tracker content based on the active slot.
 
         Supports modes: map, overhead, stats, area, flight_tracking, auto.
 
-        The ``display_mode`` parameter is passed by the LEDMatrix framework to
-        indicate which manifest display mode is active.  It maps framework mode
-        names (from manifest ``display_modes``) to our internal mode names.
+        The ``display_mode`` parameter is the framework's active slot name. It is
+        resolved to an internal view via ``_GRANULAR_MODES`` (per-view rotation +
+        the live overhead slot); the bare legacy ``flight_tracker`` slot falls back
+        to the configured ``display_mode``.
+
+        Returns ``True`` when content was rendered and ``False`` when there is
+        nothing to show for the active slot, so the framework skips to the next
+        mode instead of dwelling on a blank screen.
         """
         now = time.time()
         was_hidden = (now - self._last_displayed_time) > self._display_idle_threshold
@@ -2332,49 +2369,70 @@ class FlightTrackerPlugin(BasePlugin):
         aircraft_count = len(self.aircraft_data)
         closest = self.get_closest_aircraft()
 
-        # The framework passes display_mode='flight_tracker' (the single
-        # manifest mode name).  We always use our internal config setting
-        # to decide which view to render (map, overhead, stats, area,
-        # flight_tracking, or auto).
-        mode = self.display_mode
+        # Resolve which internal view to render from the framework's slot name.
+        # Granular slots (flight_tracker_map/_stats/_area/_flight_tracking/_live)
+        # map directly to a view; the bare legacy 'flight_tracker' slot falls back
+        # to the configured display_mode (auto/map/stats/...).
+        granular_view = self._GRANULAR_MODES.get(display_mode)
 
         self.logger.debug(
-            "[Flight Tracker] display() called: configured_mode=%s, framework_mode=%s, resolved=%s, aircraft=%s",
-            self.display_mode, display_mode, mode, aircraft_count,
+            "[Flight Tracker] display() called: configured_mode=%s, framework_mode=%s, granular=%s, aircraft=%s",
+            self.display_mode, display_mode, granular_view, aircraft_count,
         )
-        if mode == 'auto':
-            # Priority interrupts — always show these immediately
-            has_airborne_tracked = any(
-                tf.status == "AIRBORNE" for tf in self.tracked_flight_data.values()
-            )
-            if has_airborne_tracked:
-                mode = 'flight_tracking'
-            elif self.proximity_enabled and closest and closest['distance_miles'] <= self.proximity_distance_miles:
-                mode = 'overhead'
-            else:
-                # Rotate through available modes
-                auto_modes = []
-                if self.aircraft_data:
-                    auto_modes.append('map')
-                    auto_modes.append('area')
-                if self.all_aircraft_data or self.aircraft_data:
-                    auto_modes.append('stats')
-                if not auto_modes:
-                    auto_modes = ['stats']
 
-                now = time.time()
-                if now - self._auto_mode_last_change >= self._auto_rotate_interval:
-                    self._auto_mode_index = (self._auto_mode_index + 1) % len(auto_modes)
-                    self._auto_mode_last_change = now
-
-                mode = auto_modes[self._auto_mode_index % len(auto_modes)]
-
-            self.logger.debug(
-                "[Flight Tracker] Auto mode selection: chosen_mode=%s (aircraft=%s)",
-                mode, aircraft_count,
-            )
+        if granular_view is not None:
+            mode = granular_view
+            if mode == 'overhead':
+                # Live slot: only render while the proximity latch is active, so
+                # the overhead view shows for the full alert window then releases.
+                self._update_proximity_latch()
+                if not self._proximity_active():
+                    return False
+                self._active_overhead_aircraft = self._proximity_aircraft
+            elif not self._view_has_content(mode):
+                # Enabled-but-empty rotation slot — skip so the rotation advances
+                # instead of dwelling on a blank screen.
+                return False
+        elif display_mode and display_mode != 'flight_tracker':
+            # Unknown slot (e.g. the plugin-id fallback when no rotation views are
+            # selected) — nothing to show.
+            return False
         else:
-            self.logger.debug("[Flight Tracker] Manual mode selection: chosen_mode=%s", mode)
+            # Legacy single-slot behavior: choose the view from display_mode.
+            mode = self.display_mode
+            if mode == 'auto':
+                # Priority interrupts — always show these immediately
+                has_airborne_tracked = any(
+                    tf.status == "AIRBORNE" for tf in self.tracked_flight_data.values()
+                )
+                if has_airborne_tracked:
+                    mode = 'flight_tracking'
+                elif self.proximity_enabled and closest and closest['distance_miles'] <= self.proximity_distance_miles:
+                    mode = 'overhead'
+                else:
+                    # Rotate through available modes
+                    auto_modes = []
+                    if self.aircraft_data:
+                        auto_modes.append('map')
+                        auto_modes.append('area')
+                    if self.all_aircraft_data or self.aircraft_data:
+                        auto_modes.append('stats')
+                    if not auto_modes:
+                        auto_modes = ['stats']
+
+                    now = time.time()
+                    if now - self._auto_mode_last_change >= self._auto_rotate_interval:
+                        self._auto_mode_index = (self._auto_mode_index + 1) % len(auto_modes)
+                        self._auto_mode_last_change = now
+
+                    mode = auto_modes[self._auto_mode_index % len(auto_modes)]
+
+                self.logger.debug(
+                    "[Flight Tracker] Auto mode selection: chosen_mode=%s (aircraft=%s)",
+                    mode, aircraft_count,
+                )
+            else:
+                self.logger.debug("[Flight Tracker] Manual mode selection: chosen_mode=%s", mode)
 
         self.logger.info("[Flight Tracker] display(): mode=%s, aircraft=%d", mode, aircraft_count)
 
@@ -2399,7 +2457,13 @@ class FlightTrackerPlugin(BasePlugin):
                 self._renderer.render_error(f"ERR:{mode}")
             except Exception:
                 self.logger.exception("[Flight Tracker] Failed to render error fallback")
-    
+        finally:
+            # Clear the transient overhead override regardless of how rendering went.
+            self._active_overhead_aircraft = None
+
+        return True
+
+
     # -------------------------------------------------------------------------
     # New display modes (delegated to renderer.py)
     # -------------------------------------------------------------------------
@@ -2588,8 +2652,10 @@ class FlightTrackerPlugin(BasePlugin):
         """Display detailed overhead view of closest aircraft."""
         if force_clear:
             self.display_manager.clear()
-        
-        closest = self.get_closest_aircraft()
+
+        # During a live proximity alert, keep showing the latched aircraft (the one
+        # that triggered the alert) even if it has just dropped out of range.
+        closest = self._active_overhead_aircraft or self.get_closest_aircraft()
         if not closest:
             # No aircraft to display
             img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
@@ -2852,17 +2918,82 @@ class FlightTrackerPlugin(BasePlugin):
             record_time=rec_ts if record_data else "",
         )
 
+    def _get_available_modes(self) -> list:
+        """Build the rotation slot list the framework cycles through.
+
+        Backward compatible: when ``rotation_views`` is not configured the plugin
+        exposes the single legacy ``flight_tracker`` slot and renders according to
+        the ``display_mode`` setting (auto/map/stats/...) exactly as before.
+
+        When ``rotation_views`` is configured, each selected view becomes its own
+        rotation slot (``flight_tracker_<view>``). An empty list means the plugin
+        contributes no scroll-through slots. The overhead live slot
+        (``flight_tracker_live``) is appended when proximity preemption is enabled.
+        """
+        rotation_views = self.config.get('rotation_views', None)
+        modes = []
+        if rotation_views is None:
+            modes.append('flight_tracker')
+        else:
+            for view in rotation_views:
+                if view in self._VALID_ROTATION_VIEWS:
+                    modes.append(f'flight_tracker_{view}')
+        if self.proximity_enabled and self.live_priority_enabled:
+            modes.append('flight_tracker_live')
+        return modes
+
+    def _update_proximity_latch(self) -> None:
+        """Latch the proximity alert when an aircraft enters the alert radius.
+
+        Keeps the overhead view "live" for ``proximity_duration`` seconds after the
+        closest aircraft was last within ``proximity_distance_miles``, so a plane
+        passing overhead stays on screen for the full alert window even after it
+        moves out of the radius.
+        """
+        if not self.proximity_enabled:
+            return
+        closest = self.get_closest_aircraft()
+        if closest and closest['distance_miles'] <= self.proximity_distance_miles:
+            self.proximity_triggered_time = time.time()
+            self._proximity_aircraft = closest
+
+    def _proximity_active(self) -> bool:
+        """True while the proximity latch is within its alert window."""
+        if not self.proximity_enabled or self.proximity_triggered_time is None:
+            return False
+        return (time.time() - self.proximity_triggered_time) < self.proximity_duration
+
+    def _view_has_content(self, view: str) -> bool:
+        """Whether a scroll-through view has anything to render right now.
+
+        Used to skip an enabled-but-empty rotation slot so the rotation moves on
+        instead of dwelling on a blank/"No Aircraft" screen.
+        """
+        if view == 'stats':
+            return True
+        if view == 'flight_tracking':
+            return bool(self.tracked_flight_data)
+        # map, area
+        return bool(self.aircraft_data)
+
+    def has_live_priority(self) -> bool:
+        """Whether this plugin should preempt the rotation for overhead aircraft."""
+        return bool(self.live_priority_enabled and self.proximity_enabled)
+
     def has_live_content(self) -> bool:
-        """Check if plugin has live/urgent content (proximity alerts)."""
+        """Live content = an aircraft is (or was recently) within the proximity radius."""
         if not self.proximity_enabled:
             return False
-        
-        closest = self.get_closest_aircraft()
-        if not closest:
-            return False
-        
-        return closest['distance_miles'] <= self.proximity_distance_miles
-    
+        self._update_proximity_latch()
+        return self._proximity_active()
+
+    def get_live_modes(self) -> list:
+        """Return the live slot name when there is overhead content to preempt with."""
+        if self.has_live_priority() and self.has_live_content():
+            return ['flight_tracker_live']
+        return []
+
+
     def validate_config(self) -> bool:
         """Validate plugin configuration."""
         if not super().validate_config():

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -185,11 +185,20 @@ class FlightTrackerPlugin(BasePlugin):
         self.proximity_config = self.config.get('proximity_alert', {})
         self.proximity_enabled = self.proximity_config.get('enabled', True)
         self.proximity_distance_miles = self.proximity_config.get('distance_miles', 0.1)
+        # Hard cap on how long a single overhead flight holds the screen, measured
+        # from when it was locked on (not refreshed while it dwells in the radius).
         self.proximity_duration = self.proximity_config.get('duration_seconds', 30)
+        # After a flight's window ends, suppress the preempt for this long so the
+        # normal rotation (weather/clock/sports) is guaranteed screen time.
+        self.proximity_cooldown = self.proximity_config.get('cooldown_seconds', 30)
         # Opt-in: when True, an aircraft entering the proximity radius preempts
         # the normal rotation to show the overhead view (the 'flight_tracker_live'
         # slot). Defaults False so existing installs are unaffected.
         self.live_priority_enabled = self.config.get('live_priority', False)
+        # Faster fetch cadence while a flight is locked on, so altitude/distance
+        # update smoothly during the overhead window. The ADS-B source is ~1Hz, so
+        # this is safe; idle fetches stay at update_interval.
+        self.live_update_interval = self.config.get('live_update_interval', 2)
         
         # Runtime data
         self.aircraft_data = {}  # ICAO -> aircraft dict (within map_radius_miles)
@@ -262,14 +271,16 @@ class FlightTrackerPlugin(BasePlugin):
         self.last_stat_change = 0
         self.stat_duration = 10  # Show each stat for 10 seconds
 
-        # Proximity alert variables (for overhead mode)
-        self.proximity_triggered_time = None
-        # Snapshot of the aircraft that last triggered the proximity latch, so the
-        # overhead view keeps showing the same plane for the full alert window even
-        # if it briefly drops out of range.
-        self._proximity_aircraft = None
+        # Proximity alert / overhead live-priority state machine (IDLE -> LOCKED ->
+        # COOLDOWN). When a plane enters the radius we lock onto that specific ICAO
+        # and show it for proximity_duration, then enter a cooldown before any other
+        # flight can preempt again.
+        self._lock_icao = None          # ICAO of the flight currently locked on
+        self._lock_start = 0.0          # time the lock was acquired
+        self._lock_aircraft = None      # last-known data for the locked flight
+        self._cooldown_until = 0.0      # preempt suppressed until this time
         # Set transiently while rendering the live overhead slot so _display_overhead
-        # shows the latched aircraft rather than the current closest.
+        # shows the locked aircraft rather than the current closest.
         self._active_overhead_aircraft = None
 
         # Fonts
@@ -2019,7 +2030,11 @@ class FlightTrackerPlugin(BasePlugin):
         current_time = time.time()
         is_visible = (current_time - self._last_displayed_time) < self._display_idle_threshold
 
-        if current_time - self.last_fetch >= self.update_interval:
+        # Fetch faster while a flight is locked on so the overhead view's
+        # altitude/distance stay current; fall back to update_interval when idle.
+        fetch_interval = self.live_update_interval if self._lock_icao is not None else self.update_interval
+
+        if current_time - self.last_fetch >= fetch_interval:
             self.last_fetch = current_time
 
             if self.data_source == 'flightradar24':
@@ -2383,12 +2398,11 @@ class FlightTrackerPlugin(BasePlugin):
         if granular_view is not None:
             mode = granular_view
             if mode == 'overhead':
-                # Live slot: only render while the proximity latch is active, so
-                # the overhead view shows for the full alert window then releases.
-                self._update_proximity_latch()
-                if not self._proximity_active():
+                # Live slot: only render while a flight is locked on. Show that
+                # specific flight (not whatever is currently closest) for its window.
+                if not self._evaluate_proximity():
                     return False
-                self._active_overhead_aircraft = self._proximity_aircraft
+                self._active_overhead_aircraft = self._lock_aircraft
             elif not self._view_has_content(mode):
                 # Enabled-but-empty rotation slot — skip so the rotation advances
                 # instead of dwelling on a blank screen.
@@ -2942,26 +2956,58 @@ class FlightTrackerPlugin(BasePlugin):
             modes.append('flight_tracker_live')
         return modes
 
-    def _update_proximity_latch(self) -> None:
-        """Latch the proximity alert when an aircraft enters the alert radius.
+    def _closest_in_radius(self):
+        """Return (icao, aircraft) for the closest aircraft within the alert radius,
+        or (None, None) if nothing is within ``proximity_distance_miles``."""
+        if not self.aircraft_data:
+            return None, None
+        icao, ac = min(self.aircraft_data.items(), key=lambda kv: kv[1]['distance_miles'])
+        if ac['distance_miles'] <= self.proximity_distance_miles:
+            return icao, ac
+        return None, None
 
-        Keeps the overhead view "live" for ``proximity_duration`` seconds after the
-        closest aircraft was last within ``proximity_distance_miles``, so a plane
-        passing overhead stays on screen for the full alert window even after it
-        moves out of the radius.
+    def _evaluate_proximity(self) -> bool:
+        """Advance the overhead state machine and report whether a flight is live.
+
+        IDLE -> LOCKED: when a plane enters the radius, lock onto that ICAO and show
+            it for ``proximity_duration`` (the hard cap), refreshing its data each
+            cycle so altitude/distance stay current — but never switching to a
+            different (closer) plane mid-window.
+        LOCKED -> COOLDOWN: once the cap elapses, release and suppress the preempt
+            for ``proximity_cooldown`` so the normal rotation gets screen time.
+        COOLDOWN -> IDLE: after the cooldown, the next plane in range can lock on.
+
+        This is the single source of truth for the live state; it has side effects
+        (acquiring/releasing the lock) and is safe to call repeatedly within a cycle.
         """
-        if not self.proximity_enabled:
-            return
-        closest = self.get_closest_aircraft()
-        if closest and closest['distance_miles'] <= self.proximity_distance_miles:
-            self.proximity_triggered_time = time.time()
-            self._proximity_aircraft = closest
-
-    def _proximity_active(self) -> bool:
-        """True while the proximity latch is within its alert window."""
-        if not self.proximity_enabled or self.proximity_triggered_time is None:
+        if not (self.proximity_enabled and self.live_priority_enabled):
             return False
-        return (time.time() - self.proximity_triggered_time) < self.proximity_duration
+        now = time.time()
+
+        if self._lock_icao is not None:
+            # Keep the locked flight's data fresh while it is still tracked.
+            ac = self.aircraft_data.get(self._lock_icao)
+            if ac is not None:
+                self._lock_aircraft = ac
+            # Hold for the full window even if the plane has left the radius, so a
+            # plane that flew over still shows for the configured duration.
+            if now - self._lock_start < self.proximity_duration:
+                return True
+            # Cap reached — release and start the cooldown.
+            self._lock_icao = None
+            self._cooldown_until = now + self.proximity_cooldown
+            return False
+
+        if now < self._cooldown_until:
+            return False
+
+        icao, ac = self._closest_in_radius()
+        if icao is not None:
+            self._lock_icao = icao
+            self._lock_start = now
+            self._lock_aircraft = ac
+            return True
+        return False
 
     def _view_has_content(self, view: str) -> bool:
         """Whether a scroll-through view has anything to render right now.
@@ -2981,11 +3027,8 @@ class FlightTrackerPlugin(BasePlugin):
         return bool(self.live_priority_enabled and self.proximity_enabled)
 
     def has_live_content(self) -> bool:
-        """Live content = an aircraft is (or was recently) within the proximity radius."""
-        if not self.proximity_enabled:
-            return False
-        self._update_proximity_latch()
-        return self._proximity_active()
+        """Live content = a flight is currently locked on (overhead) and not in cooldown."""
+        return self._evaluate_proximity()
 
     def get_live_modes(self) -> list:
         """Return the live slot name when there is overhead content to preempt with."""

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -2663,156 +2663,32 @@ class FlightTrackerPlugin(BasePlugin):
         self.display_manager.update_display()
     
     def _display_overhead(self, force_clear: bool = False) -> None:
-        """Display detailed overhead view of closest aircraft."""
+        """Display the overhead 'card' for the closest aircraft.
+
+        Rendering lives in ``FlightRenderer.render_overhead`` (the modern view
+        home, shared style with the area/stats cards). This wrapper keeps the
+        live-preempt latch logic and feeds the renderer the manager-derived
+        progress/delay fields. Used by both the ``flight_tracker_live`` preempt
+        slot and the legacy ``display_mode: "overhead"``.
+        """
         if force_clear:
             self.display_manager.clear()
 
-        # During a live proximity alert, keep showing the latched aircraft (the one
-        # that triggered the alert) even if it has just dropped out of range.
+        # During a live proximity alert, keep showing the latched aircraft (the
+        # one that triggered the alert) even if it just dropped out of range.
         closest = self._active_overhead_aircraft or self.get_closest_aircraft()
         if not closest:
-            # No aircraft to display
-            img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
-            draw = ImageDraw.Draw(img)
-            self._draw_text_with_outline(draw, "No Aircraft", 
-                                       (self.display_width // 2 - 30, self.display_height // 2 - 4), 
-                                       self.fonts['medium'], fill=(200, 200, 200), outline_color=(0, 0, 0))
-            self.display_manager.image = img.copy()
-            self.display_manager.update_display()
+            self._renderer.render_error("No Aircraft")
             return
-        
-        # Create image
-        img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
-        draw = ImageDraw.Draw(img)
-        
-        # Determine layout based on display size
-        dsize = self._display_size()
-        is_small_display = dsize in ('tiny', 'small')
 
-        # Gather enriched fields for overhead display
-        oh_origin = closest.get('origin') or ''
-        oh_dest = closest.get('destination') or ''
-        oh_airline = closest.get('airline_name') or ''
-        oh_progress = self._compute_flight_progress(closest)
         oh_delay = self._format_delay(closest)
+        self._renderer.render_overhead(
+            closest,
+            progress=self._compute_flight_progress(closest),
+            delay=oh_delay or "",
+            delay_color=self._delay_color(oh_delay) if oh_delay else None,
+        )
 
-        if dsize == 'tiny':
-            # Tiny display (≤64×32): callsign on top, altitude+distance on bottom
-            self._draw_text_smart(draw, closest['callsign'], (1, 1),
-                                self.fonts['data_small'], fill=(255, 255, 255), use_outline=False)
-            line2 = f"{int(closest['altitude'])}ft {closest['distance_miles']:.1f}mi"
-            y2 = self._calculate_line_spacing(self.fonts['data_small']) + 1
-            if y2 < self.display_height:
-                self._draw_text_smart(draw, line2, (1, y2),
-                                    self.fonts['data_small'], fill=closest['color'], use_outline=False)
-            # Route on third line if space
-            if oh_origin and oh_dest:
-                y3 = y2 + self._calculate_line_spacing(self.fonts['data_small'])
-                if y3 < self.display_height:
-                    self._draw_text_smart(draw, f"{oh_origin}-{oh_dest}", (1, y3),
-                                        self.fonts['data_small'], fill=(150, 255, 150), use_outline=False)
-
-        elif is_small_display:
-            # Small display layout (128×32) with dynamic spacing
-            y_offset = 2
-
-            # Line 1: Callsign + optional airline ICAO
-            callsign_text = closest['callsign']
-            if closest.get('airline_icao') and self.display_width > 64:
-                callsign_text = f"{closest['callsign']} {closest['airline_icao']}"
-            self._draw_text_smart(draw, callsign_text, (2, y_offset),
-                                self.fonts['data_medium'], fill=(255, 255, 255), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Line 2: Altitude and Speed
-            self._draw_text_smart(draw, f"ALT:{int(closest['altitude'])}ft", (2, y_offset),
-                                self.fonts['data_small'], fill=closest['color'], use_outline=False)
-            self._draw_text_smart(draw, f"SPD:{int(closest['speed'])}kt", (self.display_width // 2, y_offset),
-                                self.fonts['data_small'], fill=(200, 200, 200), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_small'])
-
-            # Line 3: Distance and Heading
-            self._draw_text_smart(draw, f"DIST:{closest['distance_miles']:.2f}mi", (2, y_offset),
-                                self.fonts['data_small'], fill=(200, 200, 200), use_outline=False)
-            if closest['heading']:
-                self._draw_text_smart(draw, f"HDG:{int(closest['heading'])}°", (self.display_width // 2, y_offset),
-                                    self.fonts['data_small'], fill=(200, 200, 200), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_small'])
-
-            # Line 4: Route or type (only if space)
-            if y_offset + self._calculate_line_spacing(self.fonts['data_small']) <= self.display_height:
-                if oh_origin and oh_dest:
-                    route_text = f"{oh_origin}->{oh_dest}"
-                    if oh_progress is not None:
-                        route_text += f" {int(oh_progress * 100)}%"
-                    self._draw_text_smart(draw, route_text, (2, y_offset),
-                                        self.fonts['data_small'], fill=(150, 255, 150), use_outline=False)
-                else:
-                    self._draw_text_smart(draw, f"TYPE:{closest['aircraft_type']}", (2, y_offset),
-                                        self.fonts['data_small'], fill=(150, 150, 150), use_outline=False)
-        else:
-            # Large display layout (192x96 or bigger) with dynamic spacing
-            y_offset = 4
-
-            # Title
-            self._draw_text_with_outline(draw, "OVERHEAD AIRCRAFT", (self.display_width // 2 - 40, y_offset),
-                                       self.fonts['title_large'], fill=(255, 200, 0), outline_color=(0, 0, 0))
-            y_offset += self._calculate_line_spacing(self.fonts['title_large']) + 4
-
-            # Callsign + airline name (large displays only)
-            callsign_line = f"Callsign: {closest['callsign']}"
-            if oh_airline:
-                callsign_line += f"  ({oh_airline})"
-            self._draw_text_smart(draw, callsign_line, (4, y_offset),
-                                self.fonts['data_large'], fill=(255, 255, 255), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_large'])
-
-            # Altitude
-            self._draw_text_smart(draw, f"Altitude: {int(closest['altitude'])} ft", (4, y_offset),
-                                self.fonts['data_medium'], fill=closest['color'], use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Speed
-            self._draw_text_smart(draw, f"Speed: {int(closest['speed'])} knots", (4, y_offset),
-                                self.fonts['data_medium'], fill=(200, 200, 200), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Distance
-            self._draw_text_smart(draw, f"Distance: {closest['distance_miles']:.2f} miles", (4, y_offset),
-                                self.fonts['data_medium'], fill=(255, 150, 0), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Heading
-            if closest['heading'] and y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                self._draw_text_smart(draw, f"Heading: {int(closest['heading'])}°", (4, y_offset),
-                                    self.fonts['data_medium'], fill=(200, 200, 200), use_outline=False)
-                y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Route + progress
-            if oh_origin and oh_dest and y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                route_text = f"Route: {oh_origin} -> {oh_dest}"
-                if oh_progress is not None:
-                    route_text += f"  ({int(oh_progress * 100)}%)"
-                self._draw_text_smart(draw, route_text, (4, y_offset),
-                                    self.fonts['data_medium'], fill=(150, 255, 150), use_outline=False)
-                y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Delay status
-            if oh_delay and y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                delay_color = self._delay_color(oh_delay)
-                self._draw_text_smart(draw, f"Status: {oh_delay}", (4, y_offset),
-                                    self.fonts['data_medium'], fill=delay_color, use_outline=False)
-                y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Aircraft type (only if there's space)
-            if y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                self._draw_text_smart(draw, f"Type: {closest['aircraft_type']}", (4, y_offset),
-                                    self.fonts['data_medium'], fill=(150, 150, 150), use_outline=False)
-        
-        # Display the image
-        self.display_manager.image = img.copy()
-        self.display_manager.update_display()
-    
     def _display_stats(self, force_clear: bool = False) -> None:
         """Display flight statistics using the renderer's stat card layout.
 

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-01",
+      "version": "1.7.0",
+      "notes": "Overhead live-priority behavior: lock onto the specific flight that enters the radius (no longer hops to whatever is momentarily closest); duration_seconds is now a hard cap measured from lock-on (a lingering plane no longer overstays); add proximity_alert.cooldown_seconds to guarantee the normal rotation screen time after each flight; add live_update_interval for a faster fetch (default 2s) while a flight is locked on so altitude/distance update smoothly.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-01",
       "version": "1.6.0",

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-05-31",
+      "version": "1.5.5",
+      "notes": "Fix adsb.fi data source returning no aircraft: parse the 'aircraft' response key (adsb.fi opendata) in addition to 'ac' (adsb.lol)",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-19",
       "version": "1.5.4",
@@ -86,5 +92,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-19"
+  "last_updated": "2026-05-31"
 }

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-01",
+      "version": "1.6.0",
+      "notes": "Add configurable rotation views (rotation_views: pick which of map/stats/area/flight_tracking cycle, or none) and overhead live-priority preempt (live_priority: a plane entering the proximity radius cuts in to the overhead view for the proximity_alert window, then releases). Empty rotation_views + live_priority gives a blank-until-overhead board. Fully backward compatible: unset rotation_views keeps the legacy single display_mode behavior.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-31",
       "version": "1.5.5",
@@ -92,5 +98,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-31"
+  "last_updated": "2026-06-01"
 }

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-01",
+      "version": "1.8.0",
+      "notes": "Redesign the overhead view as a 'card' and move it into the shared renderer (alongside area/stats). The plane-overhead moment now reads as: airline logo + colored callsign hero, an altitude/speed value strip, a route line with progress, and a heading-arrow + distance badge. Fixes the duplicate airline tag (the old 'UAL360 UAL') and the unrenderable degree glyph in the heading ('HDG:227°'). Layout is size-adaptive: logo and distance label drop out gracefully on very small panels.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-01",
       "version": "1.7.0",

--- a/plugins/ledmatrix-flights/renderer.py
+++ b/plugins/ledmatrix-flights/renderer.py
@@ -9,6 +9,7 @@ Plus the area-mode card renderer for cycling through nearby aircraft.
 """
 
 import logging
+import math
 import os
 import time
 from typing import Any, Dict, Optional
@@ -638,6 +639,178 @@ class FlightRenderer:
 
     def render_area_card_image(self, aircraft, index=0, total_count=1):
         return self._render_area_card_to_image(aircraft, index, total_count)
+
+    # =====================================================================
+    # Overhead Card (single closest / latched aircraft — the live preempt view)
+    # =====================================================================
+
+    @staticmethod
+    def _heading_arrow_points(cx, cy, size, heading):
+        """Polygon points for an arrowhead centered at (cx, cy) pointing toward
+        compass ``heading`` (0=N/up, 90=E/right). Pure geometry — returns [] for
+        a missing/invalid heading so the caller can skip drawing.
+        """
+        try:
+            deg = float(heading) % 360
+        except (TypeError, ValueError):
+            return []
+        rad = math.radians(deg)
+        # Screen space: +y is down, so North (0°) points to (0, -1).
+        fx, fy = math.sin(rad), -math.cos(rad)   # forward unit vector (toward tip)
+        px, py = -fy, fx                         # perpendicular (right of travel)
+        back = size * 0.7                        # how far the base sits behind center
+        half = size * 0.6                        # half-width of the base
+        tip = (cx + fx * size, cy + fy * size)
+        left = (cx - fx * back + px * half, cy - fy * back + py * half)
+        right = (cx - fx * back - px * half, cy - fy * back - py * half)
+        return [tip, left, right]
+
+    def _draw_heading_arrow(self, draw, cx, cy, size, heading, color=(255, 255, 255)):
+        """Draw a filled triangular arrow pointing in the compass ``heading``."""
+        pts = self._heading_arrow_points(cx, cy, size, heading)
+        if pts:
+            draw.polygon(pts, fill=color)
+
+    def _render_overhead_to_image(self, aircraft, progress=None, delay="", delay_color=None):
+        """Hero card for the 'plane overhead now' moment: airline logo, big
+        callsign, route + progress, a heading-arrow badge, and an ALT/SPD/DIST
+        metric strip. Size-adaptive off self.width/height. Returns the image.
+        """
+        w, h = self.width, self.height
+        img = Image.new("RGB", (w, h), (0, 0, 0))
+        draw = ImageDraw.Draw(img)
+
+        if not aircraft:
+            self._draw_centered(draw, "No Aircraft", (h - self._fh(self.font_medium)) // 2,
+                                self.font_medium, self.dim_color)
+            return img
+
+        callsign = aircraft.get("callsign", "---")
+        color = tuple(aircraft.get("color", self.header_color))
+        airline_icao = aircraft.get("airline_icao", "")
+        alt = self._fmt_alt(aircraft.get("altitude"))
+        spd = self._fmt_spd(aircraft.get("speed"))
+        dist = format_distance(aircraft.get("distance_miles"), self.units_legacy)
+        heading = aircraft.get("heading")
+        origin = aircraft.get("origin", "")
+        destination = aircraft.get("destination", "")
+        atype = aircraft.get("aircraft_type", "")
+        has_heading = heading is not None and heading != ""
+
+        # These pixel fonts report inflated getmetrics() line heights (≈13px for an
+        # 8px glyph), which won't stack on a 32px panel. Measure real ink extent and
+        # stack on a tight cursor instead.
+        def _ink(font, sample="ALT0"):
+            bb = draw.textbbox((0, 0), sample, font=font)
+            return bb[1], bb[3] - bb[1]  # (top offset, ink height)
+
+        top_m, ink_m = _ink(self.font_medium)
+        top_s, ink_s = _ink(self.font_small)
+        gap = 1
+
+        # --- Right zone: heading badge. Show the distance under the arrow only
+        # when the badge can be reasonably wide (≤40% of the panel); otherwise
+        # draw an arrow-only badge and fold distance back into the metric strip. ---
+        badge_w = 0
+        dist_in_badge = False
+        if has_heading:
+            want = max(self._tw(draw, dist, self.font_small) + 4, 18)
+            if want <= w * 0.4:
+                badge_w, dist_in_badge = want, True
+            else:
+                badge_w = max(10, min(int(w * 0.22), 18))  # arrow only
+            bx = w - badge_w
+            draw.line([(bx, 1), (bx, h - 2)], fill=(40, 40, 40))
+            if dist_in_badge:
+                arrow_cy = max(ink_s, (h - ink_s) // 2 - 1)
+                self._draw_centered(draw, dist, h - ink_s - 1 - top_s, self.font_small,
+                                    (180, 180, 180), zone_x=bx, zone_w=badge_w)
+            else:
+                arrow_cy = h // 2
+            arrow_sz = max(3, min(badge_w - 4, h // 2) // 2 + 1)
+            self._draw_heading_arrow(draw, bx + badge_w // 2, arrow_cy,
+                                     arrow_sz, heading, color)
+
+        # --- Left zone: airline logo (only when there's width to spare, and capped
+        # so it never dominates), else a small plane sprite, else a bare margin. ---
+        text_x = 2
+        logo = (_load_airline_logo(airline_icao, min(h - 4, 22))
+                if airline_icao and w >= 96 else None)
+        if logo:
+            img.paste(logo, (2, (h - logo.height) // 2), logo)
+            text_x = 2 + logo.width + 3
+            draw.line([(text_x - 2, 1), (text_x - 2, h - 2)], fill=(40, 40, 40))
+        else:
+            sw = self._draw_sprite(draw, 2, (h - 8 * self.sprite_scale) // 2,
+                                   airline_icao=airline_icao, callsign=callsign)
+            if sw:
+                text_x = 2 + sw
+
+        right_edge = w - badge_w - (2 if badge_w else 0)
+        main_w = right_edge - text_x
+
+        # Route, with progress appended only if it fits (never truncate mid-word).
+        route = ""
+        if origin and destination:
+            route = f"{origin}>{destination}"
+            if progress is not None:
+                pct = int(progress * 100)
+                for cand in (f"{route} {pct}%", f"{route}{pct}%"):
+                    if self._tw(draw, cand, self.font_small) <= main_w:
+                        route = cand
+                        break
+        elif atype and atype != "Unknown":
+            route = atype
+
+        # --- Main text zone: callsign hero, metric strip, route, delay. Center the
+        # block vertically so it reads well on both 32px and taller panels. ---
+        metrics = [(alt, color), (spd, (180, 180, 180))]
+        if not dist_in_badge:
+            metrics.append((dist, (180, 180, 180)))
+        planned = [ink_m, ink_s]            # callsign, metric strip (always)
+        if route:
+            planned.append(ink_s)
+        if delay:
+            planned.append(ink_s)
+        block_h = sum(planned) + gap * (len(planned) - 1)
+        iy = max(1, (h - block_h) // 2 + 1)
+
+        # P1: callsign (hero)
+        self._draw(draw, self._truncate(draw, callsign, self.font_medium, main_w),
+                   (text_x, iy - top_m), self.font_medium, color)
+        iy += ink_m + gap
+
+        # P2: metric strip — values only (units disambiguate); altitude colored.
+        if iy + ink_s <= h:
+            x = text_x
+            for value, col in metrics:
+                vw = self._tw(draw, value, self.font_small)
+                if x + vw > right_edge:
+                    break
+                self._draw(draw, value, (x, iy - top_s), self.font_small, col)
+                x += vw + 4
+            iy += ink_s + gap
+
+        # P3: route + progress
+        if route and iy + ink_s <= h:
+            self._draw(draw, self._truncate(draw, route, self.font_small, main_w),
+                       (text_x, iy - top_s), self.font_small, self.route_color)
+            iy += ink_s + gap
+
+        # P4: delay/status, if any space remains
+        if delay and iy + ink_s <= h:
+            self._draw(draw, self._truncate(draw, delay, self.font_small, main_w),
+                       (text_x, iy - top_s), self.font_small, delay_color or (200, 200, 200))
+
+        return img
+
+    def render_overhead(self, aircraft, progress=None, delay="", delay_color=None):
+        img = self._render_overhead_to_image(aircraft, progress, delay, delay_color)
+        self.dm.image = img.copy()
+        self.dm.update_display()
+
+    def render_overhead_image(self, aircraft, progress=None, delay="", delay_color=None):
+        return self._render_overhead_to_image(aircraft, progress, delay, delay_color)
 
     # =====================================================================
     # Stats Cards

--- a/plugins/ledmatrix-flights/test/test_adsbfi_response_key.py
+++ b/plugins/ledmatrix-flights/test/test_adsbfi_response_key.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Regression test for AdsbNetFetcher response-key parsing.
+
+adsb.lol returns aircraft under the "ac" key (ADSBexchange v2 format), but
+adsb.fi's opendata API returns them under "aircraft". The fetcher previously
+read only "ac", so the adsb.fi provider always reported "no aircraft in range".
+
+This test verifies the fetcher accepts BOTH keys.
+"""
+
+import os
+import sys
+from typing import Dict, List
+
+# Make the plugin package importable (fetcher.py imports `from utils import ...`)
+PLUGIN_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+import fetcher  # noqa: E402
+from fetcher import AdsbNetFetcher  # noqa: E402
+
+CENTER_LAT = 47.3223
+CENTER_LON = -122.3126
+ALTITUDE_COLORS: Dict[str, List[int]] = {"0": [255, 100, 0], "40000": [0, 200, 150]}
+
+
+def _fake_aircraft():
+    # Positioned exactly at the center so it is always within radius.
+    return {
+        "hex": "abc123",
+        "flight": "ASA844 ",
+        "t": "A21N",
+        "lat": CENTER_LAT,
+        "lon": CENTER_LON,
+        "alt_baro": 25450,
+        "gs": 410,
+        "track": 180,
+        "r": "N925VA",
+    }
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _run_with_payload(payload) -> int:
+    """Patch requests.get to return `payload`, run a fetch, return aircraft count."""
+    original_get = fetcher.requests.get
+    fetcher.requests.get = lambda *a, **k: _FakeResponse(payload)
+    try:
+        f = AdsbNetFetcher(provider="adsbfi")
+        result = f.fetch(CENTER_LAT, CENTER_LON, 30, ALTITUDE_COLORS)
+        return len(result or {})
+    finally:
+        fetcher.requests.get = original_get
+
+
+def test_adsbfi_aircraft_key():
+    """adsb.fi format: aircraft under 'aircraft' key must be parsed."""
+    count = _run_with_payload({"aircraft": [_fake_aircraft()], "resultCount": 1})
+    assert count == 1, f"expected 1 aircraft from 'aircraft' key, got {count}"
+    print("✓ adsb.fi 'aircraft' key parsed correctly")
+
+
+def test_adsblol_ac_key():
+    """adsb.lol format: aircraft under 'ac' key must still be parsed."""
+    count = _run_with_payload({"ac": [_fake_aircraft()], "total": 1})
+    assert count == 1, f"expected 1 aircraft from 'ac' key, got {count}"
+    print("✓ adsb.lol 'ac' key still parsed correctly")
+
+
+def test_empty_response():
+    """Neither key present → no aircraft (no crash)."""
+    count = _run_with_payload({"now": 0})
+    assert count == 0, f"expected 0 aircraft from empty response, got {count}"
+    print("✓ empty response handled")
+
+
+if __name__ == "__main__":
+    print("AdsbNetFetcher response-key regression test")
+    print("=" * 44)
+    ok = True
+    for t in (test_adsbfi_aircraft_key, test_adsblol_ac_key, test_empty_response):
+        try:
+            t()
+        except AssertionError as e:
+            ok = False
+            print(f"✗ {t.__name__}: {e}")
+    print("=" * 44)
+    print("PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)

--- a/plugins/ledmatrix-flights/test/test_overhead_card.py
+++ b/plugins/ledmatrix-flights/test/test_overhead_card.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the redesigned overhead card (FlightRenderer.render_overhead).
+
+Covers:
+  - Heading-arrow geometry (`_heading_arrow_points`) for the four cardinals and
+    invalid input.
+  - The card renders without error on the 128x32 hardware panel and on a large
+    panel, producing a non-blank image.
+  - The two bugs the redesign fixes can't recur:
+      * the duplicate airline tag ("UAL360 UAL") — the callsign is drawn once and
+        the airline ICAO is never appended to it.
+      * the raw degree glyph in the heading ("HDG:227°") — no "°" is ever drawn
+        (heading goes through format_track / an arrow instead).
+
+Run with the core venv:
+    .venv/bin/python plugins/ledmatrix-flights/test/test_overhead_card.py
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN_DIR))
+
+import PIL.ImageDraw as _ID  # noqa: E402
+from renderer import FlightRenderer  # noqa: E402
+
+
+class _FakeMatrix:
+    def __init__(self, w, h):
+        self.width = w
+        self.height = h
+
+
+class _FakeDM:
+    def __init__(self, w, h):
+        self.matrix = _FakeMatrix(w, h)
+        self.image = None
+
+    def update_display(self):
+        pass
+
+
+def make_renderer(w=128, h=32, config=None):
+    return FlightRenderer(_FakeDM(w, h), {}, config or {})
+
+
+def _aircraft(**over):
+    ac = {
+        "callsign": "UAL360",
+        "airline_icao": "UAL",
+        "altitude": 2725,
+        "speed": 163,
+        "distance_miles": 0.86,
+        "heading": 227,
+        "origin": "DEN",
+        "destination": "SEA",
+        "aircraft_type": "B738",
+        "color": (0, 200, 255),
+    }
+    ac.update(over)
+    return ac
+
+
+def _capture_text(fn):
+    """Run fn() while recording every string passed to ImageDraw.text."""
+    captured = []
+    orig = _ID.ImageDraw.text
+
+    def rec(self, xy, text="", *a, **k):
+        captured.append(text)
+        return orig(self, xy, text, *a, **k)
+
+    _ID.ImageDraw.text = rec
+    try:
+        fn()
+    finally:
+        _ID.ImageDraw.text = orig
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Heading-arrow geometry
+# ---------------------------------------------------------------------------
+
+def test_arrow_points_north_points_up():
+    # 0deg = North = up: tip is above the center (smaller y).
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 0)
+    assert tip[1] < 10 and abs(tip[0] - 10) < 0.01, tip
+
+
+def test_arrow_points_east_points_right():
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 90)
+    assert tip[0] > 10 and abs(tip[1] - 10) < 0.01, tip
+
+
+def test_arrow_points_south_points_down():
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 180)
+    assert tip[1] > 10 and abs(tip[0] - 10) < 0.01, tip
+
+
+def test_arrow_points_west_points_left():
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 270)
+    assert tip[0] < 10 and abs(tip[1] - 10) < 0.01, tip
+
+
+def test_arrow_points_intercardinals():
+    # Tip must land in the correct quadrant for the four intercardinals.
+    cases = {45: (1, -1), 135: (1, 1), 225: (-1, 1), 315: (-1, -1)}  # (sign x, sign y)
+    for hdg, (sx, sy) in cases.items():
+        tip, *_ = FlightRenderer._heading_arrow_points(0, 0, 16, hdg)
+        assert (tip[0] > 0) == (sx > 0) and (tip[1] > 0) == (sy > 0), (hdg, tip)
+
+
+def test_arrow_points_invalid_heading_empty():
+    assert FlightRenderer._heading_arrow_points(10, 10, 5, None) == []
+    assert FlightRenderer._heading_arrow_points(10, 10, 5, "") == []
+    assert FlightRenderer._heading_arrow_points(10, 10, 5, "abc") == []
+
+
+# ---------------------------------------------------------------------------
+# Card rendering
+# ---------------------------------------------------------------------------
+
+def test_renders_128x32_nonblank():
+    r = make_renderer(128, 32)
+    img = r.render_overhead_image(_aircraft(), progress=0.99, delay="")
+    assert img.size == (128, 32)
+    assert img.getbbox() is not None, "card rendered fully blank"
+
+
+def test_renders_large_nonblank():
+    r = make_renderer(256, 64)
+    img = r.render_overhead_image(_aircraft(), progress=0.5, delay="DELAYED 12m")
+    assert img.size == (256, 64)
+    assert img.getbbox() is not None
+
+
+def test_renders_without_heading_or_route():
+    # GA tail number: no airline logo, no route, no heading badge.
+    r = make_renderer(128, 32)
+    img = r.render_overhead_image(
+        _aircraft(callsign="N12345", airline_icao="", origin="", destination="",
+                  heading=None)
+    )
+    assert img.getbbox() is not None
+
+
+def test_empty_aircraft_is_safe():
+    r = make_renderer(128, 32)
+    img = r.render_overhead_image(None)
+    assert img.size == (128, 32)
+
+
+# ---------------------------------------------------------------------------
+# Regressions: no doubled airline, no degree glyph
+# ---------------------------------------------------------------------------
+
+def test_callsign_not_doubled():
+    r = make_renderer(128, 32)
+    texts = _capture_text(lambda: r.render_overhead_image(_aircraft(), progress=0.99))
+    joined = " ".join(texts)
+    # The old layout drew "UAL360 UAL"; the redesign must not.
+    assert "UAL360 UAL" not in joined, joined
+    # And the callsign itself is still shown.
+    assert any(t == "UAL360" for t in texts), texts
+
+
+def test_no_degree_glyph_drawn():
+    # Heading is shown as an arrow, never as "227°" text — the old bug rendered a
+    # degree glyph the PressStart font can't draw.
+    r = make_renderer(128, 32)
+    texts = _capture_text(lambda: r.render_overhead_image(_aircraft(), progress=0.99))
+    assert all("°" not in t for t in texts), texts
+    # The badge conveys distance as text alongside the heading arrow.
+    assert any("mi" in t for t in texts), texts
+
+
+def run():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # pragma: no cover
+            failures += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return failures == 0
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)

--- a/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+++ b/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
@@ -59,11 +59,17 @@ def make_plugin(config):
     p.proximity_enabled = pc.get("enabled", True)
     p.proximity_distance_miles = pc.get("distance_miles", 0.1)
     p.proximity_duration = pc.get("duration_seconds", 30)
+    p.proximity_cooldown = pc.get("cooldown_seconds", 30)
     p.live_priority_enabled = config.get("live_priority", False)
+    p.update_interval = config.get("update_interval", 5)
+    p.live_update_interval = config.get("live_update_interval", 2)
 
     p.display_mode = config.get("display_mode", "auto")
-    p.proximity_triggered_time = None
-    p._proximity_aircraft = None
+    # Overhead state machine
+    p._lock_icao = None
+    p._lock_start = 0.0
+    p._lock_aircraft = None
+    p._cooldown_until = 0.0
     p._active_overhead_aircraft = None
 
     p.aircraft_data = {}
@@ -80,8 +86,13 @@ def make_plugin(config):
     return p
 
 
-def _aircraft(distance_miles):
-    return {"icao": "abc123", "callsign": "TEST123", "distance_miles": distance_miles}
+def _aircraft(distance_miles, icao="abc123", callsign="TEST123"):
+    return {"icao": icao, "callsign": callsign, "distance_miles": distance_miles}
+
+
+def _set(p, *aircraft):
+    """Replace aircraft_data with the given aircraft (keyed by icao)."""
+    p.aircraft_data = {a["icao"]: a for a in aircraft}
 
 
 # ---------------------------------------------------------------------------
@@ -129,43 +140,120 @@ def test_rotation_views_plus_overhead():
 
 
 # ---------------------------------------------------------------------------
-# Proximity latch / live content
+# Overhead state machine: lock-on, hard cap, cooldown
 # ---------------------------------------------------------------------------
 
-def test_proximity_latch_holds_for_window():
-    p = make_plugin({"live_priority": True,
-                     "proximity_alert": {"distance_miles": 0.1, "duration_seconds": 20}})
-    # Aircraft enters the radius.
-    p.aircraft_data = {"abc123": _aircraft(0.05)}
+def _cfg(**proximity):
+    base = {"distance_miles": 0.5, "duration_seconds": 20, "cooldown_seconds": 30}
+    base.update(proximity)
+    return {"live_priority": True, "proximity_alert": base}
+
+
+def test_lock_on_acquires_and_reports_live():
+    p = make_plugin(_cfg())
+    _set(p, _aircraft(0.3, icao="AAA", callsign="AAL1"))
     assert p.has_live_priority() is True
     assert p.has_live_content() is True
     assert p.get_live_modes() == ["flight_tracker_live"]
-    assert p._proximity_aircraft is not None
+    assert p._lock_icao == "AAA"
+    assert p._lock_aircraft["callsign"] == "AAL1"
 
-    # Aircraft leaves the radius but we are still inside the alert window:
-    # the latch keeps the plugin "live".
-    p.aircraft_data = {"abc123": _aircraft(5.0)}
+
+def test_lock_on_does_not_switch_to_closer_plane():
+    # Once locked, a newly-closer plane must NOT steal the screen mid-window.
+    p = make_plugin(_cfg())
+    _set(p, _aircraft(0.3, icao="AAA", callsign="AAL1"))
     assert p.has_live_content() is True
+    assert p._lock_icao == "AAA"
+    # A closer plane appears; the lock stays on AAA.
+    _set(p, _aircraft(0.3, icao="AAA", callsign="AAL1"),
+            _aircraft(0.05, icao="BBB", callsign="BAW2"))
+    assert p.has_live_content() is True
+    assert p._lock_icao == "AAA"
+    assert p._lock_aircraft["callsign"] == "AAL1"
 
-    # Once the window elapses, live content clears.
-    p.proximity_triggered_time = time.time() - 999
+
+def test_hard_cap_releases_even_if_plane_lingers():
+    # The flight is held only for duration_seconds, even if it stays in the radius.
+    p = make_plugin(_cfg(duration_seconds=20))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    # Simulate the cap elapsing while the plane is still overhead.
+    p._lock_start = time.time() - 21
+    assert p.has_live_content() is False          # released
+    assert p._lock_icao is None
+    assert p._cooldown_until > time.time()        # cooldown started
+
+
+def test_window_holds_after_plane_leaves_radius():
+    # A plane that flew over still shows for the full window after leaving the radius.
+    p = make_plugin(_cfg(duration_seconds=20))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    # Plane leaves the radius but we are still inside the window.
+    _set(p, _aircraft(5.0, icao="AAA"))
+    assert p.has_live_content() is True
+    assert p._lock_icao == "AAA"
+
+
+def test_cooldown_blocks_repreempt():
+    p = make_plugin(_cfg(duration_seconds=20, cooldown_seconds=30))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    p._lock_start = time.time() - 21
+    assert p.has_live_content() is False          # released into cooldown
+    # Another plane is overhead, but cooldown suppresses the preempt.
+    _set(p, _aircraft(0.05, icao="BBB"))
     assert p.has_live_content() is False
     assert p.get_live_modes() == []
+    # After cooldown, the next plane can lock on.
+    p._cooldown_until = time.time() - 1
+    assert p.has_live_content() is True
+    assert p._lock_icao == "BBB"
+
+
+def test_cooldown_zero_allows_immediate_relock():
+    p = make_plugin(_cfg(duration_seconds=20, cooldown_seconds=0))
+    _set(p, _aircraft(0.1, icao="AAA"))
+    assert p.has_live_content() is True
+    p._lock_start = time.time() - 21
+    assert p.has_live_content() is False          # released, no cooldown
+    _set(p, _aircraft(0.1, icao="BBB"))
+    assert p.has_live_content() is True
+    assert p._lock_icao == "BBB"
 
 
 def test_live_priority_requires_optin():
     # Without live_priority, a close aircraft never preempts the rotation.
-    p = make_plugin({"proximity_alert": {"distance_miles": 0.1}})
-    p.aircraft_data = {"abc123": _aircraft(0.05)}
+    p = make_plugin({"proximity_alert": {"distance_miles": 0.5}})
+    _set(p, _aircraft(0.05))
     assert p.has_live_priority() is False
+    assert p.has_live_content() is False
     assert p.get_live_modes() == []
+    assert p._lock_icao is None
 
 
 def test_proximity_disabled_has_no_live_content():
     p = make_plugin({"live_priority": True, "proximity_alert": {"enabled": False}})
-    p.aircraft_data = {"abc123": _aircraft(0.01)}
+    _set(p, _aircraft(0.01))
     assert p.has_live_content() is False
     assert p.has_live_priority() is False
+
+
+# ---------------------------------------------------------------------------
+# Dynamic fetch interval
+# ---------------------------------------------------------------------------
+
+def test_fetch_interval_speeds_up_when_locked():
+    p = make_plugin(_cfg(distance_miles=0.5))
+    p.update_interval = 5
+    p.live_update_interval = 2
+    # Idle: the effective interval is the normal one.
+    assert (p.live_update_interval if p._lock_icao is not None else p.update_interval) == 5
+    _set(p, _aircraft(0.1, icao="AAA"))
+    p.has_live_content()  # acquire lock
+    assert p._lock_icao == "AAA"
+    assert (p.live_update_interval if p._lock_icao is not None else p.update_interval) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+++ b/plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Regression tests for configurable rotation views + overhead live-priority preempt.
+
+Covers:
+  - `_get_available_modes`: legacy single slot, per-view rotation slots, the
+    "none" (empty) case, invalid-view filtering, and the overhead live slot.
+  - The proximity latch: an aircraft entering the radius makes the plugin "live"
+    for the full proximity window, even after it leaves the radius.
+  - `display()` returning False (skip) for an inactive live slot, an empty
+    rotation slot, and an unknown slot name.
+
+Run with the core venv:
+    .venv/bin/python plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
+"""
+
+import logging
+import os
+import sys
+import time
+import types
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN_DIR))
+
+# Stub the core's BasePlugin so `manager` imports without the full LEDMatrix core
+# tree on the path. We bypass __init__ in these tests, so a no-op base is enough.
+if "src.plugin_system.base_plugin" not in sys.modules:
+    src_mod = types.ModuleType("src")
+    plugin_system_mod = types.ModuleType("src.plugin_system")
+    base_plugin_mod = types.ModuleType("src.plugin_system.base_plugin")
+
+    class _StubBasePlugin:  # pragma: no cover - trivial stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    base_plugin_mod.BasePlugin = _StubBasePlugin
+    src_mod.plugin_system = plugin_system_mod
+    plugin_system_mod.base_plugin = base_plugin_mod
+    sys.modules["src"] = src_mod
+    sys.modules["src.plugin_system"] = plugin_system_mod
+    sys.modules["src.plugin_system.base_plugin"] = base_plugin_mod
+
+logging.basicConfig(level=logging.CRITICAL)
+
+from manager import FlightTrackerPlugin  # noqa: E402
+
+
+def make_plugin(config):
+    """Build a FlightTrackerPlugin with only the attributes the units-under-test
+    need, bypassing the heavy real __init__ (which requires display/cache managers).
+    """
+    p = FlightTrackerPlugin.__new__(FlightTrackerPlugin)
+    p.config = config
+    p.logger = logging.getLogger("flight-test")
+
+    pc = config.get("proximity_alert", {})
+    p.proximity_enabled = pc.get("enabled", True)
+    p.proximity_distance_miles = pc.get("distance_miles", 0.1)
+    p.proximity_duration = pc.get("duration_seconds", 30)
+    p.live_priority_enabled = config.get("live_priority", False)
+
+    p.display_mode = config.get("display_mode", "auto")
+    p.proximity_triggered_time = None
+    p._proximity_aircraft = None
+    p._active_overhead_aircraft = None
+
+    p.aircraft_data = {}
+    p.all_aircraft_data = {}
+    p.tracked_flight_data = {}
+
+    # display() preamble attrs
+    p._last_displayed_time = 0.0
+    p._display_idle_threshold = 30.0
+    p.fr24_enrichment = False
+    p.last_fr24_enrichment = 0.0
+
+    p.modes = p._get_available_modes()
+    return p
+
+
+def _aircraft(distance_miles):
+    return {"icao": "abc123", "callsign": "TEST123", "distance_miles": distance_miles}
+
+
+# ---------------------------------------------------------------------------
+# _get_available_modes
+# ---------------------------------------------------------------------------
+
+def test_legacy_single_slot():
+    p = make_plugin({})  # no rotation_views, live_priority off
+    assert p.modes == ["flight_tracker"], p.modes
+
+
+def test_legacy_with_overhead_priority():
+    p = make_plugin({"live_priority": True})
+    assert p.modes == ["flight_tracker", "flight_tracker_live"], p.modes
+
+
+def test_rotation_views_subset_preserves_order():
+    p = make_plugin({"rotation_views": ["stats", "map"]})
+    assert p.modes == ["flight_tracker_stats", "flight_tracker_map"], p.modes
+
+
+def test_rotation_views_filters_invalid_and_overhead():
+    # 'overhead' and unknown views are not valid rotation views.
+    p = make_plugin({"rotation_views": ["map", "overhead", "bogus", "area"]})
+    assert p.modes == ["flight_tracker_map", "flight_tracker_area"], p.modes
+
+
+def test_none_rotation_with_overhead_only():
+    p = make_plugin({"rotation_views": [], "live_priority": True})
+    assert p.modes == ["flight_tracker_live"], p.modes
+
+
+def test_none_rotation_without_priority_is_empty():
+    p = make_plugin({"rotation_views": []})
+    assert p.modes == [], p.modes
+
+
+def test_rotation_views_plus_overhead():
+    p = make_plugin({"rotation_views": ["map", "stats"], "live_priority": True})
+    assert p.modes == [
+        "flight_tracker_map",
+        "flight_tracker_stats",
+        "flight_tracker_live",
+    ], p.modes
+
+
+# ---------------------------------------------------------------------------
+# Proximity latch / live content
+# ---------------------------------------------------------------------------
+
+def test_proximity_latch_holds_for_window():
+    p = make_plugin({"live_priority": True,
+                     "proximity_alert": {"distance_miles": 0.1, "duration_seconds": 20}})
+    # Aircraft enters the radius.
+    p.aircraft_data = {"abc123": _aircraft(0.05)}
+    assert p.has_live_priority() is True
+    assert p.has_live_content() is True
+    assert p.get_live_modes() == ["flight_tracker_live"]
+    assert p._proximity_aircraft is not None
+
+    # Aircraft leaves the radius but we are still inside the alert window:
+    # the latch keeps the plugin "live".
+    p.aircraft_data = {"abc123": _aircraft(5.0)}
+    assert p.has_live_content() is True
+
+    # Once the window elapses, live content clears.
+    p.proximity_triggered_time = time.time() - 999
+    assert p.has_live_content() is False
+    assert p.get_live_modes() == []
+
+
+def test_live_priority_requires_optin():
+    # Without live_priority, a close aircraft never preempts the rotation.
+    p = make_plugin({"proximity_alert": {"distance_miles": 0.1}})
+    p.aircraft_data = {"abc123": _aircraft(0.05)}
+    assert p.has_live_priority() is False
+    assert p.get_live_modes() == []
+
+
+def test_proximity_disabled_has_no_live_content():
+    p = make_plugin({"live_priority": True, "proximity_alert": {"enabled": False}})
+    p.aircraft_data = {"abc123": _aircraft(0.01)}
+    assert p.has_live_content() is False
+    assert p.has_live_priority() is False
+
+
+# ---------------------------------------------------------------------------
+# display() skip behavior (returns False -> framework rotates on)
+# ---------------------------------------------------------------------------
+
+def test_display_live_slot_skips_when_inactive():
+    p = make_plugin({"live_priority": True})
+    p.aircraft_data = {"abc123": _aircraft(5.0)}  # nothing overhead
+    assert p.display(display_mode="flight_tracker_live") is False
+
+
+def test_display_empty_rotation_view_skips():
+    p = make_plugin({"rotation_views": ["map"]})
+    p.aircraft_data = {}  # empty map -> skip
+    assert p.display(display_mode="flight_tracker_map") is False
+
+
+def test_display_unknown_slot_skips():
+    p = make_plugin({"rotation_views": []})
+    # The plugin-id fallback slot the core injects when modes is empty.
+    assert p.display(display_mode="ledmatrix-flights") is False
+
+
+# ---------------------------------------------------------------------------
+# _view_has_content
+# ---------------------------------------------------------------------------
+
+def test_view_has_content():
+    p = make_plugin({})
+    assert p._view_has_content("stats") is True  # stats always has something
+    assert p._view_has_content("map") is False
+    assert p._view_has_content("flight_tracking") is False
+    p.aircraft_data = {"abc123": _aircraft(2.0)}
+    assert p._view_has_content("map") is True
+    assert p._view_has_content("area") is True
+
+
+def run():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # pragma: no cover
+            failures += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return failures == 0
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)


### PR DESCRIPTION
## What & why

The overhead live-priority view (and the legacy `display_mode: \"overhead\"`) was the last flight view still hand-rolled in `manager.py` with its own draw calls, instead of sharing `renderer.py`'s helpers like `area`/`stats`/`flight_tracking`. This moves it into `FlightRenderer.render_overhead` (a hero sibling of the area card) and reduces `_display_overhead` to a thin wrapper that keeps the live-preempt latch and feeds in progress/delay.

The redesigned card reads the "plane overhead now" moment at a glance: **airline logo** (plane-sprite fallback) + a **colored callsign hero**, an **altitude/speed value strip**, a **route line with progress**, and a **heading-arrow + distance badge**. Sharing the renderer also means it reuses logo loading, `format_track`, and the per-metric unit formatting the other cards already use.

It also fixes two long-standing bugs in this view:
- the **duplicate airline tag** — US callsigns rendered as `UAL360 UAL` (callsign already starts with the ICAO)
- the **unrenderable degree glyph** in the heading (`HDG:227°` → the PressStart font has no `°`); heading is now an arrow, and any heading text routes through `format_track`

## Screenshots

Layout is size-adaptive — logo and the badge's distance label drop out gracefully on tiny panels, and the row block centers vertically on taller ones.

**128×32** (the common 2×1 panel):

![128x32](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/overhead-screenshots/screenshots/overhead/overhead-128x32.png)

**64×32** (single panel — degrades: truncates, plane-sprite instead of logo, arrow-only badge):

![64x32](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/overhead-screenshots/screenshots/overhead/overhead-64x32.png)

**256×64** (large panel — logo capped, block centered, distance label shown):

![256x64](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/overhead-screenshots/screenshots/overhead/overhead-256x64.png)

## Tests

- New `test/test_overhead_card.py`: heading-arrow geometry (cardinals + intercardinals + invalid), multi-size render smoke tests, and regressions for the doubled callsign and the degree glyph.
- Existing `test/test_rotation_views_and_overhead.py` still green (the preempt/latch logic is unchanged).

Run:
```
.venv/bin/python plugins/ledmatrix-flights/test/test_overhead_card.py
.venv/bin/python plugins/ledmatrix-flights/test/test_rotation_views_and_overhead.py
```

Manifest bumped 1.7.0 → 1.8.0; `plugins.json` synced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Baseball Scoreboard (v1.6.2)**
* **Bug Fixes**
  * Improved test mode handling to prevent simulated game states from being overwritten.

**LED Matrix Flights (v1.8.0)**
* **New Features**
  * Added overhead hero-card display for closest tracked aircraft.
  * Configurable live update polling intervals.
  * Custom rotation view selection.
  * Proximity alert cooldown suppression windows.
  * Multi-source flight data provider support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->