### PR TITLE
fix(flights): decouple overhead/live view from map_radius_miles

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -331,10 +331,10 @@
       "plugin_path": "plugins/ledmatrix-flights",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-06-01",
+      "last_updated": "2026-06-08",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.9.0"
+      "latest_version": "1.9.1"
     },
     {
       "id": "march-madness",

--- a/plugins/ledmatrix-flights/manager.py
+++ b/plugins/ledmatrix-flights/manager.py
@@ -893,8 +893,10 @@ class FlightTrackerPlugin(BasePlugin):
         from the full receiver range rather than just the map radius subset.
         """
         # Fetch a wider area for stats (3× map radius, capped at 100 miles so we
-        # don't hammer the public API with enormous bounding boxes).
-        stats_radius = min(self.map_radius_miles * 3, 100)
+        # don't hammer the public API with enormous bounding boxes). Never fetch
+        # less than the proximity/overhead radius, otherwise a proximity_distance_miles
+        # larger than 3× the map radius would silently never see its aircraft.
+        stats_radius = min(max(self.map_radius_miles * 3, self.proximity_distance_miles), 100)
         result = self._fetcher.fetch(
             self.center_lat,
             self.center_lon,
@@ -2290,10 +2292,12 @@ class FlightTrackerPlugin(BasePlugin):
                 has_airborne_tracked = any(
                     tf.status == "AIRBORNE" for tf in self.tracked_flight_data.values()
                 )
-                closest = self.get_closest_aircraft()
+                _, prox_ac = (
+                    self._closest_in_radius() if self.proximity_enabled else (None, None)
+                )
                 if has_airborne_tracked:
                     mode = 'flight_tracking'
-                elif self.proximity_enabled and closest and closest['distance_miles'] <= self.proximity_distance_miles:
+                elif prox_ac is not None:
                     mode = 'overhead'
                 elif self.anchor_airport and self._get_anchor_aircraft():
                     mode = 'area'
@@ -2314,8 +2318,18 @@ class FlightTrackerPlugin(BasePlugin):
                 return [img]
 
             if mode == 'overhead':
-                self._display_overhead(force_clear=False)
-                captured = self.display_manager.image
+                # Render the proximity aircraft from the full pool (independent of
+                # map_radius_miles); falls back to the closest mapped aircraft when
+                # proximity is disabled or nothing is in the proximity radius.
+                _, overhead_ac = (
+                    self._closest_in_radius() if self.proximity_enabled else (None, None)
+                )
+                self._active_overhead_aircraft = overhead_ac
+                try:
+                    self._display_overhead(force_clear=False)
+                    captured = self.display_manager.image
+                finally:
+                    self._active_overhead_aircraft = None
                 if captured is not None:
                     return [captured.copy()]
                 return None
@@ -2392,7 +2406,6 @@ class FlightTrackerPlugin(BasePlugin):
             self.last_fr24_enrichment = 0.0
 
         aircraft_count = len(self.aircraft_data)
-        closest = self.get_closest_aircraft()
 
         # Resolve which internal view to render from the framework's slot name.
         # Granular slots (flight_tracker_map/_stats/_area/_flight_tracking/_live)
@@ -2429,10 +2442,16 @@ class FlightTrackerPlugin(BasePlugin):
                 has_airborne_tracked = any(
                     tf.status == "AIRBORNE" for tf in self.tracked_flight_data.values()
                 )
+                _, prox_ac = (
+                    self._closest_in_radius() if self.proximity_enabled else (None, None)
+                )
                 if has_airborne_tracked:
                     mode = 'flight_tracking'
-                elif self.proximity_enabled and closest and closest['distance_miles'] <= self.proximity_distance_miles:
+                elif prox_ac is not None:
                     mode = 'overhead'
+                    # Render the proximity aircraft itself (from the full pool), not
+                    # whatever the map-radius-limited get_closest_aircraft() returns.
+                    self._active_overhead_aircraft = prox_ac
                 else:
                     # Rotate through available modes
                     auto_modes = []
@@ -2844,10 +2863,17 @@ class FlightTrackerPlugin(BasePlugin):
 
     def _closest_in_radius(self):
         """Return (icao, aircraft) for the closest aircraft within the alert radius,
-        or (None, None) if nothing is within ``proximity_distance_miles``."""
-        if not self.aircraft_data:
+        or (None, None) if nothing is within ``proximity_distance_miles``.
+
+        Scans ``all_aircraft_data`` (the full fetched pool) rather than
+        ``aircraft_data`` (the map_radius_miles subset) so the overhead/live-priority
+        trigger is governed solely by ``proximity_distance_miles`` and is independent
+        of the map view's ``map_radius_miles``. Otherwise a small map radius would
+        silently cap the overhead radius at ``min(map_radius_miles, proximity_distance_miles)``."""
+        pool = self.all_aircraft_data or self.aircraft_data
+        if not pool:
             return None, None
-        icao, ac = min(self.aircraft_data.items(), key=lambda kv: kv[1]['distance_miles'])
+        icao, ac = min(pool.items(), key=lambda kv: kv[1]['distance_miles'])
         if ac['distance_miles'] <= self.proximity_distance_miles:
             return icao, ac
         return None, None
@@ -2871,8 +2897,9 @@ class FlightTrackerPlugin(BasePlugin):
         now = time.time()
 
         if self._lock_icao is not None:
-            # Keep the locked flight's data fresh while it is still tracked.
-            ac = self.aircraft_data.get(self._lock_icao)
+            # Keep the locked flight's data fresh while it is still tracked. Read
+            # from the full pool so a flight outside map_radius_miles still refreshes.
+            ac = self.all_aircraft_data.get(self._lock_icao) or self.aircraft_data.get(self._lock_icao)
             if ac is not None:
                 self._lock_aircraft = ac
             # Hold for the full window even if the plane has left the radius, so a

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-flights",
   "name": "Flight Tracker",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Real-time aircraft tracking with ADS-B/FlightRadar24/OpenSky/adsb.fi/adsb.lol data, map backgrounds, area mode, flight tracking, anchor airport, and flight records",
   "author": "ChuckBuilds",
   "entry_point": "manager.py",
@@ -34,6 +34,11 @@
   "min_ledmatrix_version": "2.0.0",
   "max_ledmatrix_version": "3.0.0",
   "versions": [
+    {
+      "released": "2026-06-08",
+      "version": "1.9.1",
+      "notes": "Fix: the overhead / live-priority view is now governed solely by proximity_distance_miles, independent of map_radius_miles. Previously a small map_radius_miles silently capped the overhead trigger radius (the candidate pool was filtered to the map radius before the proximity check), so aircraft inside proximity_distance_miles but outside the map view never triggered the live overhead card. The fetch radius now also covers proximity_distance_miles."
+    },
     {
       "released": "2026-06-05",
       "version": "1.9.0",
@@ -116,5 +121,5 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-06-01"
+  "last_updated": "2026-06-08"
 }

--- a/plugins/ledmatrix-flights/manifest.json
+++ b/plugins/ledmatrix-flights/manifest.json
@@ -37,7 +37,8 @@
     {
       "released": "2026-06-08",
       "version": "1.9.1",
-      "notes": "Fix: the overhead / live-priority view is now governed solely by proximity_distance_miles, independent of map_radius_miles. Previously a small map_radius_miles silently capped the overhead trigger radius (the candidate pool was filtered to the map radius before the proximity check), so aircraft inside proximity_distance_miles but outside the map view never triggered the live overhead card. The fetch radius now also covers proximity_distance_miles."
+      "notes": "Fix: the overhead / live-priority view is now governed solely by proximity_distance_miles, independent of map_radius_miles. Previously a small map_radius_miles silently capped the overhead trigger radius (the candidate pool was filtered to the map radius before the proximity check), so aircraft inside proximity_distance_miles but outside the map view never triggered the live overhead card. The fetch radius now also covers proximity_distance_miles.",
+      "ledmatrix_min": "2.0.0"
     },
     {
       "released": "2026-06-05",

--- a/plugins/ledmatrix-flights/test_overhead_radius.py
+++ b/plugins/ledmatrix-flights/test_overhead_radius.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Regression test: the overhead / live-priority trigger must be governed by
+``proximity_distance_miles`` alone, independent of ``map_radius_miles``.
+
+Reproduces the eave-board bug where ``map_radius_miles = 1.0`` (a tight map view)
+silently capped the overhead radius, so a plane 2 mi out — well inside the 3 mi
+``proximity_distance_miles`` — never triggered the live overhead view because the
+candidate pool (``aircraft_data``) had already been filtered to the map radius.
+
+Runs without the full display stack: it builds a bare manager via
+``object.__new__`` and sets only the attributes the proximity logic touches.
+
+Exit 0 = PASS, 1 = FAIL.
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(__file__))
+from manager import FlightTrackerPlugin  # noqa: E402
+
+
+def _make_manager(map_radius, proximity_radius):
+    """A FlightTrackerPlugin with only the proximity-state attributes set."""
+    m = object.__new__(FlightTrackerPlugin)
+    m.map_radius_miles = map_radius
+    m.proximity_distance_miles = proximity_radius
+    m.proximity_enabled = True
+    m.live_priority_enabled = True
+    # State machine fields read/written by _evaluate_proximity.
+    m._lock_icao = None
+    m._lock_aircraft = None
+    m._lock_start = 0.0
+    m._cooldown_until = 0.0
+    m.proximity_duration = 30.0
+    m.proximity_cooldown = 30.0
+    # aircraft_data = map_radius subset (empty: the plane is outside 1 mi).
+    # all_aircraft_data = full fetched pool (holds the 2 mi plane).
+    plane = {'icao': 'ABC123', 'callsign': 'TEST123', 'distance_miles': 2.0,
+             'last_seen': time.time(), 'lat': 47.37, 'lon': -122.29}
+    m.aircraft_data = {}
+    m.all_aircraft_data = {'ABC123': plane}
+    return m, plane
+
+
+def main():
+    failures = []
+
+    # 1. Plane at 2 mi, map_radius 1 mi, proximity 3 mi: must be found.
+    m, plane = _make_manager(map_radius=1.0, proximity_radius=3.0)
+    icao, ac = m._closest_in_radius()
+    if icao != 'ABC123' or ac is not plane:
+        failures.append(
+            f"_closest_in_radius() ignored a plane at 2mi inside the 3mi proximity "
+            f"radius because map_radius is 1mi (got icao={icao!r})")
+
+    # 2. The full state machine must lock onto it (live content == True).
+    m, plane = _make_manager(map_radius=1.0, proximity_radius=3.0)
+    if not m._evaluate_proximity():
+        failures.append("_evaluate_proximity() did not lock onto the 2mi overhead plane")
+    elif m._lock_aircraft is not plane:
+        failures.append("_evaluate_proximity() locked, but _lock_aircraft is wrong")
+
+    # 3. proximity_distance_miles is still respected: a plane beyond it must NOT trigger.
+    m, plane = _make_manager(map_radius=1.0, proximity_radius=3.0)
+    plane['distance_miles'] = 5.0  # outside the 3mi proximity radius
+    icao, ac = m._closest_in_radius()
+    if icao is not None:
+        failures.append(
+            f"_closest_in_radius() returned a plane at 5mi outside the 3mi proximity "
+            f"radius (got icao={icao!r})")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print("PASS: overhead trigger honors proximity_distance_miles independent of map_radius_miles")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The overhead / live-priority view is silently gated by `map_radius_miles`, even though it's meant to be controlled by `proximity_distance_miles`.

`_closest_in_radius()` scans `self.aircraft_data`, which is pre-filtered to `map_radius_miles`, and only *then* applies the `proximity_distance_miles` check. So the effective overhead radius is `min(map_radius_miles, proximity_distance_miles)`. With a tight map view (e.g. `map_radius_miles = 1`), aircraft well inside `proximity_distance_miles` never enter the candidate pool, so the live overhead card never triggers — the log shows `N aircraft in range` but `Currently tracking 0 aircraft` and `display() returned False` for `flight_tracker_live`.

On top of that, the fetch/stats radius is derived solely from `map_radius_miles` (`map_radius * 3`), so a `proximity_distance_miles` larger than that wouldn't even be fetched.

## Fix

Make the overhead/live trigger depend only on `proximity_distance_miles`, independent of the map view:

- `_closest_in_radius()` scans the full fetched pool (`all_aircraft_data`), still gated by `proximity_distance_miles`.
- The locked-flight refresh in `_evaluate_proximity()` reads from the full pool, so a flight outside `map_radius_miles` keeps refreshing while locked.
- The fetch radius now covers `max(map_radius_miles * 3, proximity_distance_miles)`.
- Both auto-mode paths (`display()` and `get_vegas_content()`) select and render the proximity aircraft from the full pool.

`map_radius_miles` now controls only the map/area rendering, as the config implies.

## Tests

- `plugins/ledmatrix-flights/test_overhead_radius.py` — reproduces the bug (plane at 2 mi, `map_radius_miles=1.0`, `proximity_distance_miles=3.0`); **fails before** the fix (`got icao=None`), **passes after**. Also asserts `proximity_distance_miles` is still respected (a plane at 5 mi does not trigger).
- Plugin safety harness (`check_plugin.py`): PASS at all sizes, no overflow/crash.

Version bumped 1.9.0 → 1.9.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overhead/live-view trigger to depend solely on proximity settings, not map boundaries.
  * Locked aircraft now maintain live view even when moving outside the map area.

* **Tests**
  * Added regression test for proximity-based overhead behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->