### PR TITLE
feat(weather): redesign almanac page for readability

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-08",
+  "last_updated": "2026-06-09",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -798,7 +798,7 @@
       "repo": "https://github.com/ChuckBuilds/ledmatrix-plugins",
       "branch": "main",
       "plugin_path": "plugins/ledmatrix-weather",
-      "latest_version": "2.3.2",
+      "latest_version": "2.4.0",
       "stars": 0,
       "downloads": 0,
       "last_updated": "2026-05-27",

--- a/plugins/ledmatrix-weather/manager.py
+++ b/plugins/ledmatrix-weather/manager.py
@@ -1205,17 +1205,87 @@ class WeatherPlugin(BasePlugin):
         else:
             return "moon-new"
 
-    def _format_unix_time(self, ts, offset=0):
-        """Format a unix timestamp to local time string like '6:42a'."""
+    def _format_unix_time(self, ts, offset=0, ampm_full=False):
+        """Format a unix timestamp to a local time string.
+
+        `ampm_full=False` gives the compact '6:42a' used on narrow panels;
+        `ampm_full=True` gives the clearer '6:42am' used where the column is
+        wide enough to spell it out.
+        """
         if not ts:
             return "---"
         from datetime import datetime, timezone, timedelta
         dt = datetime.fromtimestamp(ts, tz=timezone(timedelta(seconds=offset)))
         h = dt.hour
         m = dt.minute
-        ampm = "a" if h < 12 else "p"
+        if ampm_full:
+            suffix = "am" if h < 12 else "pm"
+        else:
+            suffix = "a" if h < 12 else "p"
         h12 = h % 12 or 12
-        return f"{h12}:{m:02d}{ampm}"
+        return f"{h12}:{m:02d}{suffix}"
+
+    ALMANAC_COL_GAP = 3  # px between the label / rise / dash / set columns
+
+    def _almanac_columns(self, draw, font, ampm_full, tz_offset,
+                         sunrise_ts, sunset_ts, moonrise_ts, moonset_ts):
+        """Geometry for the rise/set grid: a label column (Sun/Moon), two equal
+        time columns (rise, set) sized to the widest formatted time, and a fixed
+        '-' separator between them so both rows line up like a table. Offsets are
+        relative to the text column's left edge (the caller adds `text_x`).
+        Returns `label_w`, `time_w`, `gap`, `dash_w`, the `rise_right` and
+        `set_right` column right edges, the `dash_left` x, and `total` width."""
+        label_w = max(draw.textlength("Sun", font=font),
+                      draw.textlength("Moon", font=font))
+        times = (sunrise_ts, sunset_ts, moonrise_ts, moonset_ts)
+        time_w = max(
+            draw.textlength(self._format_unix_time(ts, tz_offset, ampm_full), font=font)
+            for ts in times)
+        dash_w = draw.textlength("-", font=font)
+        gap = self.ALMANAC_COL_GAP
+        rise_right = label_w + gap + time_w
+        dash_left = rise_right + gap
+        set_right = dash_left + dash_w + gap + time_w
+        return {"label_w": label_w, "time_w": time_w, "gap": gap, "dash_w": dash_w,
+                "rise_right": rise_right, "dash_left": dash_left,
+                "set_right": set_right, "total": set_right}
+
+    def _almanac_time_mode(self, draw, col_w, tz_offset,
+                           sunrise_ts, sunset_ts, moonrise_ts, moonset_ts):
+        """Choose how to render the rise/set times for the available text column.
+
+        Preferred is a column grid — label | rise | '-' | set — that lines the
+        two bodies up like a little table ('Sun 6:42am - 8:51pm' over 'Moon
+        9:14pm - 7:33am'). Returns ('range', True) when the grid fits with full
+        am/pm, ('range', False) when it only fits with the compact 'a'/'p', and
+        ('stacked', False) when the column is too narrow for the grid at all
+        (e.g. 64-wide, where the moon icon leaves ~30px) — there we fall back to
+        stacked sun-only times with up/down markers.
+        """
+        font = self.display_manager.extra_small_font
+
+        def fits(full):
+            cols = self._almanac_columns(
+                draw, font, full, tz_offset,
+                sunrise_ts, sunset_ts, moonrise_ts, moonset_ts)
+            # -2 keeps the right-most time off the panel's last column.
+            return cols["total"] <= col_w - 2
+
+        if fits(True):
+            return "range", True
+        if fits(False):
+            return "range", False
+        return "stacked", False
+
+    def _draw_rise_set_marker(self, draw, x, y, rising, color, size=4):
+        """Small up (rise) / down (set) triangle, `size` px tall, top-left at
+        (x, y). Used on narrow panels where a spelled-out label won't fit."""
+        if rising:
+            draw.polygon([(x, y + size - 1), (x + size - 1, y + size - 1),
+                          (x + (size - 1) / 2, y)], fill=color)
+        else:
+            draw.polygon([(x, y), (x + size - 1, y),
+                          (x + (size - 1) / 2, y + size - 1)], fill=color)
 
     def _truncate_to_width(self, draw, text, font, max_w):
         """Trim trailing characters until `text` fits within `max_w` pixels."""
