### PR TITLE
feat(registry): add Dresden Departures Board community plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -824,6 +824,31 @@
       "verified": true,
       "screenshot": "",
       "latest_version": "1.0.2"
+    },
+    {
+      "id": "ledmatrix-dresden-departures",
+      "name": "Dresden Departures Board",
+      "description": "Dresden VVO departure board with tram times, date, clock, and weather. Shows upcoming tram/bus departures from a configurable DVB/VVO stop alongside a clock, date, and weather info.",
+      "author": "ryug0",
+      "category": "transit",
+      "tags": [
+        "dresden",
+        "tram",
+        "vvo",
+        "dvb",
+        "transit",
+        "departures",
+        "germany"
+      ],
+      "repo": "https://github.com/ryug0/ledmatrix-dresden-departures",
+      "branch": "main",
+      "plugin_path": "",
+      "stars": 0,
+      "downloads": 0,
+      "last_updated": "2026-06-02",
+      "verified": false,
+      "screenshot": "",
+      "latest_version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds [`ledmatrix-dresden-departures`](https://github.com/ryug0/ledmatrix-dresden-departures) by [@ryug0](https://github.com/ryug0) to the plugin registry as an external community plugin
- Shows upcoming DVB/VVO tram and bus departures from a configurable stop in Dresden, alongside a clock, date, and weather display
- Plugin has a valid `manifest.json` with all required fields (`id`, `name`, `class_name`, `display_modes`), `compatible_versions: [">=2.0.0"]`, and a `config_schema.json`

## Plugin details

| Field | Value |
|---|---|
| ID | `ledmatrix-dresden-departures` |
| Category | `transit` |
| Version | `1.0.0` |
| Verified | `false` (external repo) |
| Repo | https://github.com/ryug0/ledmatrix-dresden-departures |

## Notes

- `plugin_path` is empty — install flow clones/downloads directly from ryug0's repo
- Future version bumps will need manual `latest_version` updates in `plugins.json` (standard for external plugins, same as `pga-tour-leaderboard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Dresden Departures Board plugin, enabling real-time departure schedule information for Dresden transportation services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->