### PR TITLE
refactor(flights): move overhead view into renderer + redesign as a card

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -334,7 +334,7 @@
       "last_updated": "2026-06-01",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.7.0"
+      "latest_version": "1.8.2"
     },
     {
       "id": "march-madness",

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -2673,156 +2673,32 @@ class FlightTrackerPlugin(BasePlugin):
         self.display_manager.update_display()
     
     def _display_overhead(self, force_clear: bool = False) -> None:
-        """Display detailed overhead view of closest aircraft."""
+        """Display the overhead 'card' for the closest aircraft.
+
+        Rendering lives in ``FlightRenderer.render_overhead`` (the modern view
+        home, shared style with the area/stats cards). This wrapper keeps the
+        live-preempt latch logic and feeds the renderer the manager-derived
+        progress/delay fields. Used by both the ``flight_tracker_live`` preempt
+        slot and the legacy ``display_mode: "overhead"``.
+        """
         if force_clear:
             self.display_manager.clear()
 
-        # During a live proximity alert, keep showing the latched aircraft (the one
-        # that triggered the alert) even if it has just dropped out of range.
+        # During a live proximity alert, keep showing the latched aircraft (the
+        # one that triggered the alert) even if it just dropped out of range.
         closest = self._active_overhead_aircraft or self.get_closest_aircraft()
         if not closest:
-            # No aircraft to display
-            img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
-            draw = ImageDraw.Draw(img)
-            self._draw_text_with_outline(draw, "No Aircraft", 
-                                       (self.display_width // 2 - 30, self.display_height // 2 - 4), 
-                                       self.fonts['medium'], fill=(200, 200, 200), outline_color=(0, 0, 0))
-            self.display_manager.image = img.copy()
-            self.display_manager.update_display()
+            self._renderer.render_error("No Aircraft")
             return
-        
-        # Create image
-        img = Image.new('RGB', (self.display_width, self.display_height), (0, 0, 0))
-        draw = ImageDraw.Draw(img)
-        
-        # Determine layout based on display size
-        dsize = self._display_size()
-        is_small_display = dsize in ('tiny', 'small')
 
-        # Gather enriched fields for overhead display
-        oh_origin = closest.get('origin') or ''
-        oh_dest = closest.get('destination') or ''
-        oh_airline = closest.get('airline_name') or ''
-        oh_progress = self._compute_flight_progress(closest)
         oh_delay = self._format_delay(closest)
+        self._renderer.render_overhead(
+            closest,
+            progress=self._compute_flight_progress(closest),
+            delay=oh_delay or "",
+            delay_color=self._delay_color(oh_delay) if oh_delay else None,
+        )
 
-        if dsize == 'tiny':
-            # Tiny display (≤64×32): callsign on top, altitude+distance on bottom
-            self._draw_text_smart(draw, closest['callsign'], (1, 1),
-                                self.fonts['data_small'], fill=(255, 255, 255), use_outline=False)
-            line2 = f"{int(closest['altitude'])}ft {closest['distance_miles']:.1f}mi"
-            y2 = self._calculate_line_spacing(self.fonts['data_small']) + 1
-            if y2 < self.display_height:
-                self._draw_text_smart(draw, line2, (1, y2),
-                                    self.fonts['data_small'], fill=closest['color'], use_outline=False)
-            # Route on third line if space
-            if oh_origin and oh_dest:
-                y3 = y2 + self._calculate_line_spacing(self.fonts['data_small'])
-                if y3 < self.display_height:
-                    self._draw_text_smart(draw, f"{oh_origin}-{oh_dest}", (1, y3),
-                                        self.fonts['data_small'], fill=(150, 255, 150), use_outline=False)
-
-        elif is_small_display:
-            # Small display layout (128×32) with dynamic spacing
-            y_offset = 2
-
-            # Line 1: Callsign + optional airline ICAO
-            callsign_text = closest['callsign']
-            if closest.get('airline_icao') and self.display_width > 64:
-                callsign_text = f"{closest['callsign']} {closest['airline_icao']}"
-            self._draw_text_smart(draw, callsign_text, (2, y_offset),
-                                self.fonts['data_medium'], fill=(255, 255, 255), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Line 2: Altitude and Speed
-            self._draw_text_smart(draw, f"ALT:{int(closest['altitude'])}ft", (2, y_offset),
-                                self.fonts['data_small'], fill=closest['color'], use_outline=False)
-            self._draw_text_smart(draw, f"SPD:{int(closest['speed'])}kt", (self.display_width // 2, y_offset),
-                                self.fonts['data_small'], fill=(200, 200, 200), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_small'])
-
-            # Line 3: Distance and Heading
-            self._draw_text_smart(draw, f"DIST:{closest['distance_miles']:.2f}mi", (2, y_offset),
-                                self.fonts['data_small'], fill=(200, 200, 200), use_outline=False)
-            if closest['heading']:
-                self._draw_text_smart(draw, f"HDG:{int(closest['heading'])}°", (self.display_width // 2, y_offset),
-                                    self.fonts['data_small'], fill=(200, 200, 200), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_small'])
-
-            # Line 4: Route or type (only if space)
-            if y_offset + self._calculate_line_spacing(self.fonts['data_small']) <= self.display_height:
-                if oh_origin and oh_dest:
-                    route_text = f"{oh_origin}->{oh_dest}"
-                    if oh_progress is not None:
-                        route_text += f" {int(oh_progress * 100)}%"
-                    self._draw_text_smart(draw, route_text, (2, y_offset),
-                                        self.fonts['data_small'], fill=(150, 255, 150), use_outline=False)
-                else:
-                    self._draw_text_smart(draw, f"TYPE:{closest['aircraft_type']}", (2, y_offset),
-                                        self.fonts['data_small'], fill=(150, 150, 150), use_outline=False)
-        else:
-            # Large display layout (192x96 or bigger) with dynamic spacing
-            y_offset = 4
-
-            # Title
-            self._draw_text_with_outline(draw, "OVERHEAD AIRCRAFT", (self.display_width // 2 - 40, y_offset),
-                                       self.fonts['title_large'], fill=(255, 200, 0), outline_color=(0, 0, 0))
-            y_offset += self._calculate_line_spacing(self.fonts['title_large']) + 4
-
-            # Callsign + airline name (large displays only)
-            callsign_line = f"Callsign: {closest['callsign']}"
-            if oh_airline:
-                callsign_line += f"  ({oh_airline})"
-            self._draw_text_smart(draw, callsign_line, (4, y_offset),
-                                self.fonts['data_large'], fill=(255, 255, 255), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_large'])
-
-            # Altitude
-            self._draw_text_smart(draw, f"Altitude: {int(closest['altitude'])} ft", (4, y_offset),
-                                self.fonts['data_medium'], fill=closest['color'], use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Speed
-            self._draw_text_smart(draw, f"Speed: {int(closest['speed'])} knots", (4, y_offset),
-                                self.fonts['data_medium'], fill=(200, 200, 200), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Distance
-            self._draw_text_smart(draw, f"Distance: {closest['distance_miles']:.2f} miles", (4, y_offset),
-                                self.fonts['data_medium'], fill=(255, 150, 0), use_outline=False)
-            y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Heading
-            if closest['heading'] and y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                self._draw_text_smart(draw, f"Heading: {int(closest['heading'])}°", (4, y_offset),
-                                    self.fonts['data_medium'], fill=(200, 200, 200), use_outline=False)
-                y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Route + progress
-            if oh_origin and oh_dest and y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                route_text = f"Route: {oh_origin} -> {oh_dest}"
-                if oh_progress is not None:
-                    route_text += f"  ({int(oh_progress * 100)}%)"
-                self._draw_text_smart(draw, route_text, (4, y_offset),
-                                    self.fonts['data_medium'], fill=(150, 255, 150), use_outline=False)
-                y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Delay status
-            if oh_delay and y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                delay_color = self._delay_color(oh_delay)
-                self._draw_text_smart(draw, f"Status: {oh_delay}", (4, y_offset),
-                                    self.fonts['data_medium'], fill=delay_color, use_outline=False)
-                y_offset += self._calculate_line_spacing(self.fonts['data_medium'])
-
-            # Aircraft type (only if there's space)
-            if y_offset + self._calculate_line_spacing(self.fonts['data_medium']) <= self.display_height:
-                self._draw_text_smart(draw, f"Type: {closest['aircraft_type']}", (4, y_offset),
-                                    self.fonts['data_medium'], fill=(150, 150, 150), use_outline=False)
-        
-        # Display the image
-        self.display_manager.image = img.copy()
-        self.display_manager.update_display()
-    
     def _display_stats(self, force_clear: bool = False) -> None:
         """Display flight statistics using the renderer's stat card layout.
 

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.7.0",
+  "version": "1.8.2",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,12 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-02",
+      "version": "1.8.2",
+      "notes": "Redesign the overhead (plane-overhead / live-priority) view as a size-adaptive 'card' and move it into the shared renderer alongside area/stats. Compact 128x32: airline logo + colored callsign hero, altitude/speed value strip, route + progress, and a heading-arrow + distance badge. Narrow (<96px wide): drop the logo and badge, full-width text. Spacious (>=48px tall, e.g. 256x64): large font, tall logo, inline heading arrow, metric values justified across the width, and flight progress as a bar across the bottom with a triangle marker. Logo width is capped so wide wordmark logos (e.g. SkyWest) don't crowd the text; when there's no logo the friendly airline name is shown next to the callsign. Fixes the duplicate airline tag (the old 'UAL360 UAL') and the unrenderable degree glyph in the heading ('HDG:227deg').",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-01",
       "version": "1.7.0",

--- a/plugins/ledmatrix-flights/renderer.py
+++ b/plugins/ledmatrix-flights/renderer.py
@@ -9,6 +9,7 @@ Plus the area-mode card renderer for cycling through nearby aircraft.
 """
 
 import logging
+import math
 import os
 import time
 from typing import Any, Dict, Optional
@@ -60,9 +61,13 @@ _LOGO_DIR_CANDIDATES = [
 _logo_cache: Dict[str, Optional[Image.Image]] = {}
 
 
-def _load_airline_logo(icao: str, max_h: int) -> Optional[Image.Image]:
-    """Load and scale an airline logo PNG. Returns RGBA image or None."""
-    key = f"{icao}_{max_h}"
+def _load_airline_logo(icao: str, max_h: int, max_w: Optional[int] = None) -> Optional[Image.Image]:
+    """Load and scale an airline logo PNG to fit within (max_w, max_h), preserving
+    aspect. ``max_w`` defaults to 2*max_h; pass a tighter cap so wide wordmark logos
+    (e.g. SkyWest) don't crowd out the text. Returns RGBA image or None."""
+    if max_w is None:
+        max_w = max_h * 2
+    key = f"{icao}_{max_h}_{max_w}"
     if key in _logo_cache:
         return _logo_cache[key]
 
@@ -74,8 +79,7 @@ def _load_airline_logo(icao: str, max_h: int) -> Optional[Image.Image]:
                 bbox = logo.getbbox()
                 if bbox:
                     logo = logo.crop(bbox)
-                # Allow wider logos — cap height to max_h, scale width proportionally
-                logo.thumbnail((max_h * 2, max_h), Image.Resampling.LANCZOS)
+                logo.thumbnail((max_w, max_h), Image.Resampling.LANCZOS)
                 _logo_cache[key] = logo
                 logger.info(f"[Flight Tracker] Loaded airline logo: {icao} ({logo.size[0]}x{logo.size[1]})")
                 return logo
@@ -638,6 +642,244 @@ class FlightRenderer:
 
     def render_area_card_image(self, aircraft, index=0, total_count=1):
         return self._render_area_card_to_image(aircraft, index, total_count)
+
+    # =====================================================================
+    # Overhead Card (single closest / latched aircraft — the live preempt view)
+    # =====================================================================
+
+    @staticmethod
+    def _heading_arrow_points(cx, cy, size, heading):
+        """Polygon points for an arrowhead centered at (cx, cy) pointing toward
+        compass ``heading`` (0=N/up, 90=E/right). Pure geometry — returns [] for
+        a missing/invalid heading so the caller can skip drawing.
+        """
+        try:
+            deg = float(heading) % 360
+        except (TypeError, ValueError):
+            return []
+        rad = math.radians(deg)
+        # Screen space: +y is down, so North (0°) points to (0, -1).
+        fx, fy = math.sin(rad), -math.cos(rad)   # forward unit vector (toward tip)
+        px, py = -fy, fx                         # perpendicular (right of travel)
+        back = size * 0.7                        # how far the base sits behind center
+        half = size * 0.6                        # half-width of the base
+        tip = (cx + fx * size, cy + fy * size)
+        left = (cx - fx * back + px * half, cy - fy * back + py * half)
+        right = (cx - fx * back - px * half, cy - fy * back - py * half)
+        return [tip, left, right]
+
+    def _draw_heading_arrow(self, draw, cx, cy, size, heading, color=(255, 255, 255)):
+        """Draw a filled triangular arrow pointing in the compass ``heading``."""
+        pts = self._heading_arrow_points(cx, cy, size, heading)
+        if pts:
+            draw.polygon(pts, fill=color)
+
+    def _draw_metric_strip_justified(self, draw, x0, x1, y, font, alt, spd, dist, alt_color):
+        """Draw the altitude/speed/distance values justified across [x0, x1] —
+        fills the horizontal space on wide panels instead of clustering left.
+        Values only (units disambiguate, same as the compact strip)."""
+        items = [(alt, alt_color), (spd, (180, 180, 180)), (dist, (180, 180, 180))]
+        seg_w = [self._tw(draw, val, font) for val, _ in items]
+        n = len(items)
+        slack = (x1 - x0) - sum(seg_w)
+        step = slack / (n - 1) if n > 1 and slack > 0 else self._tw(draw, "  ", font)
+        x = float(x0)
+        for (value, vcol), sw in zip(items, seg_w):
+            self._draw(draw, value, (round(x), y), font, vcol)
+            x += sw + step
+
+    def _draw_progress_bar(self, draw, x0, x1, y, progress, color):
+        """Horizontal flight-progress bar from x0..x1 centered on row y: a dim
+        track, a filled portion up to `progress` in the aircraft color, end ticks,
+        and a small triangle marker riding the fill position toward the destination."""
+        p = max(0.0, min(1.0, progress))
+        draw.line([(x0, y), (x1, y)], fill=(70, 70, 70))
+        fx = x0 + round((x1 - x0) * p)
+        if fx > x0:
+            draw.line([(x0, y), (fx, y)], fill=color)
+        for ex in (x0, x1):
+            draw.line([(ex, y - 1), (ex, y + 1)], fill=(120, 120, 120))
+        t = max(3, 2 * self.sprite_scale)
+        mx = min(max(fx, x0 + t), x1 - t)          # keep the marker on the track
+        self._draw_heading_arrow(draw, mx, y, t, 90, (255, 255, 255))  # points right
+
+    def _render_overhead_to_image(self, aircraft, progress=None, delay="", delay_color=None):
+        """Hero card for the 'plane overhead now' moment: airline logo, big
+        callsign, route + progress, a heading-arrow badge, and an ALT/SPD/DIST
+        metric strip. Size-adaptive off self.width/height. Returns the image.
+        """
+        w, h = self.width, self.height
+        img = Image.new("RGB", (w, h), (0, 0, 0))
+        draw = ImageDraw.Draw(img)
+
+        if not aircraft:
+            self._draw_centered(draw, "No Aircraft", (h - self._fh(self.font_medium)) // 2,
+                                self.font_medium, self.dim_color)
+            return img
+
+        callsign = aircraft.get("callsign", "---")
+        color = tuple(aircraft.get("color", self.header_color))
+        airline_icao = aircraft.get("airline_icao", "")
+        alt = self._fmt_alt(aircraft.get("altitude"))
+        spd = self._fmt_spd(aircraft.get("speed"))
+        dist = format_distance(aircraft.get("distance_miles"), self.units_legacy)
+        heading = aircraft.get("heading")
+        origin = aircraft.get("origin", "")
+        destination = aircraft.get("destination", "")
+        atype = aircraft.get("aircraft_type", "")
+        has_heading = heading is not None and heading != ""
+
+        # These pixel fonts report inflated getmetrics() line heights (≈13px for an
+        # 8px glyph), which won't stack on a 32px panel. Measure real ink extent and
+        # stack on a tight cursor instead.
+        def _ink(font, sample="ALT0"):
+            bb = draw.textbbox((0, 0), sample, font=font)
+            return bb[1], bb[3] - bb[1]  # (top offset, ink height)
+
+        top_s, ink_s = _ink(self.font_small)  # used by the compact badge
+        gap = 1
+
+        # Three size regimes:
+        #  - narrow  (<96px wide): no room for logo or badge — drop both, full-width text.
+        #  - spacious (>=48px tall): use the big font, a tall logo, an inline heading
+        #    arrow next to the callsign, and a labeled metric strip justified across
+        #    the width (no isolated right column / dead space).
+        #  - compact (the 128x32 default): logo + right-hand arrow/distance badge.
+        narrow = w < 96
+        spacious = h >= 48 and not narrow
+        hero_font = self.font_large if spacious else self.font_medium
+        body_font = self.font_medium if spacious else self.font_small
+        top_h, ink_h = _ink(hero_font)
+        top_b, ink_b = _ink(body_font)
+
+        # --- Right zone: heading-arrow + distance badge (compact panels only). ---
+        badge_w = 0
+        dist_in_badge = False
+        if has_heading and not narrow and not spacious:
+            want = max(self._tw(draw, dist, self.font_small) + 4, 18)
+            if want <= w * 0.4:
+                badge_w, dist_in_badge = want, True
+            else:
+                badge_w = max(10, min(int(w * 0.22), 18))  # arrow only
+            bx = w - badge_w
+            draw.line([(bx, 1), (bx, h - 2)], fill=(40, 40, 40))
+            if dist_in_badge:
+                arrow_cy = max(ink_s, (h - ink_s) // 2 - 1)
+                self._draw_centered(draw, dist, h - ink_s - 1 - top_s, self.font_small,
+                                    (180, 180, 180), zone_x=bx, zone_w=badge_w)
+            else:
+                arrow_cy = h // 2
+            arrow_sz = max(3, min(badge_w - 4, h // 2) // 2 + 1)
+            self._draw_heading_arrow(draw, bx + badge_w // 2, arrow_cy,
+                                     arrow_sz, heading, color)
+
+        # --- Left zone: airline logo (tall on spacious, capped on compact). When
+        # there's no logo, render text from the left margin — the "sprite" returned
+        # by get_sprite_for_aircraft is a colored map dot, not a plane, so it just
+        # adds a meaningless blob (altitude is already encoded in the callsign color). ---
+        text_x = 2
+        logo = None
+        if airline_icao and not narrow:
+            logo_h = (h - 8) if spacious else min(h - 4, 22)
+            # Cap logo width so wide wordmark logos can't crowd out the text.
+            logo = _load_airline_logo(airline_icao, logo_h,
+                                      max_w=max(logo_h, int(w * 0.24)))
+        if logo:
+            img.paste(logo, (2, (h - logo.height) // 2), logo)
+            text_x = 2 + logo.width + 3
+            draw.line([(text_x - 2, 1), (text_x - 2, h - 2)], fill=(40, 40, 40))
+
+        right_edge = w - badge_w - (2 if badge_w else 0)
+        main_w = right_edge - text_x
+
+        # On spacious panels, flight progress is a bar across the bottom (with a
+        # plane riding it) rather than a "99%" suffix on the route line.
+        use_bar = spacious and progress is not None and bool(origin and destination)
+
+        # Route, with progress appended only if it fits (never truncate mid-word).
+        route = ""
+        if origin and destination:
+            route = f"{origin}>{destination}"
+            if progress is not None and not use_bar:
+                pct = int(progress * 100)
+                for cand in (f"{route} {pct}%", f"{route}{pct}%"):
+                    if self._tw(draw, cand, body_font) <= main_w:
+                        route = cand
+                        break
+        elif atype and atype != "Unknown":
+            route = atype
+
+        # --- Row stack: callsign hero, metric strip, route, delay — vertically
+        # centered (above the progress bar's reserved band) so it reads on both
+        # 32px and taller panels. ---
+        bar_band = (4 * self.sprite_scale + 5) if use_bar else 0
+        rows = [ink_h, ink_b]               # callsign, metric strip (always)
+        if route:
+            rows.append(ink_b)
+        if delay:
+            rows.append(ink_b)
+        block_h = sum(rows) + gap * (len(rows) - 1)
+        iy = max(1, (h - bar_band - block_h) // 2 + 1)
+
+        # P1: callsign hero. When there's no logo, trail the friendly airline name
+        # (dim, bottom-aligned) so the airline is still identifiable; on spacious
+        # panels an inline heading arrow follows.
+        cs = self._truncate(draw, callsign, hero_font, main_w)
+        self._draw(draw, cs, (text_x, iy - top_h), hero_font, color)
+        cx = text_x + self._tw(draw, cs, hero_font) + 4
+        airline_name = aircraft.get("airline_name") or ""
+        if not logo and airline_name and cx < right_edge - 6:
+            nm = self._truncate(draw, airline_name, body_font, right_edge - cx)
+            self._draw(draw, nm, (cx, iy + ink_h - ink_b - top_b), body_font, self.dim_color)
+            cx += self._tw(draw, nm, body_font) + 4
+        if spacious and has_heading and cx + ink_h // 2 <= right_edge:
+            self._draw_heading_arrow(draw, cx + ink_h // 2, iy + ink_h // 2,
+                                     max(4, ink_h // 2), heading, color)
+        iy += ink_h + gap
+
+        # P2: metric strip — justified+labeled on spacious, values-only on compact.
+        if iy + ink_b <= h:
+            if spacious:
+                self._draw_metric_strip_justified(draw, text_x, right_edge, iy - top_b,
+                                                  body_font, alt, spd, dist, color)
+            else:
+                metrics = [(alt, color), (spd, (180, 180, 180))]
+                if not dist_in_badge:
+                    metrics.append((dist, (180, 180, 180)))
+                x = text_x
+                for value, col in metrics:
+                    vw = self._tw(draw, value, body_font)
+                    if x + vw > right_edge:
+                        break
+                    self._draw(draw, value, (x, iy - top_b), body_font, col)
+                    x += vw + 4
+            iy += ink_b + gap
+
+        # P3: route + progress
+        if route and iy + ink_b <= h:
+            self._draw(draw, self._truncate(draw, route, body_font, main_w),
+                       (text_x, iy - top_b), body_font, self.route_color)
+            iy += ink_b + gap
+
+        # P4: delay/status, if any space remains
+        if delay and iy + ink_b <= h:
+            self._draw(draw, self._truncate(draw, delay, body_font, main_w),
+                       (text_x, iy - top_b), body_font, delay_color or (200, 200, 200))
+
+        # Progress bar across the bottom (spacious panels only)
+        if use_bar:
+            self._draw_progress_bar(draw, text_x, w - 4, h - 1 - bar_band // 2,
+                                    progress, color)
+
+        return img
+
+    def render_overhead(self, aircraft, progress=None, delay="", delay_color=None):
+        img = self._render_overhead_to_image(aircraft, progress, delay, delay_color)
+        self.dm.image = img.copy()
+        self.dm.update_display()
+
+    def render_overhead_image(self, aircraft, progress=None, delay="", delay_color=None):
+        return self._render_overhead_to_image(aircraft, progress, delay, delay_color)
 
     # =====================================================================
     # Stats Cards

--- a/plugins/ledmatrix-flights/test/test_overhead_card.py
+++ b/plugins/ledmatrix-flights/test/test_overhead_card.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the redesigned overhead card (FlightRenderer.render_overhead).
+
+Covers:
+  - Heading-arrow geometry (`_heading_arrow_points`) for the four cardinals and
+    invalid input.
+  - The card renders without error on the 128x32 hardware panel and on a large
+    panel, producing a non-blank image.
+  - The two bugs the redesign fixes can't recur:
+      * the duplicate airline tag ("UAL360 UAL") — the callsign is drawn once and
+        the airline ICAO is never appended to it.
+      * the raw degree glyph in the heading ("HDG:227°") — no "°" is ever drawn
+        (heading goes through format_track / an arrow instead).
+
+Run with the core venv:
+    .venv/bin/python plugins/ledmatrix-flights/test/test_overhead_card.py
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN_DIR))
+
+import PIL.ImageDraw as _ID  # noqa: E402
+from renderer import FlightRenderer  # noqa: E402
+
+
+class _FakeMatrix:
+    def __init__(self, w, h):
+        self.width = w
+        self.height = h
+
+
+class _FakeDM:
+    def __init__(self, w, h):
+        self.matrix = _FakeMatrix(w, h)
+        self.image = None
+
+    def update_display(self):
+        pass
+
+
+def make_renderer(w=128, h=32, config=None):
+    return FlightRenderer(_FakeDM(w, h), {}, config or {})
+
+
+def _aircraft(**over):
+    ac = {
+        "callsign": "UAL360",
+        "airline_icao": "UAL",
+        "altitude": 2725,
+        "speed": 163,
+        "distance_miles": 0.86,
+        "heading": 227,
+        "origin": "DEN",
+        "destination": "SEA",
+        "aircraft_type": "B738",
+        "color": (0, 200, 255),
+    }
+    ac.update(over)
+    return ac
+
+
+def _capture_text(fn):
+    """Run fn() while recording every string passed to ImageDraw.text."""
+    captured = []
+    orig = _ID.ImageDraw.text
+
+    def rec(self, xy, text="", *a, **k):
+        captured.append(text)
+        return orig(self, xy, text, *a, **k)
+
+    _ID.ImageDraw.text = rec
+    try:
+        fn()
+    finally:
+        _ID.ImageDraw.text = orig
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Heading-arrow geometry
+# ---------------------------------------------------------------------------
+
+def test_arrow_points_north_points_up():
+    # 0deg = North = up: tip is above the center (smaller y).
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 0)
+    assert tip[1] < 10 and abs(tip[0] - 10) < 0.01, tip
+
+
+def test_arrow_points_east_points_right():
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 90)
+    assert tip[0] > 10 and abs(tip[1] - 10) < 0.01, tip
+
+
+def test_arrow_points_south_points_down():
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 180)
+    assert tip[1] > 10 and abs(tip[0] - 10) < 0.01, tip
+
+
+def test_arrow_points_west_points_left():
+    tip, *_ = FlightRenderer._heading_arrow_points(10, 10, 5, 270)
+    assert tip[0] < 10 and abs(tip[1] - 10) < 0.01, tip
+
+
+def test_arrow_points_intercardinals():
+    # Tip must land in the correct quadrant for the four intercardinals.
+    cases = {45: (1, -1), 135: (1, 1), 225: (-1, 1), 315: (-1, -1)}  # (sign x, sign y)
+    for hdg, (sx, sy) in cases.items():
+        tip, *_ = FlightRenderer._heading_arrow_points(0, 0, 16, hdg)
+        assert (tip[0] > 0) == (sx > 0) and (tip[1] > 0) == (sy > 0), (hdg, tip)
+
+
+def test_arrow_points_invalid_heading_empty():
+    assert FlightRenderer._heading_arrow_points(10, 10, 5, None) == []
+    assert FlightRenderer._heading_arrow_points(10, 10, 5, "") == []
+    assert FlightRenderer._heading_arrow_points(10, 10, 5, "abc") == []
+
+
+# ---------------------------------------------------------------------------
+# Card rendering
+# ---------------------------------------------------------------------------
+
+def test_renders_128x32_nonblank():
+    r = make_renderer(128, 32)
+    img = r.render_overhead_image(_aircraft(), progress=0.99, delay="")
+    assert img.size == (128, 32)
+    assert img.getbbox() is not None, "card rendered fully blank"
+
+
+def test_renders_large_nonblank():
+    r = make_renderer(256, 64)
+    img = r.render_overhead_image(_aircraft(), progress=0.5, delay="DELAYED 12m")
+    assert img.size == (256, 64)
+    assert img.getbbox() is not None
+
+
+def test_renders_without_heading_or_route():
+    # GA tail number: no airline logo, no route, no heading badge.
+    r = make_renderer(128, 32)
+    img = r.render_overhead_image(
+        _aircraft(callsign="N12345", airline_icao="", origin="", destination="",
+                  heading=None)
+    )
+    assert img.getbbox() is not None
+
+
+def test_narrow_panel_uses_full_width_text():
+    # On a 64-wide panel there's no room for the logo/sprite or the heading badge;
+    # both are dropped so the callsign/route get the full width (no separators).
+    r = make_renderer(64, 32)
+    img = r.render_overhead_image(_aircraft(), progress=0.99)
+    assert img.getbbox() is not None
+    # No vertical separator lines (logo/badge dividers) should be drawn.
+    import PIL.ImageDraw as _ID2
+    seps = []
+    orig = _ID2.ImageDraw.line
+
+    def rec(self, xy, *a, **k):
+        seps.append(xy)
+        return orig(self, xy, *a, **k)
+
+    _ID2.ImageDraw.line = rec
+    try:
+        r.render_overhead_image(_aircraft(), progress=0.99)
+    finally:
+        _ID2.ImageDraw.line = orig
+    assert seps == [], f"narrow panel should draw no logo/badge separators, got {seps}"
+    # Callsign is drawn in full (not truncated to a couple of chars).
+    texts = _capture_text(lambda: r.render_overhead_image(_aircraft(), progress=0.99))
+    assert any(t == "UAL360" for t in texts), texts
+
+
+def test_empty_aircraft_is_safe():
+    r = make_renderer(128, 32)
+    img = r.render_overhead_image(None)
+    assert img.size == (128, 32)
+
+
+# ---------------------------------------------------------------------------
+# Regressions: no doubled airline, no degree glyph
+# ---------------------------------------------------------------------------
+
+def test_callsign_not_doubled():
+    r = make_renderer(128, 32)
+    texts = _capture_text(lambda: r.render_overhead_image(_aircraft(), progress=0.99))
+    joined = " ".join(texts)
+    # The old layout drew "UAL360 UAL"; the redesign must not.
+    assert "UAL360 UAL" not in joined, joined
+    # And the callsign itself is still shown.
+    assert any(t == "UAL360" for t in texts), texts
+
+
+def test_no_degree_glyph_drawn():
+    # Heading is shown as an arrow, never as "227°" text — the old bug rendered a
+    # degree glyph the PressStart font can't draw.
+    r = make_renderer(128, 32)
+    texts = _capture_text(lambda: r.render_overhead_image(_aircraft(), progress=0.99))
+    assert all("°" not in t for t in texts), texts
+    # The badge conveys distance as text alongside the heading arrow.
+    assert any("mi" in t for t in texts), texts
+
+
+def run():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # pragma: no cover
+            failures += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return failures == 0
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)


### PR DESCRIPTION
## What & why

The overhead live-priority view (and the legacy `display_mode: \"overhead\"`) was the last flight view still hand-rolled in `manager.py` with its own draw calls, instead of sharing `renderer.py`'s helpers like `area`/`stats`/`flight_tracking`. This moves it into `FlightRenderer.render_overhead` (a hero sibling of the area card) and reduces `_display_overhead` to a thin wrapper that keeps the live-preempt latch and feeds in progress/delay.

The card reads the "plane overhead now" moment at a glance and **adapts to the panel size**:
- **compact (128×32)** — airline logo + colored callsign hero, an altitude/speed value strip, route + progress, and a heading-arrow + distance badge on the right.
- **narrow (<96px wide, e.g. a 64-wide single panel)** — drop the logo and badge; give the callsign/altitude/route the full width instead of truncating.
- **spacious (≥48px tall, e.g. 256×64)** — large font, tall logo, an inline heading arrow next to the callsign, metric values justified across the width, and flight progress as a **bar across the bottom** with a triangle marker.

Sharing the renderer also reuses logo loading, `format_track`, and the per-metric unit formatting the other cards already use. Logo **width** is capped (not just height) so wide wordmark logos (e.g. SkyWest) don't crowd out the callsign/route. When there's **no logo**, the friendly airline name is shown next to the callsign (the `get_sprite_for_aircraft` "sprite" is a colored map dot, not a plane, so it isn't used as a fallback here).

Fixes two long-standing bugs in this view:
- the **duplicate airline tag** — US callsigns rendered as `UAL360 UAL` (the callsign already starts with the ICAO)
- the **unrenderable degree glyph** in the heading (`HDG:227°` → the PressStart font has no `°`); heading is now an arrow, and any heading text routes through `format_track`

## Screenshots

**128×32** (common 2×1 panel):

![128x32](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/overhead-screenshots/screenshots/overhead/overhead-128x32.png)

**64×32** (single panel — logo and badge dropped, full-width text):

![64x32](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/overhead-screenshots/screenshots/overhead/overhead-64x32.png)

**256×64** (large panel — tall logo, inline heading arrow, metrics justified across the width, progress bar with triangle marker):

![256x64](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/overhead-screenshots/screenshots/overhead/overhead-256x64.png)

## Tests

- New `test/test_overhead_card.py`: heading-arrow geometry (cardinals + intercardinals + invalid), multi-size render smoke tests, narrow-panel layout, and regressions for the doubled callsign and the degree glyph.
- Existing `test/test_rotation_views_and_overhead.py` still green (preempt/latch logic unchanged).

Manifest 1.7.0 → 1.8.2; `plugins.json` synced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned overhead view as a size-adaptive card with improved heading direction visualization and optimized spacing for different display sizes.

* **Bug Fixes**
  * Fixed duplicate airline information appearing in the display.
  * Corrected heading degree symbol rendering issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->