### PR TITLE
fix(weather): geocode location once and cache coordinates permanently

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-09",
+  "last_updated": "2026-06-10",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -798,10 +798,10 @@
       "repo": "https://github.com/ChuckBuilds/ledmatrix-plugins",
       "branch": "main",
       "plugin_path": "plugins/ledmatrix-weather",
-      "latest_version": "2.4.0",
+      "latest_version": "2.5.0",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-05-27",
+      "last_updated": "2026-06-10",
       "verified": true,
       "screenshot": ""
     },

--- a/plugins/ledmatrix-weather/config_schema.json
+++ b/plugins/ledmatrix-weather/config_schema.json
@@ -45,6 +45,16 @@
       "description": "Country code (e.g., US, GB, CA, FR). Use ISO 3166-1 alpha-2 codes.",
       "title": "Country Code"
     },
+    "location_latitude": {
+      "type": "number",
+      "description": "Optional. Exact latitude (-90 to 90). When both latitude and longitude are set, geocoding is skipped entirely.",
+      "title": "Latitude (optional)"
+    },
+    "location_longitude": {
+      "type": "number",
+      "description": "Optional. Exact longitude (-180 to 180). When both latitude and longitude are set, geocoding is skipped entirely.",
+      "title": "Longitude (optional)"
+    },
     "units": {
       "type": "string",
       "enum": [

--- a/plugins/ledmatrix-weather/manager.py
+++ b/plugins/ledmatrix-weather/manager.py
@@ -67,7 +67,11 @@ class WeatherPlugin(BasePlugin):
             'state': config.get('location_state', 'Texas'),
             'country': config.get('location_country', 'US')
         }
-        
+
+        # Optional explicit coordinates. When set, geocoding is skipped entirely.
+        self._coord_override = self._parse_coord_override(
+            config.get('location_latitude'), config.get('location_longitude'))
+
         self.units = config.get('units', 'imperial')
         
         # Handle update_interval - ensure it's an int
@@ -102,6 +106,7 @@ class WeatherPlugin(BasePlugin):
         self.hourly_forecast = None
         self.daily_forecast = None
         self.last_update = 0
+        self._coords = None  # last successfully resolved (lat, lon)
         
         # Error handling and throttling
         self.consecutive_errors = 0
@@ -272,6 +277,10 @@ class WeatherPlugin(BasePlugin):
             'state': new_config.get('location_state', self.location.get('state', 'Texas')),
             'country': new_config.get('location_country', self.location.get('country', 'US')),
         }
+        # Location may have changed — drop the in-memory coords so they re-resolve.
+        self._coord_override = self._parse_coord_override(
+            new_config.get('location_latitude'), new_config.get('location_longitude'))
+        self._coords = None
         self.units = new_config.get('units', self.units)
         self.show_current = new_config.get('show_current_weather', self.show_current)
         self.show_hourly = new_config.get('show_hourly_forecast', self.show_hourly)
@@ -395,6 +404,84 @@ class WeatherPlugin(BasePlugin):
             line_color=line_color, fill_color=fill_color,
         )
 
