### PR TITLE
fix(baseball-scoreboard): fix MiLB/NCAA logo layout on multi-panel displays

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -824,6 +824,31 @@
       "verified": true,
       "screenshot": "",
       "latest_version": "1.0.2"
+    },
+    {
+      "id": "ledmatrix-dresden-departures",
+      "name": "Dresden Departures Board",
+      "description": "Dresden VVO departure board with tram times, date, clock, and weather. Shows upcoming tram/bus departures from a configurable DVB/VVO stop alongside a clock, date, and weather info.",
+      "author": "ryug0",
+      "category": "transit",
+      "tags": [
+        "dresden",
+        "tram",
+        "vvo",
+        "dvb",
+        "transit",
+        "departures",
+        "germany"
+      ],
+      "repo": "https://github.com/ryug0/ledmatrix-dresden-departures",
+      "branch": "main",
+      "plugin_path": "",
+      "stars": 0,
+      "downloads": 0,
+      "last_updated": "2026-06-02",
+      "verified": false,
+      "screenshot": "",
+      "latest_version": "1.0.0"
     }
   ]
 }

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-04",
+  "last_updated": "2026-06-05",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -46,10 +46,10 @@
       "plugin_path": "plugins/baseball-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-31",
+      "last_updated": "2026-06-05",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.2"
+      "latest_version": "1.6.3"
     },
     {
       "id": "basketball-scoreboard",

--- a/plugins/baseball-scoreboard/game_renderer.py
+++ b/plugins/baseball-scoreboard/game_renderer.py
@@ -167,7 +167,7 @@ class GameRenderer:
 
                 # Crop transparent padding so scaling operates on actual content.
                 # Then constrain to the logo slot width and 75% of display height —
-                # this prevents wide 1200×630 source images (common in MiLB/ESPN)
+                # this prevents wide 1200x630 source images (common in MiLB/ESPN)
                 # from producing full-height logos that overwhelm the center text.
                 bbox = logo.getbbox()
                 if bbox:

--- a/plugins/baseball-scoreboard/game_renderer.py
+++ b/plugins/baseball-scoreboard/game_renderer.py
@@ -165,13 +165,16 @@ class GameRenderer:
                 if logo.mode != 'RGBA':
                     logo = logo.convert('RGBA')
 
-                # Crop transparent padding then scale so ink fills display_height.
-                # thumbnail into a display_height square box preserves aspect ratio
-                # and prevents wide logos from exceeding their half-card slot.
+                # Crop transparent padding so scaling operates on actual content.
+                # Then constrain to the logo slot width and 75% of display height —
+                # this prevents wide 1200×630 source images (common in MiLB/ESPN)
+                # from producing full-height logos that overwhelm the center text.
                 bbox = logo.getbbox()
                 if bbox:
                     logo = logo.crop(bbox)
-                logo.thumbnail((self.display_height, self.display_height), RESAMPLE_FILTER)
+                logo_slot = min(self.display_height, self.display_width // 2)
+                max_logo_h = int(self.display_height * 0.75)
+                logo.thumbnail((logo_slot, max_logo_h), RESAMPLE_FILTER)
 
                 # Copy before exiting context manager
                 cached_logo = logo.copy()

--- a/plugins/baseball-scoreboard/logo_manager.py
+++ b/plugins/baseball-scoreboard/logo_manager.py
@@ -117,10 +117,15 @@ class BaseballLogoManager:
                 self.logger.error(f"Logo file still doesn't exist at {actual_logo_path} after download attempt")
                 return None
 
-            # Resize to fit display (150% of display dimensions to allow extending off screen)
-            max_width = int(self.display_width * 1.5)
-            max_height = int(self.display_height * 1.5)
-            logo.thumbnail((max_width, max_height), RESAMPLE_FILTER)
+            # Crop transparent padding so scaling operates on actual content
+            bbox = logo.getbbox()
+            if bbox:
+                logo = logo.crop(bbox)
+
+            # Cap at logo slot width and 75% of display height
+            logo_slot = min(self.display_height, self.display_width // 2)
+            max_logo_h = int(self.display_height * 0.75)
+            logo.thumbnail((logo_slot, max_logo_h), RESAMPLE_FILTER)
 
             # Cache the logo
             self._logo_cache[team_abbr] = logo
@@ -158,10 +163,14 @@ class BaseballLogoManager:
                 self.logger.warning(f"MiLB logo not found for {team_abbr} at {logo_path}")
                 return None
 
-            # Resize to fit display (150% of display dimensions)
-            max_width = int(self.display_width * 1.5)
-            max_height = int(self.display_height * 1.5)
-            logo.thumbnail((max_width, max_height), RESAMPLE_FILTER)
+            # Crop transparent padding so scaling operates on actual content
+            bbox = logo.getbbox()
+            if bbox:
+                logo = logo.crop(bbox)
+
+            logo_slot = min(self.display_height, self.display_width // 2)
+            max_logo_h = int(self.display_height * 0.75)
+            logo.thumbnail((logo_slot, max_logo_h), RESAMPLE_FILTER)
 
             # Cache the logo
             self._logo_cache[team_abbr] = logo

--- a/plugins/baseball-scoreboard/manifest.json
+++ b/plugins/baseball-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "baseball-scoreboard",
   "name": "Baseball Scoreboard",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming baseball games across MLB, MiLB, and NCAA Baseball with real-time scores and schedules",
   "category": "sports",
@@ -30,6 +30,12 @@
   "branch": "main",
   "plugin_path": "plugins/baseball-scoreboard",
   "versions": [
+    {
+      "released": "2026-06-05",
+      "version": "1.6.3",
+      "notes": "Fix MiLB/NCAA logo layout: crop transparent padding before scaling, cap logo height at 75% of display height, default game card width to full display width so logos anchor at display edges instead of center",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-05-31",
       "version": "1.6.2",
@@ -127,7 +133,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-31",
+  "last_updated": "2026-06-05",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/baseball-scoreboard/scroll_display.py
+++ b/plugins/baseball-scoreboard/scroll_display.py
@@ -185,7 +185,7 @@ class ScrollDisplay:
             "gap_between_games": 48,
             "show_league_separators": True,
             "dynamic_duration": True,
-            "game_card_width": 128,
+            "game_card_width": self.display_width,
         }
 
         # Try to get league-specific settings first
@@ -335,10 +335,10 @@ class ScrollDisplay:
         scroll_settings = self._get_scroll_settings()
         gap_between_games = scroll_settings.get("gap_between_games", 24)
         show_separators = scroll_settings.get("show_league_separators", True)
-        game_card_width = scroll_settings.get("game_card_width", 128)
+        game_card_width = scroll_settings.get("game_card_width", self.display_width)
 
-        # Get or create cached game renderer using game_card_width so cards are a fixed
-        # size regardless of the full chain width (display_width may span multiple panels)
+        # Get or create cached game renderer; default card width is the full display width
+        # so each game card fills the viewport and logos sit at the display edges
         renderer = self._get_game_renderer(game_card_width)
 
         # Pass rankings cache to renderer if available
@@ -374,8 +374,9 @@ class ScrollDisplay:
                 individual_game_type = self._determine_game_type(game)
                 game_img = renderer.render_game_card(game, individual_game_type)
 
-                # Add horizontal padding to prevent logos from being cut off at edges
-                padding = 12  # Padding on each side to ensure logos aren't cut off
+                # Only pad when card is narrower than the viewport; full-width cards
+                # need no padding or the card becomes wider than the display.
+                padding = 0 if game_img.width >= self.display_width else 12
                 padded_width = game_img.width + (padding * 2)
                 padded_img = Image.new('RGB', (padded_width, game_img.height), (0, 0, 0))
                 padded_img.paste(game_img, (padding, 0))


### PR DESCRIPTION
## Summary

- **Logo height capped at 75% of display height** — MiLB logos from ESPN arrive as 1200×630 source files. After bbox crop, square/circular logos (team circles, badges) were scaling to full `display_height`, dominating the display and obscuring center text. Now capped at `int(display_height * 0.75)` via `thumbnail((logo_slot, max_logo_h))`.

- **Game card width defaults to `display_width`** — The previous hardcoded default of 128px placed logos in the middle of the viewport on multi-panel displays (e.g. 192px wide). Cards now default to the full display width so logos anchor at the far left and right edges, matching the intended scoreboard layout.

- **Padding removed for full-width cards** — The 12px per-side padding inflated full-width cards beyond the viewport width, preventing both logos from appearing simultaneously. Padding is now `0` when `card_width >= display_width`.

- **`logo_manager.py`** — Added bbox crop + matching height cap to the non-scroll render paths (`load_logo`, `load_milb_logo`) for consistency.

## Test plan

- [ ] Verify MiLB recent/upcoming games show logos anchored at display edges with score centered
- [ ] Verify MLB logos unchanged (were already bbox-cropped in `game_renderer.py`)
- [ ] Verify on a standard 128×32 display (logo_slot = 32, max_h = 24) logos still fit correctly
- [ ] Verify `game_card_width` config override in `scroll_settings` still takes precedence over the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ledmatrix-dresden-departures plugin for LED matrix display support (v1.0.0)

* **Bug Fixes**
  * Updated baseball-scoreboard to v1.6.3 with improved team logo rendering (cropped transparent padding, tighter height constraints)
  * Game cards now default to full display width with adaptive horizontal padding to avoid logo clipping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->