### PR TITLE
fix(elections): stable race id so the called-card interrupt stops looping

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-05",
+  "last_updated": "2026-06-06",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -843,10 +843,10 @@
       "plugin_path": "plugins/ledmatrix-elections",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-06-03",
+      "last_updated": "2026-06-06",
       "verified": false,
       "screenshot": "",
-      "latest_version": "1.0.0"
+      "latest_version": "1.0.1"
     },
     {
       "id": "ledmatrix-dresden-departures",

--- a/plugins/ledmatrix-elections/manifest.json
+++ b/plugins/ledmatrix-elections/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-elections",
   "name": "Election Results",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "rpierce99",
   "description": "Live election results: a scrolling ticker of important races plus a full-screen interrupt when a race is newly called. Auto-activates for your state's primary + general (dormant otherwise), drains stale calls from the ticker, and survives restarts. Filterable to your state. NYT baseline provider + optional California SoS county/city rollup.",
   "entry_point": "manager.py",
@@ -23,12 +23,18 @@
   ],
   "versions": [
     {
+      "released": "2026-06-06",
+      "version": "1.0.1",
+      "ledmatrix_min": "2.0.0",
+      "notes": "Fix the called-race interrupt looping forever: give colliding local races (e.g. multiple 'Mayor' races) a stable id derived from NYT's per-race id instead of an order-dependent counter, so the newly-called diff no longer re-fires every fetch."
+    },
+    {
       "released": "2026-06-03",
       "version": "1.0.0",
       "ledmatrix_min": "2.0.0"
     }
   ],
-  "last_updated": "2026-06-03",
+  "last_updated": "2026-06-06",
   "stars": 0,
   "downloads": 0,
   "verified": false,

--- a/plugins/ledmatrix-elections/providers/nyt.py
+++ b/plugins/ledmatrix-elections/providers/nyt.py
@@ -24,6 +24,7 @@ from data_model import (
     make_race_id,
     normalize_party,
     scope_for_office,
+    slug,
 )
 from providers import ElectionProvider
 
@@ -150,19 +151,32 @@ class NytStaticProvider(ElectionProvider):
         )
         now = time.time()
 
+        # Disambiguate genuine duplicates (e.g. multiple local "Mayor" races with
+        # the same office+state+no-district) with a STABLE, content-derived suffix
+        # so the same physical race keeps its id across fetches. NYT reorders
+        # results between pulls; an order-derived counter would reshuffle the
+        # suffixes, so diff_newly_called would see "new" ids every cycle and
+        # re-fire the called-race interrupt forever.
+        parsed = [
+            (r, race)
+            for r, race in ((r, self._parse_race(r, now)) for r in races_raw)
+            if race is not None
+        ]
+        id_counts: Dict[str, int] = {}
+        for _, race in parsed:
+            id_counts[race.id] = id_counts.get(race.id, 0) + 1
+
         races: List[Race] = []
-        seen_ids: Dict[str, int] = {}
-        for r in races_raw:
-            race = self._parse_race(r, now)
-            if race is None:
-                continue
-            # Disambiguate genuine duplicates (e.g. multiple local "Mayor" races
-            # with the same office+state+no-district) so none are lost in the merge.
-            if race.id in seen_ids:
-                seen_ids[race.id] += 1
-                race.id = f"{race.id}-{seen_ids[race.id]}"
-            else:
-                seen_ids[race.id] = 0
+        fallback_seen: Dict[str, int] = {}
+        for r, race in parsed:
+            if id_counts[race.id] > 1:
+                # Collision: suffix every member with NYT's stable per-race id.
+                nyt_id = r.get("nyt_id")
+                if nyt_id:
+                    race.id = f"{race.id}-{slug(str(nyt_id))}"
+                else:
+                    fallback_seen[race.id] = fallback_seen.get(race.id, 0) + 1
+                    race.id = f"{race.id}-{fallback_seen[race.id]}"
             if r.get("nyt_id") in key_race_ids:
                 race._key_race = True  # type: ignore[attr-defined]
             races.append(race)