+    # Coordinates for a fixed location never change, so geocode once and cache
+    # the result permanently — the geocoding API is only ever hit on a cache
+    # miss (first run for a location, or after the city is changed in config).
+    COORDS_MAX_AGE = 10 * 365 * 24 * 3600   # effectively forever
+
+    @staticmethod
+    def _parse_coord_override(lat, lon):
+        """Return (lat, lon) as floats if both are present and in valid range, else None."""
+        if lat is None or lon is None or lat == '' or lon == '':
+            return None
+        try:
+            lat_f, lon_f = float(lat), float(lon)
+        except (TypeError, ValueError):
+            return None
+        if -90 <= lat_f <= 90 and -180 <= lon_f <= 180:
+            return (lat_f, lon_f)
+        return None
+
+    def _resolve_coords(self, city: str, state: str, country: str):
+        """Resolve (lat, lon) for the configured location.
+
+        Geocodes once per location and caches the result across update cycles
+        and restarts. Cities don't move, so a cached coordinate is always valid
+        and the geocoding API is only ever called on a true cache miss.
+        """
+        # 1) Explicit config override — no network at all.
+        if self._coord_override is not None:
+            return self._coord_override
+
+        # 2) Resolved earlier this run.
+        if self._coords is not None:
+            return self._coords
+
+        # 3) Persistent cache. A cached value never goes stale (the location is
+        #    fixed), so this is the only thing that prevents a geocode call.
+        coords_key = f"{self.plugin_id}:{city}:{state}:{country}:coords"
+        cached = self.cache_manager.get(coords_key, max_age=self.COORDS_MAX_AGE)
+        if cached and 'lat' in cached and 'lon' in cached:
+            self._coords = (cached['lat'], cached['lon'])
+            return self._coords
+
+        # 4) Cache miss — geocode once and cache the result. If geocoding is down
+        #    on a cold cache there's nothing to fall back to, so the error
+        #    propagates to update()'s normal retry/backoff path.
+        lat, lon = self._geocode(city, state, country)
+        self._coords = (lat, lon)
+        self.cache_manager.set(coords_key, {'lat': lat, 'lon': lon})
+        return self._coords
+
+    def _geocode(self, city: str, state: str, country: str):
+        """Look up coordinates for a place name via the Open-Meteo geocoding API."""
+        from urllib.parse import quote_plus
+        geo_url = f"https://geocoding-api.open-meteo.com/v1/search?name={quote_plus(city)}&count=5&language=en&format=json"
+        try:
+            response = requests.get(geo_url, timeout=10)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            self._last_error_hint = f"Geo API error {status}"
+            self.logger.error(f"Open-Meteo geocoding HTTP error {status}: {e}")
+            raise
+
+        results = response.json().get('results', [])
+        if not results:
+            self._last_error_hint = f"Unknown: {city}"
+            msg = f"Could not find coordinates for {city}, {state}, {country}"
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+        # Pick the best result by matching country code
+        country_upper = country.upper() if country else ''
+        lat, lon = results[0]['latitude'], results[0]['longitude']
+        for r in results:
+            if r.get('country_code', '').upper() == country_upper:
+                lat, lon = r['latitude'], r['longitude']
+                break
+        return lat, lon
+
     def _fetch_weather(self) -> None:
         """Fetch weather data from Open-Meteo API (free, no API key required)."""
         city = self.location.get('city', 'Dallas')
@@ -428,32 +515,10 @@ class WeatherPlugin(BasePlugin):
                 self.logger.info("Using cached weather data")
                 return
 
-        # Step A: Geocoding via Open-Meteo geocoding API
-        from urllib.parse import quote_plus
-        geo_url = f"https://geocoding-api.open-meteo.com/v1/search?name={quote_plus(city)}&count=5&language=en&format=json"
-        try:
-            response = requests.get(geo_url, timeout=10)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            status = e.response.status_code if e.response is not None else None
-            self._last_error_hint = f"Geo API error {status}"
-            self.logger.error(f"Open-Meteo geocoding HTTP error {status}: {e}")
-            raise
-
-        results = response.json().get('results', [])
-        if not results:
-            self._last_error_hint = f"Unknown: {city}"
-            msg = f"Could not find coordinates for {city}, {state}, {country}"
-            self.logger.error(msg)
-            raise ValueError(msg)
-
-        # Pick the best result by matching country code
+        # Step A: Resolve coordinates. These are geocoded once and cached, so a
+        # slow or failing geocoding API can't block (or blank) the weather data.
         country_upper = country.upper() if country else ''
-        lat, lon = results[0]['latitude'], results[0]['longitude']
-        for r in results:
-            if r.get('country_code', '').upper() == country_upper:
-                lat, lon = r['latitude'], r['longitude']
-                break
+        lat, lon = self._resolve_coords(city, state, country)
 
         # Step B: Fetch forecast from Open-Meteo
         temp_unit = "fahrenheit" if self.units == "imperial" else "celsius"

