### PR TITLE
fix(baseball-scoreboard): disable anti-aliasing for outlined text

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-08",
+  "last_updated": "2026-06-09",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -49,7 +49,7 @@
       "last_updated": "2026-06-05",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.3"
+      "latest_version": "1.6.4"
     },
     {
       "id": "basketball-scoreboard",

--- a/plugins/baseball-scoreboard/game_renderer.py
+++ b/plugins/baseball-scoreboard/game_renderer.py
@@ -189,6 +189,11 @@ class GameRenderer:
     def _draw_text_with_outline(self, draw, text, position, font,
                                fill=(255, 255, 255), outline_color=(0, 0, 0)):
         """Draw text with a black outline for better readability."""
+        # Disable anti-aliasing: pixel/bitmap fonts (e.g. PressStart2P) get
+        # anti-aliased into dim partial-lit pixels on a 1:1 LED matrix, muddying
+        # glyphs. 1-bit mode keeps strokes crisp. See _draw_text_with_outline in
+        # sports.py for the same fix on the switch-mode renderer.
+        draw.fontmode = "1"
         x, y = position
         for dx, dy in [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]:
             draw.text((x + dx, y + dy), text, font=font, fill=outline_color)

--- a/plugins/baseball-scoreboard/manifest.json
+++ b/plugins/baseball-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "baseball-scoreboard",
   "name": "Baseball Scoreboard",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming baseball games across MLB, MiLB, and NCAA Baseball with real-time scores and schedules",
   "category": "sports",
@@ -30,6 +30,12 @@
   "branch": "main",
   "plugin_path": "plugins/baseball-scoreboard",
   "versions": [
+    {
+      "released": "2026-06-09",
+      "version": "1.6.4",
+      "notes": "Disable anti-aliasing when drawing the outlined text (scores, status, date). The pixel/bitmap fonts (e.g. PressStart2P) were being anti-aliased into dim partial-lit pixels on a 1:1 LED matrix, muddying glyphs so a '6' could read as a 'G'. Drawing in 1-bit mode keeps digits crisp.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-05",
       "version": "1.6.3",

--- a/plugins/baseball-scoreboard/sports.py
+++ b/plugins/baseball-scoreboard/sports.py
@@ -470,6 +470,11 @@ class SportsCore(ABC):
         self, draw, text, position, font, fill=(255, 255, 255), outline_color=(0, 0, 0)
     ):
         """Draw text with a black outline for better readability."""
+        # Disable anti-aliasing: the scoreboard uses pixel/bitmap fonts (e.g.
+        # PressStart2P) which FreeType anti-aliases into dim partial-lit pixels
+        # on a 1:1 LED matrix, muddying glyphs (a "6" can read as "G"). Drawing
+        # in 1-bit mode keeps strokes crisp and legible.
+        draw.fontmode = "1"
         x, y = position
         for dx, dy in [
             (-1, -1),

--- a/plugins/baseball-scoreboard/test_score_antialiasing.py
+++ b/plugins/baseball-scoreboard/test_score_antialiasing.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Regression test: _draw_text_with_outline must disable anti-aliasing.
+
+The scoreboard renders pixel/bitmap fonts (e.g. PressStart2P) on a 1:1 LED
+matrix. With anti-aliasing on (PIL's default), FreeType blends glyph edges into
+dim partial-lit pixels, which on the matrix muddy the digits (a "6" can read as
+a "G"). Both text-outline helpers (sports.py switch-mode renderer and
+game_renderer.py scroll renderer) must set ``draw.fontmode = "1"`` so glyphs
+render crisp.
+
+This test draws a pixel-font glyph through each helper and asserts the result
+has zero partial-lit (anti-aliased) pixels. It FAILS before the fontmode fix and
+PASSES after.
+
+Run with the core venv from anywhere:
+    /path/to/LEDMatrix/.venv/bin/python test_score_antialiasing.py
+"""
+
+import os
+import sys
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def _find_pixel_font():
+    """Locate PressStart2P-Regular.ttf in the core assets dir.
+
+    The plugin runs inside LEDMatrix/plugin-repos/<id>/, so the core fonts are a
+    couple levels up. Search upward and a few known spots.
+    """
+    name = "PressStart2P-Regular.ttf"
+    candidates = []
+    d = PLUGIN_DIR
+    for _ in range(6):
+        candidates.append(os.path.join(d, "assets", "fonts", name))
+        d = os.path.dirname(d)
+    candidates.append(os.path.join(os.getcwd(), "assets", "fonts", name))
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def _partial_lit_pixels(font):
+    """Draw a glyph via the (unbound) helper and count anti-aliased pixels.
+
+    Returns (partials, fontmode) where partials is the number of pixels that are
+    neither fully off nor fully on in the alpha channel — i.e. anti-aliasing.
+    """
+    from game_renderer import GameRenderer
+
+    img = Image.new("RGBA", (24, 16), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    # Call the real method unbound; it uses no instance state, so self can be None.
+    GameRenderer._draw_text_with_outline(None, draw, "6", (2, 1), font, fill=(255, 200, 0))
+    alpha = img.split()[3].load()
+    partials = sum(
+        1 for y in range(img.height) for x in range(img.width) if 0 < alpha[x, y] < 255
+    )
+    return partials, getattr(draw, "fontmode", None)
+
+
+def _partial_lit_pixels_sports(font):
+    from sports import SportsCore
+
+    img = Image.new("RGBA", (24, 16), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    # SportsCore is abstract; the method uses no instance state, so call unbound.
+    SportsCore._draw_text_with_outline(None, draw, "6", (2, 1), font, fill=(255, 200, 0))
+    alpha = img.split()[3].load()
+    partials = sum(
+        1 for y in range(img.height) for x in range(img.width) if 0 < alpha[x, y] < 255
+    )
+    return partials, getattr(draw, "fontmode", None)
+
+
+def main():
+    font_path = _find_pixel_font()
+    if not font_path:
+        print("SKIP: could not locate PressStart2P-Regular.ttf (run from LEDMatrix tree)")
+        # Skipping is not a pass; signal an error so the gap is visible.
+        return 2
+    # Size 10 does not land on the pixel grid -> heavy anti-aliasing if enabled.
+    font = ImageFont.truetype(font_path, 10)
+
+    failures = []
+    for label, fn in (
+        ("game_renderer.GameRenderer", _partial_lit_pixels),
+        ("sports.SportsCore", _partial_lit_pixels_sports),
+    ):
+        partials, fontmode = fn(font)
+        ok = partials == 0 and fontmode == "1"
+        status = "PASS" if ok else "FAIL"
+        print(f"[{status}] {label}: anti-aliased pixels={partials}, fontmode={fontmode!r}")
+        if not ok:
+            failures.append(label)
+
+    if failures:
+        print(f"\nFAILED: {', '.join(failures)} still anti-aliases pixel fonts")
+        return 1
+    print("\nPASS: both outline helpers disable anti-aliasing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

On a 1:1 RGB LED matrix, the baseball scoreboard's scores/status/date are drawn with pixel/bitmap fonts (e.g. PressStart2P). PIL/FreeType anti-aliases these by default, blending glyph edges into **dim partial-lit pixels**. On the physical panel those faint LEDs muddy the digits — most visibly a **"6" reads as a "G"** (reported by a user on a 128x32 board).

## Fix

Set `draw.fontmode = "1"` (1-bit, no anti-aliasing) in both `_draw_text_with_outline` helpers:
- `sports.py` — the switch-mode renderer used by live/recent/upcoming cards
- `game_renderer.py` — the scroll-mode renderer

Anti-aliasing only ever hurts these pixel fonts on a 1:1 matrix, so disabling it keeps every glyph crisp. No layout, color, or font changes.

## Test

Adds `test_score_antialiasing.py`: draws a glyph through each helper and asserts zero anti-aliased (partial-lit) pixels. Verified it **fails before** the change (39 AA pixels, `fontmode='L'`) and **passes after** (0 AA pixels, `fontmode='1'`).

Cross-size safety harness (`check_plugin.py`) passes on all sizes/modes (64x32 → 256x128).

Bumps manifest to `1.6.4` and syncs `plugins.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)