### PR TITLE
fix(baseball-scoreboard): resolve font family aliases to real files

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-10",
+  "last_updated": "2026-06-13",
   "plugins": [
     {
       "id": "7-segment-clock",
@@ -46,10 +46,10 @@
       "plugin_path": "plugins/baseball-scoreboard",
       "stars": 0,
       "downloads": 0,
-      "last_updated": "2026-06-05",
+      "last_updated": "2026-06-13",
       "verified": true,
       "screenshot": "",
-      "latest_version": "1.6.4"
+      "latest_version": "1.6.5"
     },
     {
       "id": "basketball-scoreboard",

--- a/plugins/baseball-scoreboard/game_renderer.py
+++ b/plugins/baseball-scoreboard/game_renderer.py
@@ -14,6 +14,22 @@ from typing import Any, Dict, Optional
 import pytz
 from PIL import Image, ImageDraw, ImageFont
 
+# Maps the core FontManager's common-font family aliases (src/font_manager.py
+# `common_fonts`) to the real files in assets/fonts. A font config value may be
+# either one of these family names or a literal filename; aliases resolve here,
+# filenames pass through unchanged.
+FONT_ALIASES = {
+    "press_start": "PressStart2P-Regular.ttf",
+    "four_by_six": "4x6-font.ttf",
+    "five_by_seven": "5x7.bdf",
+}
+
+
+def resolve_font_name(font_name: str) -> str:
+    """Resolve a font family alias to its filename, leaving filenames as-is."""
+    return FONT_ALIASES.get(font_name, font_name)
+
+
 # Pillow compatibility: Image.Resampling.LANCZOS is available in Pillow >= 9.1
 # Fall back to Image.LANCZOS for older versions
 try:
@@ -101,7 +117,8 @@ class GameRenderer:
         """Load a custom font from an element configuration dictionary."""
         font_name = element_config.get('font', default_font)
         font_size = int(element_config.get('font_size', default_size))
-        font_path = os.path.join('assets', 'fonts', font_name)
+        # Resolve family aliases (e.g. "press_start") to real filenames, then build path
+        font_path = os.path.join('assets', 'fonts', resolve_font_name(font_name))
 
         try:
             if os.path.exists(font_path):

--- a/plugins/baseball-scoreboard/manifest.json
+++ b/plugins/baseball-scoreboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "baseball-scoreboard",
   "name": "Baseball Scoreboard",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "author": "ChuckBuilds",
   "description": "Live, recent, and upcoming baseball games across MLB, MiLB, and NCAA Baseball with real-time scores and schedules",
   "category": "sports",
@@ -30,6 +30,12 @@
   "branch": "main",
   "plugin_path": "plugins/baseball-scoreboard",
   "versions": [
+    {
+      "released": "2026-06-13",
+      "version": "1.6.5",
+      "notes": "Resolve font family aliases (press_start, four_by_six, five_by_seven) to their real font files when loading fonts. These are the default values shipped in the config schema, but the loaders treated them as literal filenames and logged 'Font file not found ... using default' on every load before silently falling back. Aliases now map to the correct files; literal filenames still pass through unchanged.",
+      "ledmatrix_min": "2.0.0"
+    },
     {
       "released": "2026-06-09",
       "version": "1.6.4",
@@ -139,7 +145,7 @@
       "ledmatrix_min_version": "2.0.0"
     }
   ],
-  "last_updated": "2026-06-05",
+  "last_updated": "2026-06-13",
   "stars": 0,
   "downloads": 0,
   "verified": true,

--- a/plugins/baseball-scoreboard/sports.py
+++ b/plugins/baseball-scoreboard/sports.py
@@ -18,6 +18,21 @@ try:
 except AttributeError:
     RESAMPLE_FILTER = Image.LANCZOS
 
+# Maps the core FontManager's common-font family aliases (src/font_manager.py
+# `common_fonts`) to the real files in assets/fonts. A font config value may be
+# either one of these family names or a literal filename; aliases resolve here,
+# filenames pass through unchanged.
+FONT_ALIASES = {
+    "press_start": "PressStart2P-Regular.ttf",
+    "four_by_six": "4x6-font.ttf",
+    "five_by_seven": "5x7.bdf",
+}
+
+
+def resolve_font_name(font_name: str) -> str:
+    """Resolve a font family alias to its filename, leaving filenames as-is."""
+    return FONT_ALIASES.get(font_name, font_name)
+
 # Import simplified dependencies for plugin use
 from dynamic_team_resolver import DynamicTeamResolver
 from logo_downloader import LogoDownloader, download_missing_logo
@@ -223,9 +238,9 @@ class SportsCore(ABC):
         # Get font name and size, with defaults
         font_name = element_config.get('font', 'PressStart2P-Regular.ttf')
         font_size = int(element_config.get('font_size', default_size))  # Ensure integer for PIL
-        
-        # Build font path
-        font_path = os.path.join('assets', 'fonts', font_name)
+
+        # Resolve family aliases (e.g. "press_start") to real filenames, then build path
+        font_path = os.path.join('assets', 'fonts', resolve_font_name(font_name))
         
         # Try to load the font
         try:

--- a/plugins/baseball-scoreboard/test_font_aliases.py
+++ b/plugins/baseball-scoreboard/test_font_aliases.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Regression test: font family aliases must resolve to real font files.
+
+The schema defaults (and the persisted configs they produce) use the core
+FontManager's family aliases — "press_start", "four_by_six" — rather than
+literal filenames. The font loaders used to treat the config value as a
+filename, building paths like "assets/fonts/press_start" that don't exist,
+which logged "Font file not found ... using default" on every load.
+
+These tests fail before the alias-resolution fix and pass after it.
+"""
+
+import os
+import sys
+
+# Make the plugin's sibling modules importable
+plugin_dir = os.path.dirname(os.path.abspath(__file__))
+if plugin_dir not in sys.path:
+    sys.path.insert(0, plugin_dir)
+
+import game_renderer  # noqa: E402
+from game_renderer import resolve_font_name, FONT_ALIASES  # noqa: E402
+
+EXPECTED = {
+    "press_start": "PressStart2P-Regular.ttf",
+    "four_by_six": "4x6-font.ttf",
+    "five_by_seven": "5x7.bdf",
+}
+
+
+def test_aliases_resolve_to_filenames():
+    for alias, filename in EXPECTED.items():
+        got = resolve_font_name(alias)
+        assert got == filename, f"{alias!r} resolved to {got!r}, expected {filename!r}"
+    print("✓ family aliases resolve to real filenames")
+
+
+def test_filenames_pass_through():
+    for name in ("PressStart2P-Regular.ttf", "9x15B.bdf", "4x6-font.ttf"):
+        got = resolve_font_name(name)
+        assert got == name, f"filename {name!r} should pass through, got {got!r}"
+    print("✓ literal filenames pass through unchanged")
+
+
+def test_sports_and_renderer_maps_match():
+    # Both loaders carry their own copy of the map; they must stay in sync.
+    import sports
+    assert sports.FONT_ALIASES == FONT_ALIASES, (
+        "sports.FONT_ALIASES and game_renderer.FONT_ALIASES have diverged"
+    )
+    print("✓ sports.py and game_renderer.py alias maps agree")
+
+
+def test_resolved_files_exist_in_assets():
+    # Only meaningful when run from within the core LEDMatrix tree (where
+    # assets/fonts lives). Skip gracefully otherwise so CI plugin-only runs pass.
+    fonts_dir = os.path.join("assets", "fonts")
+    if not os.path.isdir(fonts_dir):
+        print(f"… skipped assets check (no {fonts_dir} relative to cwd)")
+        return
+    for filename in FONT_ALIASES.values():
+        path = os.path.join(fonts_dir, filename)
+        assert os.path.exists(path), f"alias target {path} does not exist"
+    print("✓ every alias target exists under assets/fonts")
+
+
+if __name__ == "__main__":
+    print("Baseball scoreboard font-alias regression test")
+    print("=" * 46)
+    ok = True
+    for t in (
+        test_aliases_resolve_to_filenames,
+        test_filenames_pass_through,
+        test_sports_and_renderer_maps_match,
+        test_resolved_files_exist_in_assets,
+    ):
+        try:
+            t()
+        except AssertionError as e:
+            ok = False
+            print(f"✗ {t.__name__}: {e}")
+        except Exception as e:  # import errors etc.
+            ok = False
+            print(f"✗ {t.__name__}: unexpected error: {e}")
+    print("=" * 46)
+    print("PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)

--- a/plugins/baseball-scoreboard/test_font_aliases.py
+++ b/plugins/baseball-scoreboard/test_font_aliases.py
@@ -19,7 +19,6 @@ plugin_dir = os.path.dirname(os.path.abspath(__file__))
 if plugin_dir not in sys.path:
     sys.path.insert(0, plugin_dir)
 
-import game_renderer  # noqa: E402
 from game_renderer import resolve_font_name, FONT_ALIASES  # noqa: E402
 
 EXPECTED = {


### PR DESCRIPTION
## Problem

On startup the baseball scoreboard spams the logs with:

```
WARNING - MLB - Font file not found: assets/fonts/press_start, using default
WARNING - MLB - Font file not found: assets/fonts/four_by_six, using default
```

The plugin's `config_schema.json` ships font **family aliases** as the defaults — `press_start`, `four_by_six` — which are the names defined in the core `FontManager`'s `common_fonts` map (`src/font_manager.py`). But the font loaders (`sports.py` `_load_custom_font_from_element_config` and `game_renderer.py` `_load_custom_font`) treat the config value as a literal filename, building paths like `assets/fonts/press_start` that don't exist. Every font load fails the `os.path.exists` check, logs the warning, and silently falls back to the default — so fonts still render, but the logs are noisy on every load.

The sibling sports plugins (football/hockey/soccer) avoid this only because their schema defaults happen to use real filenames; baseball's schema describes the field as a "Font family" and uses the alias names, which is arguably the more correct intent — the loader is the part that's wrong.

## Fix

Add a small `FONT_ALIASES` map mirroring the core `common_fonts` aliases and resolve aliases to their real filenames before building the path, in both loaders. Literal filenames (e.g. `9x15B.bdf`, `PressStart2P-Regular.ttf`) pass through unchanged, so existing configs keep working. This also fixes already-persisted configs that have the alias names saved, not just fresh installs.

The map is defined in each module rather than cross-imported, to respect the monorepo's shared-top-level-module-name collision rule (`sports.py` is shipped by multiple plugins).

## Testing

- New `test_font_aliases.py`: asserts aliases resolve to filenames, filenames pass through, the two map copies stay in sync, and every alias target actually exists under `assets/fonts`.
- Cross-size safety harness (`check_plugin.py`): PASS for all matrix sizes × screens (mlb_live / mlb_recent / mlb_upcoming).
- Module-collision check: PASS.

Bumps version to 1.6.5 and syncs `plugins.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for font family aliases in the baseball-scoreboard plugin, allowing users to reference common fonts by name (e.g., "press_start", "four_by_six", "five_by_seven") instead of filenames.

* **Bug Fixes**
  * Eliminated repeated "Font file not found" warnings by resolving font aliases during load.

* **Tests**
  * Added comprehensive test suite for font alias resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->