### PR TITLE
fix(soccer-scoreboard): show the live favorite league under live-priority (and stop empty leagues blanking it)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-10",
+  "last_updated": "2026-06-13",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -654,10 +654,10 @@
       "plugin_path": "plugins/soccer-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-06-02",
+      "last_updated": "2026-06-13",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.7.1"
+      "latest_version": "1.7.2"
     },
     {
       "id": "static-image",

--- a/plugins/soccer-scoreboard/manager.py
+++ b/plugins/soccer-scoreboard/manager.py
@@ -1126,6 +1126,19 @@ class SoccerScoreboardPlugin(BasePlugin if BasePlugin else object):
             except Exception as e:
                 self.logger.warning(f"Error updating manager: {e}")
 
+    def _manager_has_displayable_games(self, manager, mode_type: str) -> bool:
+        """Return True if the manager currently has games to show for this mode.
+
+        Live managers expose their games as ``live_games``; recent and upcoming
+        managers expose ``games_list``. In switch mode an empty manager must be
+        skipped: its ``display()`` clears the shared canvas when it has no games,
+        which would erase content another league's manager just drew for the same
+        mode and leave the panel blank for the rest of the slot.
+        """
+        if mode_type == 'live':
+            return bool(getattr(manager, 'live_games', None))
+        return bool(getattr(manager, 'games_list', None))
+
     def _get_available_modes(self) -> list:
         """Get list of available display modes based on enabled leagues."""
         modes = []
@@ -1409,7 +1422,7 @@ class SoccerScoreboardPlugin(BasePlugin if BasePlugin else object):
                 continue
 
             manager = self._get_league_manager_for_mode(league_key, mode_type)
-            if manager:
+            if manager and self._manager_has_displayable_games(manager, mode_type):
                 managers_to_try.append((league_key, manager))
         
         # Try each manager until one returns True (has content)
@@ -1475,7 +1488,7 @@ class SoccerScoreboardPlugin(BasePlugin if BasePlugin else object):
                                     managers_to_try.append((live_priority, league_key, live_manager))
                         else:
                             manager = self._get_league_manager_for_mode(league_key, mode_type)
-                            if manager:
+                            if manager and self._manager_has_displayable_games(manager, mode_type):
                                 managers_to_try.append((False, league_key, manager))
 
                     # Sort by live_priority (True first) for live mode, then try each manager
@@ -1564,7 +1577,7 @@ class SoccerScoreboardPlugin(BasePlugin if BasePlugin else object):
                 enabled_league_keys = self._get_enabled_leagues_for_mode(mode_type)
                 for key in enabled_league_keys:
                     manager = self._get_league_manager_for_mode(key, mode_type)
-                    if manager:
+                    if manager and self._manager_has_displayable_games(manager, mode_type):
                         managers_to_try.append((key, manager))
                 
                 # Try each manager until one returns True (has content)

--- a/plugins/soccer-scoreboard/manager.py
+++ b/plugins/soccer-scoreboard/manager.py
@@ -1766,23 +1766,51 @@ class SoccerScoreboardPlugin(BasePlugin if BasePlugin else object):
 
     def get_live_modes(self) -> list:
         """
-        Return the registered plugin mode name(s) that have live content.
-        
-        This should return the mode names as registered in manifest.json, not internal
-        mode names. The plugin is registered with "soccer_live", "soccer_recent", "soccer_upcoming".
+        Return the registered live mode name(s) of the leagues that currently
+        have live content, e.g. ``["soccer_fifa.world_live"]``.
+
+        The host registers this plugin's modes per-league (``soccer_<league>_live``,
+        built by ``_get_available_modes``), not under the generic ``soccer_live``
+        manifest name. The display controller looks the returned modes up in its
+        registered-mode map and only switches to one that exists; returning the
+        generic ``soccer_live`` matches nothing, so it falls back to the first
+        ``*_live`` mode in registration order — which may be an empty league whose
+        game isn't the one that's actually live. Returning the real per-league
+        mode names lets the controller switch straight to the league with the
+        live game.
         """
         if not self.is_enabled:
             return []
 
-        # Check if any league has live content
-        has_any_live = self.has_live_content()
-        
-        if has_any_live:
-            # Return the registered plugin mode name, not internal mode names
-            # The plugin is registered with "soccer_live" in manifest.json
-            return ["soccer_live"]
-        
-        return []
+        with self._config_lock:
+            registry = dict(self._league_registry)
+
+        live_modes = []
+        for league_key, league_data in registry.items():
+            if not league_data.get('enabled', False):
+                continue
+
+            live_manager = self._get_league_manager_for_mode(league_key, 'live')
+            if not live_manager:
+                continue
+            live_games = getattr(live_manager, "live_games", [])
+            if not live_games:
+                continue
+
+            show_all_live = league_data.get('show_all_live', False) or getattr(live_manager, 'show_all_live', False)
+            if show_all_live:
+                live_modes.append(f"soccer_{league_key}_live")
+                continue
+
+            favorite_teams = getattr(live_manager, "favorite_teams", [])
+            if favorite_teams and any(
+                game.get("home_abbr") in favorite_teams
+                or game.get("away_abbr") in favorite_teams
+                for game in live_games
+            ):
+                live_modes.append(f"soccer_{league_key}_live")
+
+        return live_modes
 
     def get_info(self) -> Dict[str, Any]:
         """Get plugin information."""
@@ -1805,7 +1833,7 @@ class SoccerScoreboardPlugin(BasePlugin if BasePlugin else object):
             info = {
                 "plugin_id": self.plugin_id,
                 "name": "Soccer Scoreboard",
-                "version": "1.7.1",
+                "version": "1.7.2",
                 "enabled": self.is_enabled,
                 "display_size": f"{self.display_width}x{self.display_height}",
                 "leagues": league_info,

--- a/plugins/soccer-scoreboard/manifest.json
+++ b/plugins/soccer-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "soccer-scoreboard",
   "name": "Soccer Scoreboard",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming soccer games across multiple leagues including Premier League, La Liga, Bundesliga, Serie A, Ligue 1, MLS, Liga Portugal, Champions League, Europa League, and FIFA World Cup",
   "category": "sports",
@@ -26,6 +26,11 @@
     "soccer_upcoming"
   ],
   "versions": [
+    {
+      "released": "2026-06-13",
+      "version": "1.7.2",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-02",
       "version": "1.7.1",
@@ -102,7 +107,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-06-02",
+  "last_updated": "2026-06-13",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/soccer-scoreboard/test/test_empty_mode_no_blank.py
+++ b/plugins/soccer-scoreboard/test/test_empty_mode_no_blank.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Regression test: empty switch-mode managers must not blank the panel.
+
+Run standalone from the plugin directory:
+
+    cd plugins/soccer-scoreboard
+    python test/test_empty_mode_no_blank.py
+
+Background
+----------
+In switch mode the plugin pools every enabled league's manager for a given mode
+(e.g. ``soccer_usa.1_recent`` tries the recent managers of *all* enabled
+leagues). A recent/upcoming manager with no games clears the shared canvas in
+its ``display()`` (see ``SportsRecent.display`` / ``SportsUpcoming.display`` in
+``sports.py``) and returns False. If that empty manager runs *before* the league
+that actually has a game, it wipes the panel; the league with content then hits
+its own redraw-dedup ("already showing this game") and returns True without
+repainting — so the slot shows content briefly, then goes blank.
+
+The fix gates recent/upcoming managers on having games before their ``display()``
+is called, mirroring the live path. This test asserts an empty manager is never
+asked to display, and that a mode with no games at all returns False so the
+display controller skips it instead of holding a blank slot.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+
+
+def _install_host_stubs() -> None:
+    for name in (
+        "src",
+        "src.plugin_system",
+        "src.plugin_system.base_plugin",
+        "src.background_data_service",
+        "src.common",
+        "src.common.scroll_helper",
+        "src.logo_downloader",
+    ):
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["src.plugin_system.base_plugin"].BasePlugin = object
+    sys.modules["src.plugin_system.base_plugin"].VegasDisplayMode = None
+    sys.modules["src.background_data_service"].get_background_service = lambda *a, **k: None
+    sys.modules["src.common.scroll_helper"].ScrollHelper = None
+    sys.modules["src.logo_downloader"].LogoDownloader = object
+    sys.modules["src.logo_downloader"].download_missing_logo = lambda *a, **k: None
+
+
+_install_host_stubs()
+logging.basicConfig(level=logging.CRITICAL)
+
+import manager  # noqa: E402
+
+
+class FakeManager:
+    """Stand-in for a recent/upcoming league manager.
+
+    Mirrors the real contract: ``display()`` returns False when there are no
+    games (after clearing the canvas), True when it has a game to draw.
+    """
+
+    def __init__(self, games):
+        self.games_list = list(games)
+        self.live_games = []
+        self.display_calls = 0
+
+    def display(self, force_clear=False):
+        self.display_calls += 1
+        return bool(self.games_list)
+
+
+def _make_plugin(managers_by_league):
+    plugin = manager.SoccerScoreboardPlugin.__new__(manager.SoccerScoreboardPlugin)
+    plugin.is_enabled = True
+    plugin.logger = logging.getLogger("test")
+    plugin._should_use_scroll_mode = lambda mode_type: False
+    plugin._get_enabled_leagues_for_mode = lambda mode_type: list(managers_by_league.keys())
+    plugin._get_league_manager_for_mode = lambda key, mode_type: managers_by_league[key]
+    plugin._record_dynamic_progress = lambda m: None
+    plugin._evaluate_dynamic_cycle_completion = lambda: None
+    plugin._current_display_league = None
+    plugin._current_display_mode_type = None
+    return plugin
+
+
+def test_empty_manager_is_skipped() -> None:
+    """An empty league manager must not have display() called (it would blank)."""
+    empty = FakeManager([])                  # usa.1 recent — no favorite-team games
+    populated = FakeManager([{"id": "g1"}])  # fifa.world recent — the USA game
+    plugin = _make_plugin({"usa.1": empty, "fifa.world": populated})
+
+    result = plugin.display("soccer_usa.1_recent")
+
+    assert result is True, f"expected content to display, got {result!r}"
+    assert empty.display_calls == 0, (
+        "empty manager's display() was called — it clears the canvas and blanks "
+        "the league that has content"
+    )
+    assert populated.display_calls == 1, "manager with the game should have displayed once"
+    print("  [ok] empty manager skipped; populated manager drawn")
+
+
+def test_all_empty_mode_returns_false() -> None:
+    """A mode with no games anywhere must return False so the controller skips it."""
+    a = FakeManager([])
+    b = FakeManager([])
+    plugin = _make_plugin({"usa.1": a, "fifa.world": b})
+
+    result = plugin.display("soccer_usa.1_upcoming")
+
+    assert result is False, (
+        f"expected False so the display controller skips the slot, got {result!r}"
+    )
+    assert a.display_calls == 0 and b.display_calls == 0, "no empty manager should display"
+    print("  [ok] all-empty mode returns False (controller skips, no blank hold)")
+
+
+def main() -> int:
+    tests = [test_empty_manager_is_skipped, test_all_empty_mode_returns_false]
+    for t in tests:
+        try:
+            t()
+        except AssertionError as e:
+            print(f"  [FAIL] {t.__name__}: {e}")
+            return 1
+    print("All tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/soccer-scoreboard/test_live_mode_targeting.py
+++ b/plugins/soccer-scoreboard/test_live_mode_targeting.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Regression test for get_live_modes() per-league targeting.
+
+Before the fix, get_live_modes() returned the generic ["soccer_live"], which
+does not match any mode the host actually registers for this plugin (modes are
+registered per league as "soccer_<league>_live"). The display controller could
+not switch to the league that had the live game and fell back to the first
+"*_live" mode in registration order — often an empty league.
+
+This test asserts get_live_modes() returns the real per-league live mode names,
+only for leagues whose live games match the favorites filter (or show_all_live).
+
+Run: <core-venv>/bin/python plugins/soccer-scoreboard/test_live_mode_targeting.py
+"""
+
+import sys
+import threading
+import types
+from pathlib import Path
+
+plugin_dir = Path(__file__).parent
+sys.path.insert(0, str(plugin_dir))
+
+
+def _stub_core_src():
+    """Stub the core ``src.*`` modules the plugin imports at load time.
+
+    The plugin's ``sports.py`` does ``from src.logo_downloader import ...`` etc.,
+    which only resolve inside a LEDMatrix core checkout. ``get_live_modes`` needs
+    none of them at call time, so stubbing keeps this test runnable from the
+    monorepo (and CI) without a core tree on the path.
+    """
+    def mod(name, **attrs):
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules.setdefault(name, m)
+        return m
+
+    mod("src")
+    mod("src.common")
+    mod("src.plugin_system")
+    mod("src.logo_downloader", LogoDownloader=object, download_missing_logo=lambda *a, **k: None)
+    mod("src.common.scroll_helper", ScrollHelper=object)
+    mod("src.plugin_system.base_plugin", BasePlugin=None, VegasDisplayMode=object)
+    mod("src.background_data_service", get_background_service=lambda *a, **k: None)
+
+
+_stub_core_src()
+
+from manager import SoccerScoreboardPlugin  # noqa: E402
+
+
+class StubLiveManager:
+    """Minimal stand-in for a league's live manager."""
+
+    def __init__(self, live_games, favorite_teams, show_all_live=False):
+        self.live_games = live_games
+        self.favorite_teams = favorite_teams
+        self.show_all_live = show_all_live
+
+
+def make_plugin(registry, managers_by_league):
+    """Build a plugin instance with just the state get_live_modes() touches."""
+    plugin = SoccerScoreboardPlugin.__new__(SoccerScoreboardPlugin)
+    plugin.is_enabled = True
+    plugin._config_lock = threading.Lock()
+    plugin._league_registry = registry
+    plugin._get_league_manager_for_mode = (
+        lambda league_key, mode_type: managers_by_league.get(league_key)
+    )
+    return plugin
+
+
+def game(home, away):
+    return {"home_abbr": home, "away_abbr": away}
+
+
+results = []
+
+
+def check(name, passed):
+    results.append((name, passed))
+    print(f"{'PASS' if passed else 'FAIL'}: {name}")
+
+
+# --- Case 1: two leagues, both with a favorite live game -------------------
+registry = {
+    "fifa.world": {"enabled": True},
+    "usa.1": {"enabled": True},
+}
+managers = {
+    "fifa.world": StubLiveManager([game("GER", "CUW")], ["USA", "GER"]),
+    "usa.1": StubLiveManager([game("SEA", "LA")], ["SEA"]),
+}
+modes = make_plugin(registry, managers).get_live_modes()
+check(
+    "both live favorites -> both per-league modes",
+    modes == ["soccer_fifa.world_live", "soccer_usa.1_live"],
+)
+check("never returns the generic soccer_live", "soccer_live" not in modes)
+
+# --- Case 2: only one league has a live favorite ---------------------------
+managers = {
+    "fifa.world": StubLiveManager([game("GER", "CUW")], ["USA", "GER"]),
+    "usa.1": StubLiveManager([], ["SEA"]),  # no live game
+}
+modes = make_plugin(registry, managers).get_live_modes()
+check("only the league with a live game", modes == ["soccer_fifa.world_live"])
+
+# --- Case 3: live game whose teams are not favorites is excluded -----------
+managers = {
+    "fifa.world": StubLiveManager([game("BRA", "ARG")], ["USA", "GER"]),
+    "usa.1": StubLiveManager([], ["SEA"]),
+}
+modes = make_plugin(registry, managers).get_live_modes()
+check("non-favorite live game excluded", modes == [])
+
+# --- Case 4: show_all_live includes any live game --------------------------
+managers = {
+    "fifa.world": StubLiveManager([game("BRA", "ARG")], [], show_all_live=True),
+    "usa.1": StubLiveManager([], ["SEA"]),
+}
+modes = make_plugin(registry, managers).get_live_modes()
+check("show_all_live includes any live game", modes == ["soccer_fifa.world_live"])
+
+# --- Case 5: disabled league excluded even with a live favorite ------------
+registry_disabled = {
+    "fifa.world": {"enabled": False},
+    "usa.1": {"enabled": True},
+}
+managers = {
+    "fifa.world": StubLiveManager([game("GER", "CUW")], ["GER"]),
+    "usa.1": StubLiveManager([game("SEA", "LA")], ["SEA"]),
+}
+modes = make_plugin(registry_disabled, managers).get_live_modes()
+check("disabled league excluded", modes == ["soccer_usa.1_live"])
+
+# --- Case 6: returned modes match the host's registration scheme -----------
+modes = make_plugin(registry, managers).get_live_modes()
+check(
+    "all modes are soccer_<league>_live",
+    all(m.startswith("soccer_") and m.endswith("_live") for m in modes) and modes,
+)
+
+print()
+passed = sum(1 for _, p in results if p)
+print(f"{passed}/{len(results)} checks passed")
+sys.exit(0 if passed == len(results) else 1)


### PR DESCRIPTION
This PR now contains **two related fixes** so a live favorite soccer game (e.g. a World Cup match) actually displays under live-priority. In the common multi-league setup — one favorite team per league, only one league live at a time — **both** are needed: fix #1 makes the controller switch to the league that has the live game; fix #2 keeps the other (empty) enabled league from blanking it.

---

## Fix 1 — target the live league (`get_live_modes`)

`get_live_modes()` returned the generic `["soccer_live"]`. But the host registers this plugin's modes **per league** — `soccer_<league>_live` (built by `_get_available_modes`) — not under the manifest's generic `soccer_live`. The display controller looks the returned modes up in its registered-mode map and only switches to one that exists:

```python
for suggested_mode in plugin.get_live_modes():
    if suggested_mode in self.plugin_modes:   # "soccer_live" is never here
        return suggested_mode
# fallback: first scanned mode ending in "_live"
```

So `"soccer_live"` matched nothing and the controller fell back to the **first `*_live` mode in registration order** — often an empty league (e.g. an out-of-season MLS). The league that actually had the live game was never selected, so the live view never appeared.

**Fix:** return the real per-league live mode names — `soccer_<league>_live` for each enabled league whose live games pass the favorites filter (or `show_all_live`). The controller can then switch straight to the league with the live game.

Adds `test_live_mode_targeting.py` (returns per-league modes only for leagues with favorite live games; never the generic `soccer_live`). Fails before this fix, passes after.

## Fix 2 — don't let an empty co-enabled league blank the panel (switch mode)

In switch mode the plugin pools **every enabled league's** manager for a given mode (e.g. `soccer_usa.1_recent` tries the recent managers of all enabled leagues, returning the first with content). Live managers are only added to the try-list when they actually have games (`live_games`), but **recent and upcoming managers were added unconditionally**.

An empty recent/upcoming manager clears the shared canvas in its `display()` (see `SportsRecent.display` / `SportsUpcoming.display` in `sports.py`, which call `display_manager.clear()` when `games_list` is empty) and returns `False`. When such an empty manager runs *before* the league that does have a game:

1. The empty manager wipes the panel.
2. The league with content then hits its own redraw-dedup (`if not force_clear and game_id == self._last_rendered_game_id: return True`) and returns `True` **without repainting**.

Net effect: content flashes for a moment when the slot is entered, then the panel goes **blank for the rest of the slot**. And when *no* enabled league has games for that mode, the empty managers still cause the controller to hold the slot blank instead of skipping (live mode skips correctly).

**Fix:** gate recent/upcoming managers on having games before `display()` is called, mirroring live-mode behavior, via a `_manager_has_displayable_games(manager, mode_type)` helper. Empty managers are no longer asked to display (so they can't clear the canvas), and a mode with no games anywhere returns `False` so the controller skips it. Updated all three switch-mode try-list build sites: the generic `soccer_recent`/`soccer_upcoming` path, the league-specific `soccer_<league>_<mode>` path, and the scroll→switch fallback. `update()` populates every enabled manager's games independently of `display()`, so gating display does not prevent a manager from loading.

Adds `test/test_empty_mode_no_blank.py` (empty manager's `display()` is never called when another league has content; an all-empty mode returns `False`). Fails before this fix, passes after.

## How they compose

With `fifa.world` (one nation) + `usa.1` (one club, not playing) both enabled and a live World Cup game: fix #1 makes the controller select `soccer_fifa.world_live` instead of the empty MLS mode, and fix #2 keeps the empty MLS manager from clearing the canvas the World Cup card just drew.

## Testing

- `test_live_mode_targeting.py` — per-league live-mode targeting (fails before fix #1).
- `test/test_empty_mode_no_blank.py` — empty managers skipped in switch mode (fails before fix #2).
- Cross-size safety harness (`check_plugin.py`) passes at every size (no overflow/crash).

Version bumped 1.7.1 → 1.7.2 (manifest + `get_info`).
