### PR TITLE
fix(tide-display): show setup prompt when unconfigured, fix schema 400

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-02",
+  "last_updated": "2026-06-04",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -725,7 +725,7 @@
       "last_updated": "2026-05-31",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.0",
+      "latest_version": "1.0.1",
       "icon": "fa-water"
     },
     {

--- a/plugins/tide-display/config_schema.json
+++ b/plugins/tide-display/config_schema.json
@@ -22,7 +22,7 @@
     "station_id": {
       "type": "string",
       "title": "NOAA Station ID",
-      "description": "7-digit NOAA tide station ID. Find yours at tidesandcurrents.noaa.gov/stations.html",
+      "description": "Optional 7-digit NOAA tide station ID. Leave blank to show a setup prompt. Find yours at tidesandcurrents.noaa.gov/stations.html",
       "pattern": "^([0-9]{7})?$",
       "default": "",
       "examples": ["9447130", "8724580", "8443970"],

--- a/plugins/tide-display/config_schema.json
+++ b/plugins/tide-display/config_schema.json
@@ -23,7 +23,8 @@
       "type": "string",
       "title": "NOAA Station ID",
       "description": "7-digit NOAA tide station ID. Find yours at tidesandcurrents.noaa.gov/stations.html",
-      "pattern": "^[0-9]{7}$",
+      "pattern": "^([0-9]{7})?$",
+      "default": "",
       "examples": ["9447130", "8724580", "8443970"],
       "x-placeholder": "e.g. 9447130 (Seattle)"
     },

--- a/plugins/tide-display/manager.py
+++ b/plugins/tide-display/manager.py
@@ -426,9 +426,10 @@ class TidePlugin(BasePlugin):
     # ── Placeholder screens ─────────────────────────────────────────────────────
 
     def _no_station(self, draw, dw, dh, L):
-        draw.rectangle([0,0,dw-1,dh-1], outline=C_BAR_OUT)
-        self._txtc(dw//2, L['row1'], 'TIDE DISPLAY', C_WAVE1)
-        self._txtc(dw//2, L['row2'], 'Set station ID', C_LABEL)
+        draw.rectangle([0, 0, dw-1, dh-1], outline=C_BAR_OUT)
+        self._txtc(dw//2, dh//2 - 8, 'TIDE', C_WAVE1, small=False)
+        self._txtc(dw//2, dh//2 + 4, 'Set Station ID', C_LABEL)
+        self._txtc(dw//2, dh//2 + 12, 'in Settings', C_LABEL)
 
     def _loading(self, draw, dw, dh, L):
         n = int(self.wave_phase/30)%4

--- a/plugins/tide-display/manager.py
+++ b/plugins/tide-display/manager.py
@@ -427,9 +427,14 @@ class TidePlugin(BasePlugin):
 
     def _no_station(self, draw, dw, dh, L):
         draw.rectangle([0, 0, dw-1, dh-1], outline=C_BAR_OUT)
-        self._txtc(dw//2, dh//2 - 8, 'TIDE', C_WAVE1, small=False)
-        self._txtc(dw//2, dh//2 + 4, 'Set Station ID', C_LABEL)
-        self._txtc(dw//2, dh//2 + 12, 'in Settings', C_LABEL)
+        header_h, small_h, spacing = 8, 6, 2
+        base_y = dh // 2 - 8
+        line_y = [base_y + i * (small_h + spacing) + header_h + spacing
+                  for i in range(2)]
+        line_y = [min(y, dh - small_h - 1) for y in line_y]
+        self._txtc(dw//2, base_y, 'TIDE', C_WAVE1, small=False)
+        self._txtc(dw//2, line_y[0], 'Set Station ID', C_LABEL)
+        self._txtc(dw//2, line_y[1], 'in Settings', C_LABEL)
 
     def _loading(self, draw, dw, dh, L):
         n = int(self.wave_phase/30)%4

--- a/plugins/tide-display/manifest.json
+++ b/plugins/tide-display/manifest.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "homepage": "https://github.com/ChuckBuilds/ledmatrix-plugins/tree/main/plugins/tide-display",
   "config_schema": "config_schema.json",
-  "last_updated": "2026-05-31",
+  "last_updated": "2026-06-04",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/tide-display/manifest.json
+++ b/plugins/tide-display/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "tide-display",
   "name": "Tide Display",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "ChuckBuilds",
   "description": "Coastal tide display with animated wave level, tide schedule, 24-hour chart, and tidal statistics. Powered by the free NOAA Tides & Currents API (US stations, no API key required).",
   "entry_point": "manager.py",
@@ -11,6 +11,11 @@
   "display_modes": ["current", "schedule", "chart", "stats"],
   "compatible_versions": [">=2.0.0"],
   "versions": [
+    {
+      "released": "2026-06-04",
+      "version": "1.0.1",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-31",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary

- **Setup prompt**: When no station ID is configured, \`_no_station()\` now renders \`TIDE\` in the larger PressStart2P 8px font with \`Set Station ID / in Settings\` instructions below in the smaller 4×6 font. The previous version used \`extra_small_font\` for both lines, which was invisible at a glance on the physical matrix and appeared as a blank blue border outline.
- **Schema fix**: \`station_id\` pattern changed from \`^[0-9]{7}$\` to \`^([0-9]{7})?$\` so an empty field is valid and doesn't trigger a 400 on the \`/api/v3/plugins/config\` endpoint when a user opens settings before entering a station ID.

## Root cause

Plugin was installed with an empty config. The schema rejected the form save with 400, and the placeholder display was unreadable — the user saw only a blue border cycling through 4 modes every ~13 seconds.

The 400 had two layers:
1. **Empty station ID** — schema pattern \`^[0-9]{7}$\` rejects an empty string (fixed here by allowing empty via \`^([0-9]{7})?$\`)
2. **All-digit string coerced to int** — a fallback in \`_parse_form_value_with_schema\` called \`int()\` on all-digit strings regardless of schema type, converting \`"8726607"\` → \`8726607\` before validation, which then failed \`"type": "string"\` (fixed in companion [LEDMatrix #363](https://github.com/ChuckBuilds/LEDMatrix/pull/363))

## Related

[LEDMatrix #363](https://github.com/ChuckBuilds/LEDMatrix/pull/363) — fixes the core \`api_v3.py\` string-to-int coercion bug that caused the 400 for all-digit string fields.

## Test plan

- [ ] Open tide-display settings with no station ID — form should save without error
- [ ] Physical display should show \`TIDE\` header (PressStart2P) + instruction text when unconfigured
- [ ] Enter a valid 7-digit station ID — should save successfully and display tide data
- [ ] Enter an invalid value (e.g. 5 digits) — should be rejected by the schema pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Station ID is now optional; leaving it blank triggers an automatic setup prompt.
  * Setup guidance display updated with clearer, centered messaging.

* **Bug Fixes**
  * Plugin updated to version 1.0.1 and metadata refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->