### PR TITLE
fix(7-segment-clock): render digits with correct asset polarity

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -20,10 +20,10 @@
       "plugin_path": "plugins/7-segment-clock",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-15",
+      "last_updated": "2026-06-07",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.0.1"
+      "latest_version": "1.0.2"
     },
     {
       "id": "baseball-scoreboard",

--- a/plugins/7-segment-clock/manager.py
+++ b/plugins/7-segment-clock/manager.py
@@ -198,23 +198,22 @@ class SevenSegmentClockPlugin(BasePlugin):
         # Get the base image (transparent foreground on black background)
         base_image = self.number_images[digit].copy()
 
-        # Create a colored version with transparent background
-        # The images have white/colored pixels for lit segments on transparent/black background
+        # Create a colored version with transparent background.
+        # The digit assets encode lit segments as fully transparent pixels and
+        # unlit areas as opaque black, so a transparent pixel is a lit segment.
         colored_image = Image.new("RGBA", base_image.size, (0, 0, 0, 0))
-        
-        # Apply color to visible pixels (non-transparent pixels that represent lit segments)
+
+        # Color the lit (transparent) pixels; keep the unlit (opaque) ones clear.
         for x in range(base_image.width):
             for y in range(base_image.height):
                 pixel = base_image.getpixel((x, y))
                 if len(pixel) == 4:  # RGBA
                     r, g, b, a = pixel
-                    # If pixel has any alpha and is not pure black, it's a lit segment
-                    # Apply the configured color to lit segments
-                    if a > 0 and (r, g, b) != (0, 0, 0):
-                        # This is a lit segment - apply the configured color with full opacity
+                    if a == 0:
+                        # Transparent pixel = lit segment - apply the configured color
                         colored_image.putpixel((x, y), (*color, 255))
                     else:
-                        # Black or transparent pixel - keep fully transparent
+                        # Opaque pixel = unlit - keep fully transparent so it doesn't draw
                         colored_image.putpixel((x, y), (0, 0, 0, 0))
                 else:
                     # Not RGBA format - convert and handle
@@ -265,12 +264,12 @@ class SevenSegmentClockPlugin(BasePlugin):
                 pixel = base_image.getpixel((x, y))
                 if len(pixel) == 4:  # RGBA
                     r, g, b, a = pixel
-                    # If pixel has any alpha and is not pure black, it's a lit segment
-                    if a > 0 and (r, g, b) != (0, 0, 0):
-                        # This is a lit segment - apply the configured color with full opacity
+                    # Lit segments are transparent, unlit areas are opaque black.
+                    if a == 0:
+                        # Transparent pixel = lit segment - apply the configured color
                         colored_image.putpixel((x, y), (*color, 255))
                     else:
-                        # Black or transparent pixel - keep fully transparent
+                        # Opaque pixel = unlit - keep fully transparent so it doesn't draw
                         colored_image.putpixel((x, y), (0, 0, 0, 0))
                 else:
                     # Not RGBA format - convert and handle

--- a/plugins/7-segment-clock/manifest.json
+++ b/plugins/7-segment-clock/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "7-segment-clock",
   "name": "7-Segment Clock",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Display a retro-style 7-segment clock with customizable colors",
   "author": "LEDMatrix",
   "entry_point": "manager.py",
@@ -25,6 +25,11 @@
   "config_schema": "config_schema.json",
   "versions": [
     {
+      "released": "2026-06-07",
+      "version": "1.0.2",
+      "ledmatrix_min": "2.0.0"
+    },
+    {
       "released": "2026-05-15",
       "version": "1.0.1",
       "ledmatrix_min": "2.0.0"
@@ -35,5 +40,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-15"
+  "last_updated": "2026-06-07"
 }

--- a/plugins/7-segment-clock/test_render_polarity.py
+++ b/plugins/7-segment-clock/test_render_polarity.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Regression test for the 7-segment-clock digit/separator render polarity.
+
+Run standalone from the plugin directory:
+
+    cd plugins/7-segment-clock
+    python test_render_polarity.py
+
+The digit assets encode lit segments as fully *transparent* pixels and unlit
+areas as opaque black. The renderer must therefore color the transparent
+pixels. A previous version colored the opaque pixels instead, which produced a
+fully blank frame (nothing colored) or, when "color every opaque pixel" was
+tried, garbled blocks (e.g. "1" rendered as a solid rectangle).
+
+This test renders digits through the real `_render_digit` and asserts:
+  1. a digit with all segments lit ("8") produces visible pixels  -> not blank
+  2. "1" lights fewer pixels than "8"                              -> right polarity
+     (the broken "color opaque pixels" path inverts this, since the unlit mask
+      for "1" is nearly the whole tile)
+  3. every lit pixel is exactly the configured color; unlit pixels are clear
+
+No external test framework is required — the script exits non-zero on the first
+failure and prints a summary on success.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from PIL import Image
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+
+
+def _install_host_stubs() -> None:
+    for name in ("src", "src.plugin_system", "src.plugin_system.base_plugin"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["src.plugin_system.base_plugin"].BasePlugin = object
+
+
+_install_host_stubs()
+
+import manager  # noqa: E402
+
+
+def _make_plugin() -> "manager.SevenSegmentClockPlugin":
+    """Build an instance without running __init__ (which needs the full host)."""
+    plugin = object.__new__(manager.SevenSegmentClockPlugin)
+    assets = PLUGIN_DIR / "assets" / "images"
+    plugin.number_images = {
+        i: Image.open(assets / f"number_{i}.png").convert("RGBA") for i in range(10)
+    }
+    plugin.separator_image = Image.open(assets / "separator.png").convert("RGBA")
+
+    class _NullLogger:
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+
+    plugin.logger = _NullLogger()
+    return plugin
+
+
+def _lit_pixels(img: Image.Image, color):
+    """Return (count_of_visible_pixels, set_of_distinct_visible_rgb)."""
+    px = img.convert("RGBA").load()
+    count = 0
+    colors = set()
+    for y in range(img.height):
+        for x in range(img.width):
+            r, g, b, a = px[x, y]
+            if a > 0:
+                count += 1
+                colors.add((r, g, b))
+    return count, colors
+
+
+def test_eight_is_not_blank() -> None:
+    plugin = _make_plugin()
+    color = (0, 255, 0)
+    count, colors = _lit_pixels(plugin._render_digit(8, color), color)
+    assert count > 0, "digit '8' rendered blank — render polarity is wrong"
+    assert colors == {color}, f"lit pixels not the configured color: {colors}"
+    print(f"  [ok] '8' renders {count} lit pixels, all {color}")
+
+
+def test_one_lights_fewer_than_eight() -> None:
+    plugin = _make_plugin()
+    color = (255, 255, 255)
+    eight, _ = _lit_pixels(plugin._render_digit(8, color), color)
+    one, _ = _lit_pixels(plugin._render_digit(1, color), color)
+    # "8" lights all seven segments; "1" lights only two. If the renderer is
+    # coloring the *unlit* mask instead, this inverts (one > eight).
+    assert one < eight, f"polarity inverted: '1'={one} lit vs '8'={eight} lit"
+    print(f"  [ok] '1' ({one}) lights fewer pixels than '8' ({eight})")
+
+
+def test_separator_renders() -> None:
+    plugin = _make_plugin()
+    color = (255, 0, 0)
+    count, colors = _lit_pixels(plugin._render_separator(color), color)
+    assert count > 0, "separator rendered blank"
+    assert colors == {color}, f"separator pixels not the configured color: {colors}"
+    print(f"  [ok] separator renders {count} lit pixels, all {color}")
+
+
+def main() -> int:
+    tests = [
+        test_eight_is_not_blank,
+        test_one_lights_fewer_than_eight,
+        test_separator_renders,
+    ]
+    for t in tests:
+        try:
+            t()
+        except AssertionError as exc:
+            print(f"  [FAIL] {t.__name__}: {exc}")
+            return 1
+    print("All render-polarity tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The `7-segment-clock` plugin rendered every digit **blank**. Its digit and separator PNG assets encode **lit segments as transparent pixels** and unlit areas as **opaque black**, but `_render_digit` / `_render_separator` colored *opaque, non-black* pixels — which matches nothing in these assets, so the recolored image came out fully transparent.

This flips the polarity: a transparent pixel is a lit segment (gets the configured color); opaque pixels stay clear. No asset changes — the segment shapes were already correct, only the render interpretation was inverted.

## Before / after (128×32)

![before and after](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/7seg-clock-screenshots/before_after.png)

All ten digits render correctly:

![digits 0-9](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/7seg-clock-screenshots/digits_0_9.png)

## Testing

- **Regression test** (`test_render_polarity.py`): renders real digits through the actual code and asserts non-blank, correctly-colored output with the right polarity (`1` lights fewer pixels than `8`, which catches the inverse "color the mask" failure mode). **Fails before this change, passes after.**
- **Cross-size safety harness** (`scripts/check_plugin.py`): **PASS** at all sizes (64×32, 128×32, 64×64, 128×64, 256×32, 128×96, 256×128).
- Bumped manifest `1.0.1` → `1.0.2` and synced `plugins.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 7-segment display rendering to correctly identify lit segments and apply the configured color accurately.

* **Updates**
  * 7-segment-clock plugin updated to version 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->