--- a/plugins/ledmatrix-elections/test_elections.py
+++ b/plugins/ledmatrix-elections/test_elections.py
@@ -358,9 +358,56 @@ def test_status_label():
           "precinct-basis reporting shows '% prec', not a false '100% in'")
 
 
+def _raw_mayor(nyt_id, called):
+    """Minimal NYT-raw 'Mayor' race (no seat_number) — collides on office+state."""
+    return {
+        "office": "Mayor",
+        "nyt_id": nyt_id,
+        "type": "primary",
+        "top_reporting_unit": {
+            "state_postal": "CA",
+            "total_votes": 100,
+            "eevp": 100,
+            "candidates": [
+                {"nyt_id": "c1", "votes": {"total": 60}},
+                {"nyt_id": "c2", "votes": {"total": 40}},
+            ],
+        },
+        "outcome": {"won": ["c1"]} if called else {},
+    }
+
+
+def test_stable_race_id_across_reorder():
+    print("[Stable race id across feed reorder]")
+    p = NytStaticProvider({"election_date": "2026-06-02", "election_type": "primary"})
+    called_mayor = _raw_mayor("mayor-aaa", called=True)
+    other_mayor = _raw_mayor("mayor-bbb", called=False)
+
+    # Same two physical races, but NYT serves them in a different order on the
+    # next pull (it reorders by reporting/votes).
+    races1 = p.parse({"races": [called_mayor, other_mayor]})
+    races2 = p.parse({"races": [other_mayor, called_mayor]})
+
+    id_by_nyt1 = {r.nyt_id: r.id for r in races1}
+    id_by_nyt2 = {r.nyt_id: r.id for r in races2}
+    check(len(set(id_by_nyt1.values())) == 2, "colliding mayors get distinct ids")
+    check(id_by_nyt1 == id_by_nyt2,
+          f"each physical race keeps a stable id across reorder ({id_by_nyt1} vs {id_by_nyt2})")
+
+    # End-to-end: the called mayor must fire as 'newly called' exactly once, not
+    # re-fire on every reordered pull (the interrupt-loop bug).
+    store = RaceStore()
+    store.set_election("CA_2026-06-02_primary")
+    check(store.diff_newly_called(races1, now=1000.0) == [],
+          "cold start seeds snapshot, no replay")
+    check(store.diff_newly_called(races2, now=1100.0) == [],
+          "reordered pull does not re-fire the already-called race")
+
+
 def main():
     for fn in (test_nyt_parse, test_nyt_build_url, test_nyt_race_calls, test_ca_sos_parse,
                test_filters, test_merge, test_sort, test_diff,
+               test_stable_race_id_across_reorder,
                test_ca_sos_defaults, test_chamber_classification, test_local_races,
                test_local_races_other_state, test_district_aliases, test_status_label):
         fn()


### PR DESCRIPTION
## Problem
On the elections plugin, the full-screen "called" interrupt re-fires for the same race on **every** rotation and never drains.

Root cause: local races that collide on `office + state + no-district` (e.g. multiple "Mayor" races) are disambiguated in the NYT provider with an **order-dependent counter** suffix (`-1`, `-2`, …). NYT reorders results between pulls, so the suffix — and therefore the race `id` — changes every fetch. `diff_newly_called` then sees a fresh `false→true` flip each cycle, re-stamps `called_at = now`, and re-enqueues the interrupt indefinitely (the `interrupt_max_age` staleness guard never kicks in because the call always looks brand-new).

## Fix
Derive the disambiguation suffix from NYT's **stable per-race `nyt_id`** instead of an order-dependent counter, so the same physical race keeps its `id` across fetches. The newly-called diff then fires once and the race drains to the ticker as intended.

## Test
Adds `test_stable_race_id_across_reorder`: parses the same two colliding races in both orders and asserts (a) each physical race keeps a stable id, and (b) end-to-end through `RaceStore.diff_newly_called`, the called race fires once and does **not** re-fire on the reordered pull. Fails before the fix, passes after. Full suite: 72 passed.

Verified live in the RGBMatrixEmulator: `Elections updated: 1 races shown, 0 pending calls`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the Ledmatrix Elections plugin (v1.0.1) where called-race interrupts would repeatedly trigger. Race identifiers are now stable and consistent across feed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->