--- a/plugins/ledmatrix-weather/manifest.json
+++ b/plugins/ledmatrix-weather/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ledmatrix-weather",
   "name": "Weather Display",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": "ChuckBuilds",
   "class_name": "WeatherPlugin",
   "description": "Comprehensive weather display with current conditions, hourly forecast, daily forecast, almanac (sunrise/sunset, moon phase), precipitation radar, weather alerts, UV index, wind direction, and weather icons. Powered by Open-Meteo (free, no API key) + RainViewer.",
@@ -25,6 +25,12 @@
     "radar"
   ],
   "versions": [
+    {
+      "released": "2026-06-10",
+      "version": "2.5.0",
+      "note": "Geocode the configured location once and cache the coordinates permanently across update cycles and restarts, instead of re-resolving every refresh. Cities don't move, so the geocoding API is now only ever called on a cache miss — eliminating the per-refresh geocoding timeouts that previously aborted the whole weather update, blanked the widget, and triggered up-to-an-hour error backoff. Add optional location_latitude/location_longitude config fields to skip geocoding entirely.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-09",
       "version": "2.4.0",
@@ -101,7 +107,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-05-27",
+  "last_updated": "2026-06-10",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/ledmatrix-weather/test_geocode_cache.py
+++ b/plugins/ledmatrix-weather/test_geocode_cache.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Regression test for geocode caching + last-known-coords fallback.
+
+Before the fix, the weather plugin geocoded the configured city on *every*
+refresh (every update_interval, on cache expiry) as a hard prerequisite to the
+forecast call. When the Open-Meteo geocoding endpoint timed out, the whole
+weather update aborted before any forecast was fetched, exponential backoff
+disabled the widget for up to an hour, and a freshly-restarted plugin (no
+cached weather) rendered blank — "weather widget fails to load".
+
+The fix resolves coordinates once and caches them permanently across cycles and
+restarts. Cities don't move, so a cached coordinate never goes stale and the
+geocoding API is only ever called on a true cache miss.
+
+Run with the core venv from a LEDMatrix checkout so manager's imports resolve:
+    LEDMatrix/.venv/bin/python <thisfile>
+"""
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from manager import WeatherPlugin  # noqa: E402
+
+logging.getLogger().addHandler(logging.NullHandler())
+
+
+class FakeCache:
+    """Minimal cache_manager double with controllable entry age."""
+
+    def __init__(self):
+        self.store = {}  # key -> (data, age_seconds)
+
+    def set(self, key, data, ttl=None):
+        self.store[key] = (data, 0)
+
+    def get(self, key, max_age=300):
+        if key not in self.store:
+            return None
+        data, age = self.store[key]
+        return data if age <= max_age else None
+
+    def age(self, key, seconds):
+        """Pretend an existing entry was written `seconds` ago."""
+        data, _ = self.store[key]
+        self.store[key] = (data, seconds)
+
+
+def _new_plugin(cache, override=None, coords=None):
+    p = object.__new__(WeatherPlugin)
+    p.plugin_id = "ledmatrix-weather"
+    p.cache_manager = cache
+    p.logger = logging.getLogger("test-weather")
+    p._coord_override = override
+    p._coords = coords
+    p._last_error_hint = None
+    return p
+
+
+def _counting_geocode(result=(47.0, -122.0), fail_with=None):
+    """Return a _geocode replacement that records how many times it ran."""
+    calls = {"n": 0}
+
+    def geocode(self, city, state, country):
+        calls["n"] += 1
+        if fail_with is not None:
+            raise fail_with
+        return result
+
+    return geocode, calls
+
+
+def check_resolves_once_then_reuses():
+    cache = FakeCache()
+    p = _new_plugin(cache)
+    geocode, calls = _counting_geocode((47.0, -122.0))
+    p._geocode = geocode.__get__(p, WeatherPlugin)
+
+    first = p._resolve_coords("Federal Way", "WA", "US")
+    second = p._resolve_coords("Federal Way", "WA", "US")
+
+    fails = []
+    if first != (47.0, -122.0) or second != (47.0, -122.0):
+        fails.append(f"expected (47.0, -122.0) both times, got {first} / {second}")
+    if calls["n"] != 1:
+        fails.append(f"expected exactly 1 geocode call, got {calls['n']}")
+    return fails
+
+
+def check_reuses_across_restart():
+    """A fresh instance (in-memory coords gone, as after a restart) reads the
+    fresh cached coords without geocoding."""
+    cache = FakeCache()
+    seed = _new_plugin(cache)
+    geocode, _ = _counting_geocode((47.0, -122.0))
+    seed._geocode = geocode.__get__(seed, WeatherPlugin)
+    seed._resolve_coords("Federal Way", "WA", "US")  # populate cache
+
+    p = _new_plugin(cache)  # "restart": _coords is None
+    geocode2, calls2 = _counting_geocode((1.0, 1.0))  # would differ if called
+    p._geocode = geocode2.__get__(p, WeatherPlugin)
+    coords = p._resolve_coords("Federal Way", "WA", "US")
+
+    fails = []
+    if coords != (47.0, -122.0):
+        fails.append(f"expected cached (47.0, -122.0), got {coords}")
+    if calls2["n"] != 0:
+        fails.append(f"expected 0 geocode calls on restart, got {calls2['n']}")
+    return fails
+
+
+def check_cached_coords_never_expire():
+    """THE headline regression: cities don't move, so a cached coordinate is
+    reused no matter how old it is — the geocoding API is never called again
+    once a location has been resolved."""
+    cache = FakeCache()
+    seed = _new_plugin(cache)
+    geocode, _ = _counting_geocode((47.0, -122.0))
+    seed._geocode = geocode.__get__(seed, WeatherPlugin)
+    seed._resolve_coords("Federal Way", "WA", "US")  # populate cache
+
+    coords_key = "ledmatrix-weather:Federal Way:WA:US:coords"
+    cache.age(coords_key, 5 * 365 * 24 * 3600)  # 5 years old
+
+    p = _new_plugin(cache)  # restart: in-memory coords gone
+    geocode2, calls2 = _counting_geocode((1.0, 1.0))  # would differ if called
+    p._geocode = geocode2.__get__(p, WeatherPlugin)
+    coords = p._resolve_coords("Federal Way", "WA", "US")
+
+    fails = []
+    if coords != (47.0, -122.0):
+        fails.append(f"expected cached (47.0, -122.0), got {coords}")
+    if calls2["n"] != 0:
+        fails.append(f"a 5-year-old cached coord must not re-geocode, got {calls2['n']} call(s)")
+    return fails
+
+
+def check_raises_when_never_resolved():
+    """With no cached coords at all, a geocode failure still propagates so the
+    normal error/backoff path runs."""
+    cache = FakeCache()
+    p = _new_plugin(cache)
+    geocode, _ = _counting_geocode(fail_with=TimeoutError("read timed out"))
+    p._geocode = geocode.__get__(p, WeatherPlugin)
+    try:
+        p._resolve_coords("Nowhere", "XX", "US")
+    except TimeoutError:
+        return []
+    return ["expected TimeoutError to propagate when no coords were ever cached"]
+
+
+def check_override_skips_geocoding():
+    cache = FakeCache()
+    p = _new_plugin(cache, override=(10.0, 20.0))
+    geocode, calls = _counting_geocode((47.0, -122.0))
+    p._geocode = geocode.__get__(p, WeatherPlugin)
+    coords = p._resolve_coords("Federal Way", "WA", "US")
+
+    fails = []
+    if coords != (10.0, 20.0):
+        fails.append(f"expected override (10.0, 20.0), got {coords}")
+    if calls["n"] != 0:
+        fails.append(f"override must skip geocoding, but geocoded {calls['n']}x")
+    return fails
+
+
+def check_parse_override():
+    cases = [
+        ((47.5, -122.3), (47.5, -122.3)),   # valid floats
+        (("47.5", "-122.3"), (47.5, -122.3)),  # numeric strings
+        ((None, -122.3), None),             # missing one
+        (("", ""), None),                   # empty strings
+        ((91.0, 0.0), None),                # lat out of range
+        ((0.0, 181.0), None),               # lon out of range
+        (("x", "y"), None),                 # non-numeric
+    ]
+    fails = []
+    for (lat, lon), expected in cases:
+        got = WeatherPlugin._parse_coord_override(lat, lon)
+        if got != expected:
+            fails.append(f"_parse_coord_override({lat!r}, {lon!r}) = {got}, expected {expected}")
+    return fails
+
+
+CHECKS = [
+    ("resolve once then reuse", check_resolves_once_then_reuses),
+    ("reuse across restart", check_reuses_across_restart),
+    ("cached coords never expire", check_cached_coords_never_expire),
+    ("raise when never resolved", check_raises_when_never_resolved),
+    ("override skips geocoding", check_override_skips_geocoding),
+    ("parse override validation", check_parse_override),
+]
+
+
+def main():
+    total_fail = 0
+    for name, fn in CHECKS:
+        fails = fn()
+        if fails:
+            total_fail += 1
+            print(f"FAIL {name}:")
+            for f in fails:
+                print(f"       {f}")
+        else:
+            print(f"PASS {name}")
+    if total_fail:
+        print(f"\n{total_fail} check(s) failed")
+        sys.exit(1)
+    print("\nGeocode-once-and-cache behavior holds")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/ledmatrix-weather/test_geocode_cache.py
+++ b/plugins/ledmatrix-weather/test_geocode_cache.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression test for geocode caching + last-known-coords fallback.
+"""Regression test for geocode-once-and-cache coordinate resolution.
 
 Before the fix, the weather plugin geocoded the configured city on *every*
 refresh (every update_interval, on cache expiry) as a hard prerequisite to the
@@ -58,10 +58,11 @@ def _new_plugin(cache, override=None, coords=None):
 
 
 def _counting_geocode(result=(47.0, -122.0), fail_with=None):
-    """Return a _geocode replacement that records how many times it ran."""
+    """Return a _geocode replacement (assigned as an instance attribute, so it
+    is called without `self`) that records how many times it ran."""
     calls = {"n": 0}
 
-    def geocode(self, city, state, country):
+    def geocode(city, state, country):
         calls["n"] += 1
         if fail_with is not None:
             raise fail_with
@@ -74,7 +75,7 @@ def check_resolves_once_then_reuses():
     cache = FakeCache()
     p = _new_plugin(cache)
     geocode, calls = _counting_geocode((47.0, -122.0))
-    p._geocode = geocode.__get__(p, WeatherPlugin)
+    p._geocode = geocode
 
     first = p._resolve_coords("Federal Way", "WA", "US")
     second = p._resolve_coords("Federal Way", "WA", "US")
@@ -93,12 +94,12 @@ def check_reuses_across_restart():
     cache = FakeCache()
     seed = _new_plugin(cache)
     geocode, _ = _counting_geocode((47.0, -122.0))
-    seed._geocode = geocode.__get__(seed, WeatherPlugin)
+    seed._geocode = geocode
     seed._resolve_coords("Federal Way", "WA", "US")  # populate cache
 
     p = _new_plugin(cache)  # "restart": _coords is None
     geocode2, calls2 = _counting_geocode((1.0, 1.0))  # would differ if called
-    p._geocode = geocode2.__get__(p, WeatherPlugin)
+    p._geocode = geocode2
     coords = p._resolve_coords("Federal Way", "WA", "US")
 
     fails = []
@@ -116,7 +117,7 @@ def check_cached_coords_never_expire():
     cache = FakeCache()
     seed = _new_plugin(cache)
     geocode, _ = _counting_geocode((47.0, -122.0))
-    seed._geocode = geocode.__get__(seed, WeatherPlugin)
+    seed._geocode = geocode
     seed._resolve_coords("Federal Way", "WA", "US")  # populate cache
 
     coords_key = "ledmatrix-weather:Federal Way:WA:US:coords"
@@ -124,7 +125,7 @@ def check_cached_coords_never_expire():
 
     p = _new_plugin(cache)  # restart: in-memory coords gone
     geocode2, calls2 = _counting_geocode((1.0, 1.0))  # would differ if called
-    p._geocode = geocode2.__get__(p, WeatherPlugin)
+    p._geocode = geocode2
     coords = p._resolve_coords("Federal Way", "WA", "US")
 
     fails = []
@@ -141,7 +142,7 @@ def check_raises_when_never_resolved():
     cache = FakeCache()
     p = _new_plugin(cache)
     geocode, _ = _counting_geocode(fail_with=TimeoutError("read timed out"))
-    p._geocode = geocode.__get__(p, WeatherPlugin)
+    p._geocode = geocode
     try:
         p._resolve_coords("Nowhere", "XX", "US")
     except TimeoutError:
@@ -153,7 +154,7 @@ def check_override_skips_geocoding():
     cache = FakeCache()
     p = _new_plugin(cache, override=(10.0, 20.0))
     geocode, calls = _counting_geocode((47.0, -122.0))
-    p._geocode = geocode.__get__(p, WeatherPlugin)
+    p._geocode = geocode
     coords = p._resolve_coords("Federal Way", "WA", "US")
 
     fails = []


### PR DESCRIPTION
## Problem

The weather plugin geocoded the configured city to lat/lon on **every** refresh (each `update_interval`, on cache expiry) as a hard prerequisite to the forecast call:

```python
response = requests.get(geo_url, timeout=10)   # Step A: geocode
...
response = requests.get(forecast_url, timeout=10)  # Step B: never reached if A times out
```

When `geocoding-api.open-meteo.com` timed out, the whole weather update aborted before any forecast was fetched. Two things made it bad:

1. A `ReadTimeout` isn't caught locally — the only `except` around the geocode is `requests.exceptions.HTTPError`, so a read timeout falls through to `update()`'s generic handler.
2. That handler applies exponential backoff, doubling up to 3600s. After 5 consecutive geocode timeouts the widget is disabled for up to an hour, and a freshly-restarted plugin (no cached weather) renders blank.

Observed in the wild as recurring `HTTPSConnectionPool(host='geocoding-api.open-meteo.com', port=443): Read timed out` errors with `update() took 19.23s` and the weather widget failing to load.

## Fix

Cities don't move, so resolve coordinates **once** and cache them permanently across update cycles and restarts. The geocoding API is now only ever called on a true cache miss (first run for a location, or after the city is changed in config), removing the recurring per-refresh network dependency entirely.

- New `_resolve_coords()`: config override → in-memory → persistent cache → (only on miss) geocode + cache.
- New optional `location_latitude` / `location_longitude` config fields to skip geocoding even on a cold cache.
- Geocoding logic extracted unchanged into `_geocode()`.

## Tests

Adds `test_geocode_cache.py` (6 checks, all passing): resolve-once reuse, reuse across restart, a cached coordinate reused regardless of age (never re-geocoded), error propagation on a cold-cache geocode failure, the override path, and override validation.

Existing `test_almanac_layout.py` and the cross-size plugin safety harness both still pass at every supported size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional manual latitude/longitude configuration fields to specify location without automatic detection.
  * Geocoded coordinates are now permanently cached across plugin updates and restarts, improving performance and reducing API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->