@@ -1293,10 +1363,10 @@ class WeatherPlugin(BasePlugin):
             moonset_ts = moon.get('moonset')
             moon_phase = moon.get('phase')
 
+            # Compact strings for the narrow stacked fallback; the range layout
+            # formats from the timestamps directly (it picks full vs short am/pm).
             sunrise = self._format_unix_time(sunrise_ts, tz_offset)
             sunset = self._format_unix_time(sunset_ts, tz_offset)
-            moonrise = self._format_unix_time(moonrise_ts, tz_offset)
-            moonset = self._format_unix_time(moonset_ts, tz_offset)
             phase_name = self._get_moon_phase_name(moon_phase)
 
             # Day length
@@ -1307,9 +1377,11 @@ class WeatherPlugin(BasePlugin):
                 dm = int((diff % 3600) // 60)
                 day_len = f"{dh}h{dm}m"
 
-            # Moon phase icon (left side) — use most of the height
+            # Moon phase icon (left side). Cap the size so a tall panel (128x64)
+            # doesn't blow the icon up to ~58px, starving the text column — that
+            # truncated the phase name and wasted the bottom half of the panel.
             moon_icon_code = self._get_moon_icon_code(moon_phase)
-            icon_size = height - 6
+            icon_size = min(height - 6, 32)
 
             try:
                 moon_icon = WeatherIcons.load_weather_icon(moon_icon_code, icon_size)
@@ -1319,8 +1391,10 @@ class WeatherPlugin(BasePlugin):
             except Exception:
                 pass
 
-            # Text area starts after the icon
-            text_x = icon_size + 8
+            # Text area starts after the icon. Narrow panels use a tighter gap so
+            # the rise/set rows get every pixel of width they can.
+            gap = 4 if width < 100 else 8
+            text_x = icon_size + gap
             col_w = width - text_x
 
             # Size fonts and rows to the actual panel so nothing overflows the
@@ -1330,14 +1404,9 @@ class WeatherPlugin(BasePlugin):
             rows = layout["rows"]
             pct_font = layout["pct_font"]
 
-            def draw_pair(y, left, left_fill, right, right_fill):
-                """Left-aligned + right-aligned text on one row, each clamped to
-                the text column so neither bleeds off-panel."""
-                draw.text((text_x, y), self._truncate_to_width(draw, left, font_sm, col_w),
-                          font=font_sm, fill=left_fill)
-                right = self._truncate_to_width(draw, right, font_sm, col_w)
-                rx = max(text_x, width - draw.textlength(right, font=font_sm) - 2)
-                draw.text((rx, y), right, font=font_sm, fill=right_fill)
+            time_mode, ampm_full = self._almanac_time_mode(
+                draw, col_w, tz_offset,
+                sunrise_ts, sunset_ts, moonrise_ts, moonset_ts)
 
             # Row 1: Phase name (+ illumination %)
             if rows[0] is not None:
@@ -1349,20 +1418,53 @@ class WeatherPlugin(BasePlugin):
                     draw.text((width - pct_w - 2, rows[0]), pct,
                               font=pct_font, fill=(140, 140, 180))
 
-            # Row 2: Sunrise / Sunset
-            if rows[1] is not None:
-                draw_pair(rows[1], f"Rise {sunrise}", (255, 200, 0),
-                          f"Set {sunset}", (255, 120, 50))
+            if time_mode == "range":
+                # Rows 2-3: a label | rise | '-' | set grid so the two bodies line
+                # up like a table — rise times stack over rise times, set over set,
+                # with the hyphen in a fixed separator column between them.
+                cols = self._almanac_columns(
+                    draw, font_sm, ampm_full, tz_offset,
+                    sunrise_ts, sunset_ts, moonrise_ts, moonset_ts)
+                rise_right = text_x + cols["rise_right"]
+                dash_left = text_x + cols["dash_left"]
+                set_right = text_x + cols["set_right"]
 
-            # Row 3: Moonrise / Moonset
-            if rows[2] is not None:
-                draw_pair(rows[2], f"MR {moonrise}", (180, 180, 220),
-                          f"MS {moonset}", (140, 140, 180))
+                def draw_grid_row(y, label, rise_ts, set_ts, fill):
+                    draw.text((text_x, y), label, font=font_sm, fill=fill)
+                    rise_s = self._format_unix_time(rise_ts, tz_offset, ampm_full)
+                    set_s = self._format_unix_time(set_ts, tz_offset, ampm_full)
+                    # Right-align each time within its column so the digits stack.
+                    draw.text((rise_right - draw.textlength(rise_s, font=font_sm), y),
+                              rise_s, font=font_sm, fill=fill)
+                    draw.text((dash_left, y), "-", font=font_sm, fill=fill)
+                    draw.text((set_right - draw.textlength(set_s, font=font_sm), y),
+                              set_s, font=font_sm, fill=fill)
+
+                if rows[1] is not None:
+                    draw_grid_row(rows[1], "Sun", sunrise_ts, sunset_ts, (255, 200, 0))
+                if rows[2] is not None:
+                    draw_grid_row(rows[2], "Moon", moonrise_ts, moonset_ts, (180, 180, 220))
+            else:
+                # Stacked fallback (narrow panels): sunrise then sunset, each with
+                # an up/down marker. No room for a labeled range or the moon row.
+                text_budget = col_w - 8  # marker (4) + gap (2) + right margin (2)
+                if rows[1] is not None:
+                    self._draw_rise_set_marker(draw, text_x, rows[1] + 1, True, (255, 200, 0))
+                    draw.text((text_x + 6, rows[1]),
+                              self._truncate_to_width(draw, sunrise, font_sm, text_budget),
+                              font=font_sm, fill=(255, 200, 0))
+                if rows[2] is not None:
+                    self._draw_rise_set_marker(draw, text_x, rows[2] + 1, False, (255, 120, 50))
+                    draw.text((text_x + 6, rows[2]),
+                              self._truncate_to_width(draw, sunset, font_sm, text_budget),
+                              font=font_sm, fill=(255, 120, 50))
 
             # Row 4: Day length
             if day_len and rows[3] is not None:
-                draw.text((text_x, rows[3]), f"Day {day_len}", font=font_sm,
-                          fill=self.COLORS['dim'])
+                day_text = f"Day {day_len}" if time_mode == "range" else day_len
+                draw.text((text_x, rows[3]),
+                          self._truncate_to_width(draw, day_text, font_sm, col_w - 2),
+                          font=font_sm, fill=self.COLORS['dim'])
 
             self.display_manager.image = img
             self.display_manager.update_display()

--- a/plugins/ledmatrix-weather/manifest.json
+++ b/plugins/ledmatrix-weather/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-weather",
   "name": "Weather Display",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "author": "ChuckBuilds",
   "class_name": "WeatherPlugin",
   "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, almanac (sunrise/sunset, moon phase), precipitation radar, weather alerts, UV index, wind direction, and weather icons. Powered by Open-Meteo (free, no API key) + RainViewer.",
@@ -25,6 +25,12 @@
     "radar"
   ],
   "versions": [
+    {
+      "released": "2026-06-09",
+      "version": "2.4.0",
+      "note": "Redesign the almanac (moon) page for readability: replace cryptic 'MR/MS' with a 'Sun 6:42am - 8:51pm' / 'Moon 9:14pm - 7:33am' grid (label | rise | set columns aligned so the two rows line up), spell out am/pm where the panel is wide enough (compact 'a'/'p' where it isn't), cap the moon icon so tall panels no longer truncate the phase name, and add a stacked sun-only fallback so 64-wide panels stay legible.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-04",
       "version": "2.3.2",

--- a/plugins/ledmatrix-weather/test_almanac_layout.py
+++ b/plugins/ledmatrix-weather/test_almanac_layout.py
@@ -75,7 +75,9 @@ def check_layout_helper(w, h):
     from PIL import ImageDraw
     plugin = _new_plugin(w, h)
     draw = ImageDraw.Draw(Image.new("RGB", (w, h)))
-    text_x = (h - 6) + 8           # icon_size + 8, mirrors _display_almanac
+    icon_size = min(h - 6, 32)            # mirrors _display_almanac icon cap
+    gap = 4 if w < 100 else 8
+    text_x = icon_size + gap
     col_w = w - text_x
     body_h = 6
     pct_reserve = int(draw.textlength("100%", font=plugin.display_manager.extra_small_font)) + 2
@@ -117,6 +119,66 @@ def check_render_edges(w, h):
     return fails
 
 
+def check_time_mode(w, h):
+    """The rise/set rows must read clearly, not as cryptic 'MR/MS'. Wide short
+    panels (128x32, 256x32) get the labeled 'Sun 6:42am-8:51pm' range with full
+    am/pm; the cramped 64-wide panel falls back to stacked sun-only times rather
+    than truncating a range into garbage."""
+    from PIL import ImageDraw
+    plugin = _new_plugin(w, h)
+    draw = ImageDraw.Draw(Image.new("RGB", (w, h)))
+    icon_size = min(h - 6, 32)
+    gap = 4 if w < 100 else 8
+    col_w = w - (icon_size + gap)
+    data = weather_for_phase(0.5)
+    s, m = data["sun"], data["moon"]
+    mode, full = plugin._almanac_time_mode(
+        draw, col_w, data["timezone_offset"],
+        s["sunrise"], s["sunset"], m["moonrise"], m["moonset"])
+
+    fails = []
+    if w >= 128:
+        if mode != "range":
+            fails.append(f"expected labeled range on {w}-wide, got {mode!r}")
+        if not full:
+            fails.append(f"expected full am/pm on {w}-wide, got compact")
+    if w == 64 and mode != "stacked":
+        fails.append(f"expected stacked fallback on 64-wide, got {mode!r}")
+    return fails
+
+
+def check_columns(w, h):
+    """In range mode the rise/set times are laid out as a grid: every formatted
+    time fits inside its shared-width time column (so the two rows' rise times
+    stack and set times stack), and the whole grid stays inside the text column.
+    Narrow panels use the stacked fallback instead, so there's no grid to check."""
+    from PIL import ImageDraw
+    plugin = _new_plugin(w, h)
+    font = plugin.display_manager.extra_small_font
+    draw = ImageDraw.Draw(Image.new("RGB", (w, h)))
+    icon_size = min(h - 6, 32)
+    gap = 4 if w < 100 else 8
+    col_w = w - (icon_size + gap)
+    data = weather_for_phase(0.5)
+    s, m = data["sun"], data["moon"]
+    tz = data["timezone_offset"]
+    mode, full = plugin._almanac_time_mode(
+        draw, col_w, tz, s["sunrise"], s["sunset"], m["moonrise"], m["moonset"])
+    if mode != "range":
+        return []
+
+    cols = plugin._almanac_columns(
+        draw, font, full, tz, s["sunrise"], s["sunset"], m["moonrise"], m["moonset"])
+    fails = []
+    for ts in (s["sunrise"], s["sunset"], m["moonrise"], m["moonset"]):
+        tw = draw.textlength(plugin._format_unix_time(ts, tz, full), font=font)
+        if tw > cols["time_w"] + 0.01:
+            fails.append(f"time {tw:.0f}px overflows its {cols['time_w']:.0f}px column")
+    if cols["total"] > col_w - 2:
+        fails.append(f"grid {cols['total']:.0f}px exceeds text column {col_w - 2}px")
+    return fails
+
+
 def main():
     total_fail = 0
 
@@ -132,11 +194,38 @@ def main():
         else:
             print(f"PASS {tag}")
 
-    # Full render must stay on-panel where this dense page is meant to live
-    # (the moon icon makes 64-wide too cramped for the rise/set rows).
-    for (w, h) in [(128, 32), (256, 32), (128, 64)]:
+    # Full render must stay on-panel at every supported size, including the
+    # cramped 64-wide panel (the stacked fallback now keeps it on-panel where
+    # the old labeled rows bled off).
+    for (w, h) in SIZES:
         fails = check_render_edges(w, h)
         tag = f"render {w}x{h}"
+        if fails:
+            total_fail += 1
+            print(f"FAIL {tag}:")
+            for f in fails:
+                print(f"       {f}")
+        else:
+            print(f"PASS {tag}")
+
+    # Rise/set rows read clearly (labeled range + full am/pm where it fits,
+    # stacked fallback where it doesn't) instead of the old cryptic MR/MS.
+    for (w, h) in SIZES:
+        fails = check_time_mode(w, h)
+        tag = f"time-mode {w}x{h}"
+        if fails:
+            total_fail += 1
+            print(f"FAIL {tag}:")
+            for f in fails:
+                print(f"       {f}")
+        else:
+            print(f"PASS {tag}")
+
+    # In range mode the times line up as a grid (shared time columns) and the
+    # whole label | rise | '-' | set grid stays inside the text column.
+    for (w, h) in SIZES:
+        fails = check_columns(w, h)
+        tag = f"columns {w}x{h}"
         if fails:
             total_fail += 1
             print(f"FAIL {tag}:")


### PR DESCRIPTION
The almanac (moon) page was hard to parse at a glance. The moon rise/set row used cryptic **`MR`/`MS`** labels while the sun row spelled out `Rise`/`Set`, so the eye couldn't pattern-match the two as the same kind of data, and the single-letter am/pm (`6:42a`) read ambiguously even on panels with room to spare.

## What changed

- **Label each body, show rise→set as a range:** `Sun 6:42am - 8:51pm` / `Moon 9:14pm - 7:33am`. Consistent, no cryptic abbreviations.
- **Adaptive am/pm:** spelled out where the text column is wide enough (128×32, 256×32), compact `a`/`p` where it isn't — decided per panel size.
- **Narrow-panel fallback:** on 64-wide panels, where even a compact labeled range can't fit beside the moon icon, fall back to stacked sun-only times with up/down markers instead of truncating a range into garbage (`Sun 6:4`).
- **Icon cap:** the moon icon was scaling to `height - 6` (~58px on 128×64), which truncated the phase name and starved the text column. Capped at 32px.

## Before / after

**128×32**

![128x32](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/almanac-screenshots/compare_128x32.png)

**64×32** (narrow fallback — old layout bled off-panel)

![64x32](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/almanac-screenshots/compare_64x32.png)

**128×64** (icon cap — old layout truncated the phase name)

![128x64](https://raw.githubusercontent.com/rpierce99/ledmatrix-plugins/almanac-screenshots/compare_128x64.png)

## Testing

- `test_almanac_layout.py` extended: the layout-mode decision is asserted per size (labeled range + full am/pm on wide panels, stacked fallback on 64-wide), and the full render is now edge-checked at 64×32 too (previously skipped because the old layout bled off-panel there).
- Passes the cross-size safety harness (`scripts/check_plugin.py`) at every supported size.
- Manifest bumped 2.3.2 → 2.4.0; `plugins.json` synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weather Display plugin updated to v2.4.0 with a redesigned almanac (moon) page
  * Improved sun/moon rise-set time displays with better labeling and readability
  * Adaptive AM/PM formatting that adjusts based on panel width
  * Enhanced layout and icon sizing for different display dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->